### PR TITLE
Wrapping a SON object into a class object without touching embeded documents

### DIFF
--- a/doc/api/pymongo/collection.rst
+++ b/doc/api/pymongo/collection.rst
@@ -25,7 +25,7 @@
       .. automethod:: update(spec, document[, upsert=False[, manipulate=False[, safe=False[, multi=False[, **kwargs]]]]])
       .. automethod:: remove([spec_or_object_id=None[, safe=False[, **kwargs]]])
       .. automethod:: drop
-      .. automethod:: find([spec=None[, fields=None[, skip=0[, limit=0[, timeout=True[, snapshot=False[, tailable=False[, sort=None[, max_scan=None[, as_class=None[, **kwargs]]]]]]]]]]])
+      .. automethod:: find([spec=None[, fields=None[, skip=0[, limit=0[, timeout=True[, snapshot=False[, tailable=False[, sort=None[, max_scan=None[, as_class=None[, wrap=None[, **kwargs]]]]]]]]]]]])
       .. automethod:: find_one([spec_or_id=None[, *args[, **kwargs]]])
       .. automethod:: count
       .. automethod:: create_index

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Changes in Version 1.10
+-----------------------
+
+- added `wrap` argument for
+  :meth:`~pymongo.collection.Collection.find`, and in
+  :meth: `~pymongo.database._fix_outgoing`.
+
 Changes in Version 1.9
 -------------------------
 

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -527,6 +527,8 @@ class Collection(object):
           - `as_class` (optional): class to use for documents in the
             query result (default is
             :attr:`~pymongo.connection.Connection.document_class`)
+          - `wrap` (optional): a class object used to wrap documents in the
+            query result
           - `network_timeout` (optional): specify a timeout to use for
             this query, which will override the
             :class:`~pymongo.connection.Connection`-level default

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -37,7 +37,7 @@ class Cursor(object):
 
     def __init__(self, collection, spec=None, fields=None, skip=0, limit=0,
                  timeout=True, snapshot=False, tailable=False, sort=None,
-                 max_scan=None, as_class=None,
+                 max_scan=None, as_class=None, wrap=None,
                  _must_use_master=False, _is_command=False,
                  **kwargs):
         """Create a new cursor.
@@ -97,6 +97,7 @@ class Cursor(object):
         self.__explain = False
         self.__hint = None
         self.__as_class = as_class
+        self.__wrap = wrap
         self.__tz_aware = collection.database.connection.tz_aware
         self.__must_use_master = _must_use_master
         self.__is_command = _is_command
@@ -599,7 +600,7 @@ class Cursor(object):
             raise StopIteration
         db = self.__collection.database
         if len(self.__data) or self._refresh():
-            next = db._fix_outgoing(self.__data.pop(0), self.__collection)
+            next = db._fix_outgoing(self.__data.pop(0), self.__collection, self.__wrap)
         else:
             raise StopIteration
         return next

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -208,17 +208,23 @@ class Database(object):
             son = manipulator.transform_incoming(son, collection)
         return son
 
-    def _fix_outgoing(self, son, collection):
+    def _fix_outgoing(self, son, collection, wrap):
         """Apply manipulators to a SON object as it comes out of the database.
 
         :Parameters:
           - `son`: the son object coming out of the database
           - `collection`: the collection the son object was saved in
+          - `wrap` : a class object which its __init__ take a SON object and a collection
+
+          If `wrap` is not None, return an instance of the wrap object. Return
+          a SON object otherwise.
         """
         for manipulator in reversed(self.__outgoing_manipulators):
             son = manipulator.transform_outgoing(son, collection)
         for manipulator in reversed(self.__outgoing_copying_manipulators):
             son = manipulator.transform_outgoing(son, collection)
+        if wrap is not None:
+            return wrap(son, collection=collection)
         return son
 
     def command(self, command, value=1,


### PR DESCRIPTION
I got deeper into the `as_class` feature code and I went to the conclusion that I can't use `as_class`, as it is written, for MongoKit. The main raison is that an `as_class` object is fired for every embeded documents.

http://github.com/mongodb/mongo-python-driver/blob/master/bson/__init__.py#L224

This seems harmless at the first sight but it drop dramatically the performances down. A MongoKit document isn't a simple dict and instantiating a MongoKit document is a little slower than instantiating a dict.

`as_class` is a good feature but not well appropriated for ODM wrapping. I thought about it and I come with a pull request which allow to wrap a SON object only one time.

Tell me about it.
