### PR TITLE
Fix test_properties()

### DIFF
--- a/test/test_replica_set_connection.py
+++ b/test/test_replica_set_connection.py
@@ -71,7 +71,14 @@ class TestConnectionReplicaSetBase(unittest.TestCase):
                               for h in response["hosts"]])
             self.arbiters = set([_partition_node(h)
                                  for h in response.get("arbiters", [])])
-            self.primary = _partition_node(pair)
+
+            repl_set_status = conn.admin.command('replSetGetStatus')
+            primary_info = next(
+                m for m in repl_set_status['members']
+                if m['stateStr'] == 'PRIMARY'
+            )
+
+            self.primary = _partition_node(primary_info['name'])
         else:
             raise SkipTest()
 


### PR DESCRIPTION
Fix a test: Instead of assuming the hostname in a replica set's config is the same as socket.gethostname(), actually record the hostname.
