### PR TITLE
fix for pickling ObjectId

### DIFF
--- a/bson/objectid.py
+++ b/bson/objectid.py
@@ -191,12 +191,12 @@ class ObjectId(object):
         """return value of object for pickling.
         needed explicitly because __slots__() defined.
         """
-        return self.__str__()
+        return self.__id
 
-    def __setstate__(self, oid):
+    def __setstate__(self, value):
         """explicit state set from pickling
         """
-        self.__validate(oid)
+        self.__id = value
 
     def __str__(self):
         return self.__id.encode("hex")

--- a/test/test_objectid.py
+++ b/test/test_objectid.py
@@ -15,6 +15,7 @@
 """Tests for the objectid module."""
 
 import datetime
+import pickle
 import warnings
 import unittest
 import sys
@@ -123,6 +124,10 @@ class TestObjectId(unittest.TestCase):
         as_utc = (aware - aware.utcoffset()).replace(tzinfo=utc)
         oid = ObjectId.from_datetime(aware)
         self.assertEqual(as_utc, oid.generation_time)
+
+    def test_pickling(self):
+        orig = ObjectId()
+        self.assertEqual(orig, pickle.loads(pickle.dumps(orig)))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
fix pickling of ObjectId by defining `__getstate__()` and `__setstate__()` because `__slots__()` is defined

ran into this with pymongo 1.10 with exception:
`TypeError: a class that defines __slots__ without defining __getstate__ cannot be pickled`
