### PR TITLE
Performance boost Gridfs write. Use also StrinIO when sending a string.

### DIFF
--- a/gridfs/grid_file.py
+++ b/gridfs/grid_file.py
@@ -271,16 +271,20 @@ class GridIn(object):
                     raise TypeError("must specify an encoding for file in "
                                     "order to write unicode")
 
-            while data:
+            data_len = len(data)
+            data = StringIO(data)
+            while True:
                 space = self.chunk_size - self._buffer.tell()
+                to_write = data.read(space)
 
-                if len(data) <= space:
-                    self._buffer.write(data)
+                if not to_write:
+                    break
+                elif data_len <= space:
+                    self._buffer.write(to_write)
                     break
                 else:
-                    self._buffer.write(data[:space])
+                    self._buffer.write(to_write)
                     self.__flush_buffer()
-                    data = data[space:]
 
     def writelines(self, sequence):
         """Write a sequence of strings to the file.


### PR DESCRIPTION
Changing the slice operation "data = data[space:]" of strings to StringIO.read(space) in grid_file.py increases write performance in my test 5~10x.

Test script can be found here http://pastebin.com/wiKWSzDM

Cya Josip

OLD:
delicj@lumacbu /opt/develop/bo_gridfs (hg)-[default] % bin/py bench.py write
Write: Wrinting (10) files with ( 1) kB
Write: Wrinting (10) files with (10) kB
Write: Wrinting (10) files with (100) kB
Write: Wrinting (10) files with (1000) kB
Write: Wrinting (5) files with (10000) kB
Write: Wrinting (1) files with (100000) kB
Write: Wrinting (50) files with ( 5) kB
Write: Wrinting (50) files with ( 5) kB
Write: Wrinting (50) files with (50) kB
Write: Wrinting (5) files with (5000) kB
Write: Wrinting (1) files with (50000) kB
Write: count (1) took (34.21)s for (233) MB
Write: Writing (202) files took (34.21)s for (233) MB
bin/py bench.py write  16,30s user 16,68s system 95% cpu 34,409 total

NEW:
delicj@lumacbu /opt/develop/bo_gridfs (hg)-[default] % bin/py bench.py write
Write: Wrinting (10) files with ( 1) kB
Write: Wrinting (10) files with (10) kB
Write: Wrinting (10) files with (100) kB
Write: Wrinting (10) files with (1000) kB
Write: Wrinting (5) files with (10000) kB
Write: Wrinting (1) files with (100000) kB
Write: Wrinting (50) files with ( 5) kB
Write: Wrinting (50) files with ( 5) kB
Write: Wrinting (50) files with (50) kB
Write: Wrinting (5) files with (5000) kB
Write: Wrinting (1) files with (50000) kB
Write: count (1) took (4.84)s for (233) MB
Write: Writing (202) files took (4.84)s for (233) MB
