### PR TITLE
MongoDB server now has a few "not master" error types, but python library does not handle

### DIFF
--- a/pymongo/connection.py
+++ b/pymongo/connection.py
@@ -628,9 +628,9 @@ class Connection(common.BaseObject):  # TODO support auth for pooling
         # TODO unify logic with database.error method
         if error.get("err") is None:
             return error
-        if error["err"] == "not master":
+        if error["err"].startswith("not master"):
             self.disconnect()
-            raise AutoReconnect("not master")
+            raise AutoReconnect(error["err"])
 
         if "code" in error:
             if error["code"] in [11000, 11001, 12582]:

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -482,7 +482,7 @@ class Database(common.BaseObject):
         error = self.command("getlasterror")
         if error.get("err", 0) is None:
             return None
-        if error["err"] == "not master":
+        if error["err"].startswith("not master"):
             self.__connection.disconnect()
         return error
 

--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -94,7 +94,7 @@ def _unpack_response(response, cursor_id=None, as_class=dict, tz_aware=False):
                                cursor_id)
     elif response_flag & 2:
         error_object = bson.BSON(response[20:]).decode()
-        if error_object["$err"] == "not master":
+        if error_object["$err"].startswith("not master"):
             raise AutoReconnect("master has changed")
         raise OperationFailure("database error: %s" %
                                error_object["$err"])


### PR DESCRIPTION
Currently if MongoDB responds with "not master and slaveok=false" the python library will raise an OperationalError instead of an AutoReconnect (which is the documented behavior.)  This commit fixes that problem.
