### PR TITLE
Implement .close() on Connection since then it will be usable with closing()

### DIFF
--- a/pymongo/connection.py
+++ b/pymongo/connection.py
@@ -591,6 +591,9 @@ class Connection(common.BaseObject):  # TODO support auth for pooling
         self.__host = None
         self.__port = None
 
+    def close(self):
+        self.disconnect()
+
     def set_cursor_manager(self, manager_class):
         """Set this connection's cursor manager.
 


### PR DESCRIPTION
I want to be able to do:

``` python
def connect_db():
    from pymongo import Connection
    return Connection(MONGO_HOST)

with closing(connect_db) as conn:
    do_some_thing_with(conn)
```
# commit info: just small Connection.close() that does the same as disconnect() to use with contextlib.closing
