### PR TITLE
See if safe=True will fix intermittent failures in test_insert_find_one

### DIFF
--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -484,18 +484,18 @@ class TestCollection(unittest.TestCase):
 
     def test_insert_find_one(self):
         db = self.db
-        db.test.remove({})
+        db.test.remove({}, safe=True)
         self.assertEqual(db.test.find().count(), 0)
         doc = {"hello": u"world"}
-        id = db.test.insert(doc)
+        id = db.test.insert(doc, safe=True)
         self.assertEqual(db.test.find().count(), 1)
         self.assertEqual(doc, db.test.find_one())
         self.assertEqual(doc["_id"], id)
         self.assert_(isinstance(id, ObjectId))
 
         def remove_insert_find_one(dict):
-            db.test.remove({})
-            db.test.insert(dict)
+            db.test.remove({}, safe=True)
+            db.test.insert(dict, safe=True)
             return db.test.find_one() == dict
 
         qcheck.check_unittest(self, remove_insert_find_one,


### PR DESCRIPTION
Tests sometimes fail with:

```
exceptions.AssertionError: 3 != 0
Traceback (most recent call last):
  File "/usr/lib/python2.6/unittest.py", line 279, in run
    testMethod()
  File "/mnt/bamboo-home/xml-data/build-dir/DRIVER-PYTHON-JOB1/test/test_collection.py", line 488, in test_insert_find_one
    self.assertEqual(db.test.find().count(), 0)
  File "/usr/lib/python2.6/unittest.py", line 350, in failUnlessEqual
    (msg or '%r != %r' % (first, second))
```
