### PR TITLE
make doc building more resilient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class doc(Command):
                 pass
 
         if has_subprocess:
-            status = subprocess.call(["sphinx-build", "-b", mode, "doc", path])
+            status = subprocess.call(["sphinx-build", "-E", "-b", mode, "doc", path])
 
             if status:
                 raise RuntimeError("documentation step '%s' failed" % mode)


### PR DESCRIPTION
fixes an issue where a python code error (a module couldn't be imported)
broke future `setup.py doc` invocations until you removed all .pyc files
