### PR TITLE
PYTHON-301: FixedOffset objects can now be copied / pickled

### DIFF
--- a/bson/tz_util.py
+++ b/bson/tz_util.py
@@ -38,9 +38,6 @@ class FixedOffset(tzinfo):
     def __getinitargs__(self):
         return self.__offset, self.__name
 
-    def __reduce__(self):
-        return _UTC, ()
-
     def utcoffset(self, dt):
         return self.__offset
 
@@ -53,12 +50,3 @@ class FixedOffset(tzinfo):
 
 utc = FixedOffset(0, "UTC")
 """Fixed offset timezone representing UTC."""
-
-
-def _UTC():
-    """Factory function for utc unpickling.
-
-    Makes sure that unpickling a utc instance always returns the same
-    module global.
-    """
-    return utc

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -48,11 +48,9 @@ class TestTimestamp(unittest.TestCase):
 
         dc = copy.deepcopy(d)
         self.assertEqual(dc, t.as_datetime())
-        self.assertEqual(d.tzinfo, dc.tzinfo)
 
         dp = pickle.loads(pickle.dumps(d))
         self.assertEqual(dp, t.as_datetime())
-        self.assertEqual(d.tzinfo, dp.tzinfo)
 
     def test_exceptions(self):
         self.assertRaises(TypeError, Timestamp)


### PR DESCRIPTION
Defined getinitargs so FixedOffset objects can now be copied / pickled.

Added testcase as well.
