### PR TITLE
TypeError: _get_string() takes exactly 3 arguments (1 given) 

### DIFF
--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -147,7 +147,7 @@ def _get_date(data, as_class, tz_aware):
 
 def _get_code_w_scope(data, as_class, tz_aware):
     (_, data) = _get_int(data)
-    (code, data) = _get_string(data)
+    (code, data) = _get_string(data, as_class, tz_aware)
     (scope, data) = _get_object(data, as_class, tz_aware)
     return (Code(code, scope), data)
 


### PR DESCRIPTION
My commit fixes this error:

  File "/usr/lib64/python2.6/site-packages/pymongo/database.py", line 288, in command
    _is_command=True)
  File "/usr/lib64/python2.6/site-packages/pymongo/collection.py", line 469, in find_one
    for result in self.find(spec_or_id, _args, *_kwargs).limit(-1):
  File "/usr/lib64/python2.6/site-packages/pymongo/cursor.py", line 601, in next
    if len(self.__data) or self._refresh():
  File "/usr/lib64/python2.6/site-packages/pymongo/cursor.py", line 564, in _refresh
    self.__query_spec(), self.__fields))
  File "/usr/lib64/python2.6/site-packages/pymongo/cursor.py", line 533, in __send_message
    self.__tz_aware)
  File "/usr/lib64/python2.6/site-packages/pymongo/helpers.py", line 106, in _unpack_response
    result["data"] = bson.decode_all(response[20:], as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 396, in decode_all
    (doc, data) = _bson_to_dict(data, as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 239, in _bson_to_dict
    return (_elements_to_dict(elements, as_class, tz_aware), data[obj_size:])
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 227, in _elements_to_dict
    (key, value, data) = _element_to_dict(data, as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 220, in _element_to_dict
    (value, data) = _element_getter[element_type](data, as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 99, in _get_object
    (object, data) = _bson_to_dict(data, as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 239, in _bson_to_dict
    return (_elements_to_dict(elements, as_class, tz_aware), data[obj_size:])
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 227, in _elements_to_dict
    (key, value, data) = _element_to_dict(data, as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 220, in _element_to_dict
    (value, data) = _element_getter[element_type](data, as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 99, in _get_object
    (object, data) = _bson_to_dict(data, as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 239, in _bson_to_dict
    return (_elements_to_dict(elements, as_class, tz_aware), data[obj_size:])
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 227, in _elements_to_dict
    (key, value, data) = _element_to_dict(data, as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 220, in _element_to_dict
    (value, data) = _element_getter[element_type](data, as_class, tz_aware)
  File "/usr/lib64/python2.6/site-packages/bson/__init__.py", line 150, in _get_code_w_scope
    (code, data) = _get_string(data)
TypeError: _get_string() takes exactly 3 arguments (1 given)
