### PR TITLE
AutoReconnect error should be raised instead of TypeError when ReadPrefrence.SECONDARY is used

### DIFF
--- a/pymongo/replica_set_connection.py
+++ b/pymongo/replica_set_connection.py
@@ -815,7 +815,7 @@ class ReplicaSetConnection(common.BaseObject):
             except AutoReconnect, why:
                 self.disconnect()
                 errors.append(why)
-        raise AutoReconnect(', '.join(errors))
+        raise AutoReconnect(', '.join(map(str, errors)))
 
     def __cmp__(self, other):
         # XXX: Implement this?


### PR DESCRIPTION
This fix is for a bug where non-strings are joined using .join(...) in case the user has ReadPreference.SECONDARY. This causes a TypeError to be thrown instead of the expected AutoReconnect error.
