### PR TITLE
PYTHON-319 Use urllib.unquote_plus

### DIFF
--- a/pymongo/connection.py
+++ b/pymongo/connection.py
@@ -218,7 +218,9 @@ class Connection(common.BaseObject):
         URIs. Any port specified in the host string(s) will override
         the `port` parameter. If multiple mongodb URIs containing
         database or auth information are passed, the last database,
-        username, and password present will be used.
+        username, and password present will be used.  For username and
+        passwords reserved characters like ':', '/', '+' and '@' must be
+        escaped following RFC 2396.
 
         :Parameters:
           - `host` (optional): hostname or IP address of the
@@ -1107,7 +1109,7 @@ class Connection(common.BaseObject):
 
         .. versionadded:: 2.0
         """
-        self.admin['$cmd'].sys.unlock.find_one() 
+        self.admin['$cmd'].sys.unlock.find_one()
 
     def __enter__(self):
         return self

--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -62,7 +62,7 @@ def _rpartition(entity, sep):
 
 def parse_userinfo(userinfo):
     """Validates the format of user information in a MongoDB URI.
-    Reserved characters like ':', '/' and '@' must be escaped
+    Reserved characters like ':', '/', '+' and '@' must be escaped
     following RFC 2396.
 
     Returns a 2-tuple containing the unescaped username followed
@@ -70,6 +70,9 @@ def parse_userinfo(userinfo):
 
     :Paramaters:
         - `userinfo`: A string of the form <username>:<password>
+
+    .. versionchanged:: 2.1.1+
+       Now uses `urllib.unquote_plus` so `+` characters must be escaped.
     """
     if '@' in userinfo or userinfo.count(':') > 1:
         raise InvalidURI("':' or '@' characters in a username or password "
@@ -78,8 +81,8 @@ def parse_userinfo(userinfo):
     if not user or not passwd:
         raise InvalidURI("An empty string is not a "
                          "valid username or password.")
-    user = urllib.unquote(user)
-    passwd = urllib.unquote(passwd)
+    user = urllib.unquote_plus(user)
+    passwd = urllib.unquote_plus(passwd)
 
     return user, passwd
 

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -51,6 +51,12 @@ class TestURI(unittest.TestCase):
         self.assert_(parse_userinfo('user:password'))
         self.assertEqual(('us:r', 'p@ssword'),
                          parse_userinfo('us%3Ar:p%40ssword'))
+        self.assertEqual(('us er', 'p ssword'),
+                         parse_userinfo('us+er:p+ssword'))
+        self.assertEqual(('us er', 'p ssword'),
+                         parse_userinfo('us%20er:p%20ssword'))
+        self.assertEqual(('us+er', 'p+ssword'),
+                         parse_userinfo('us%2Ber:p%2Bssword'))
 
     def test_split_hosts(self):
         self.assertRaises(ConfigurationError, split_hosts,


### PR DESCRIPTION
Makes userinfo parser handle `+` signs as spaces.
If `+` signs were used then they will now need to
be escaped.
