### PR TITLE
Adding support for multi-key indexes

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -30,6 +30,8 @@ _ZERO = "\x00\x00\x00\x00"
 def _gen_index_name(keys):
     """Generate an index name from the set of fields it is over.
     """
+    if isinstance(keys[0], list):
+        return u"_".join(["%s" % x for x in [item for item in keys]])
     return u"_".join([u"%s_%s" % item for item in keys])
 
 


### PR DESCRIPTION
The documentation seems to indicate that you can provide a list of [[key, order], [key1, order1]] in order to create multi-key indexes, but when that is provided, an error is thrown. This commit fixes that issue and allows multi-key indexes to be created. 
