### PR TITLE
Fix overflow bug while calculating new size of buffer 

### DIFF
--- a/bson/buffer.c
+++ b/bson/buffer.c
@@ -67,7 +67,12 @@ static int buffer_grow(buffer_t buffer, int min_length) {
         return 0;
     }
     while (size < min_length) {
+        int old_size = size;
         size *= 2;
+        if (size <= old_size) {
+           /* size did not increase. Could be an overflow or size < 1. Just go with min_length */
+           size = min_length;
+	    }  
     }
     buffer->buffer = (char*)realloc(buffer->buffer, sizeof(char) * size);
     if (buffer->buffer == NULL) {


### PR DESCRIPTION
I found a bug where the pymongo code ends up in a tight infinite loop and locks the whole prcess. Using gdb I was able to trace it to line 69 in bson/buffer.c

What is happening is that if the size is such that multiplying by two ends up overflowing it, we will never get out of the loop which tries to increase size to the next power of 2 beyond min_length
