### PR TITLE
Custrom cursor implementation

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -97,6 +97,7 @@ class Collection(object):
         self.__database = database
         self.__name = unicode(name)
         self.__full_name = u"%s.%s" % (self.__database.name, self.__name)
+        self.__cursor_class = Cursor
         if create or options is not None:
             self.__create(options)
 
@@ -164,6 +165,31 @@ class Collection(object):
            ``database`` is now a property rather than a method.
         """
         return self.__database
+
+    @property
+    def cursor_class(self):
+        """The :class:`~pymongo.cursor.Cursor` that this
+        :class:`Collection` is a part of.
+        """
+        return self.__cursor_class
+
+    @cursor_class.setter
+    def cursor_class(self, cursor_class):
+        """Set cursor class for collection.
+
+        Raises :class:`TypeError` if `cursor_class` is not an instance of
+        :class:`~pymongo.cursor.Cursor`.
+
+        :Parameters:
+          - `cursor_class`: class to use for cursors
+        """
+
+
+        if not issubclass(cursor_class, Cursor):
+            raise TypeError("Cursor class must be a subclass of Cursor")
+
+        self.__cursor_class = cursor_class
+
 
     def save(self, to_save, manipulate=True, safe=False, **kwargs):
         """Save a document in this collection.
@@ -549,7 +575,7 @@ class Collection(object):
 
         .. mongodoc:: find
         """
-        return Cursor(self, *args, **kwargs)
+        return self.__cursor_class(self, *args, **kwargs)
 
     def count(self):
         """Get the number of documents in this collection.

--- a/test/test_custom_cursors.py
+++ b/test/test_custom_cursors.py
@@ -1,0 +1,29 @@
+import unittest
+
+from pymongo.cursor import Cursor
+from pymongo.database import Database
+from test_connection import get_connection
+
+
+class CustomCursor(Cursor):
+    def custom_method(self):
+        return "kinda workds"
+
+
+class TestCustomCursors(unittest.TestCase):
+
+    def setUp(self):
+        self.db = Database(get_connection(), "pymongo_test")
+
+    def testBasics(self):
+        # it is not persisstent now, so we need to set it for every collection instance
+        collection = self.db.custom_cursor
+        self.assertEquals(collection.find().__class__, Cursor)
+        self.assertRaises(TypeError, setattr, collection, 'cursor_class', unicode)
+        collection.cursor_class = CustomCursor
+        self.assertEquals(collection.find().__class__, CustomCursor)
+        self.assertEquals(collection.find().custom_method(), "kinda workds")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rationale:
I need custom cursors for my ORM, so i can override **getitem** and produce my models from cursor, overwise i need to introduce my own ModelSet/Cursor class, and implement lazy limit/offset from scratch.

Implementation:
Pulled code implements cursor_class property for collection instance and some tests.

Please comment if you need any fixes, so we can get it into master.

Thx, Anatoly
///
