### PR TITLE
Avoid MemoryError on large queries

### DIFF
--- a/pymongo/connection.py
+++ b/pymongo/connection.py
@@ -752,7 +752,7 @@ class Connection(common.BaseObject):
         Takes length to receive and repeatedly calls recv until able to
         return a buffer of that length, raising ConnectionFailure on error.
         """
-        chunks = []
+        message = EMPTY
         while length:
             try:
                 chunk = sock_info.sock.recv(length)
@@ -764,8 +764,8 @@ class Connection(common.BaseObject):
             if chunk == EMPTY:
                 raise ConnectionFailure("connection closed")
             length -= len(chunk)
-            chunks.append(chunk)
-        return EMPTY.join(chunks)
+            message += chunk
+        return message
 
     def __receive_message_on_socket(self, operation, request_id, sock_info):
         """Receive a message in response to `request_id` on `sock`.


### PR DESCRIPTION
When receiving data from large queries we were running into a MemoryError. From investigating sock_info.sock.recv returns a buffer of length size, which is then inserted into the chunks list. Unfortunately we were only receiving a small amount of bytes per iteration so chunks was filling up with items of size (approximately) length and quickly running out of memory. In total our query looked like it would try to allocate about 4Tb worth of memory.

I've rewritten the function to behave more like the a previous version which fixes the memory issue as the chunk memory is freed once the data has been concatenated to the message.
