### PR TITLE
Simple db.currentOp helper

### DIFF
--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -344,6 +344,12 @@ class Database(object):
             raise CollectionInvalid("%s invalid: %s" % (name, info))
         return info
 
+    def current_op(self):
+        """Get information on oeprations currently running
+        (same as: db.currentOp() in JavaScript console)
+        """
+        return self['$cmd.sys.inprog'].find_one()
+
     def profiling_level(self):
         """Get the database's current profiling level.
 


### PR DESCRIPTION
Just because the docs always refer to the js helper instead of the underlying query, so it takes a few minutes to figure out how to get current ops without the helper.

Would be nice, but no big deal if you don't want to clutter pymongo with a bunch of helper functions.
