### PR TITLE
Increase tested timeout from .1 to .25 seconds; some machines in the midst of testing seem unable to respond in .1.

### DIFF
--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -368,19 +368,21 @@ class TestConnection(unittest.TestCase):
 
     def test_network_timeout(self):
         no_timeout = Connection(self.host, self.port)
-        timeout = Connection(self.host, self.port, network_timeout=0.1)
+        timeout_sec = 0.25
+        timeout = Connection(self.host, self.port, network_timeout=timeout_sec)
 
         no_timeout.pymongo_test.drop_collection("test")
         no_timeout.pymongo_test.test.insert({"x": 1}, safe=True)
 
+        # A $where clause that takes half a second longer than the timeout
         where_func = """function (doc) {
-  var d = new Date().getTime() + 200;
+  var d = new Date().getTime() + %f * 1000 + 500;;
   var x = new Date().getTime();
   while (x < d) {
     x = new Date().getTime();
   }
   return true;
-}"""
+}""" % timeout_sec
 
         def get_x(db):
             return db.test.find().where(where_func).next()["x"]


### PR DESCRIPTION
It seems the machine running our Bamboo CIS is sometimes under sufficiently heavy load that Mongo can't respond in .1 seconds. The timeout can be longer and it's still a good test of the driver's response to a timeout.
