### PR TITLE
MasterSlaveConnection should start request on connection to master

### DIFF
--- a/pymongo/master_slave_connection.py
+++ b/pymongo/master_slave_connection.py
@@ -192,6 +192,7 @@ class MasterSlaveConnection(BaseObject):
         that all operations performed within a request will be sent
         using the Master connection.
         """
+        self.master.start_request()
         self.__in_request = True
 
     def end_request(self):


### PR DESCRIPTION
MasterSlaveConnection should start request on connection to master in its start_request(), in case master was created with auto_start_request=False
