### PR TITLE
Fixed DBRef __hash__ to properly handle __kwargs

### DIFF
--- a/bson/dbref.py
+++ b/bson/dbref.py
@@ -114,8 +114,8 @@ class DBRef(object):
 
         .. versionadded:: 1.1
         """
-        return hash((self.__collection, self.__id,
-                     self.__database, self.__kwargs))
+        return hash((self.__collection, self.__id, self.__database,
+                     tuple(sorted(self.__kwargs.items()))))
 
     def __deepcopy__(self, memo):
         """Support function for `copy.deepcopy()`.

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -330,6 +330,18 @@ class TestBSON(unittest.TestCase):
         d = OrderedDict([("one", 1), ("two", 2), ("three", 3), ("four", 4)])
         self.assertEqual(d, BSON.encode(d).decode(as_class=OrderedDict))
 
+    def test_dbref_hash(self):
+        dbref_1a = DBRef('collection', 'id', 'database')
+        dbref_1b = DBRef('collection', 'id', 'database')
+        self.assertEquals(hash(dbref_1a), hash(dbref_1b))
+
+        dbref_2a = DBRef('collection', 'id', 'database', custom='custom')
+        dbref_2b = DBRef('collection', 'id', 'database', custom='custom')
+        self.assertEquals(hash(dbref_2a), hash(dbref_2b))
+
+        self.assertNotEqual(hash(dbref_1a), hash(dbref_2a))
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
DBRef.**hash** looks like this:
        return hash((self.__collection, self.__id, self.__database, self.__kwargs))

The problem here is that `self.__kwargs` is a dict, which is unhashable type, so this code can never work.
I just replaced __kwargs with a tuple of key, values.

Fixing dbref hash allows to create dicts with dbrefs as keys, which is quite useful to cache dereferenced documents.
