### PR TITLE
MemoryError while retrieving large cursors

### DIFF
--- a/pymongo/connection.py
+++ b/pymongo/connection.py
@@ -35,6 +35,7 @@ access:
 """
 
 import datetime
+import io
 import random
 import socket
 import struct
@@ -853,14 +854,13 @@ class Connection(common.BaseObject):
         Takes length to receive and repeatedly calls recv until able to
         return a buffer of that length, raising ConnectionFailure on error.
         """
-        chunks = []
+        buffer = io.BytesIO()
         while length:
-            chunk = sock_info.sock.recv(length)
-            if chunk == EMPTY:
+            chunk_len = buffer.write(sock_info.sock.recv(length))
+            if chunk_len == 0:
                 raise ConnectionFailure("connection closed")
-            length -= len(chunk)
-            chunks.append(chunk)
-        return EMPTY.join(chunks)
+            length -= chunk_len
+        return buffer.getvalue()
 
     def __receive_message_on_socket(self, operation, request_id, sock_info):
         """Receive a message in response to `request_id` on `sock`.


### PR DESCRIPTION
This is the issue we experience on windows machines:
Python version v2.7.2
Mongo v2.0.7 (running on ubuntu)

``` python
>>> ================================ RESTART ================================
>>> from pymongo import Connection
>>> c = Connection("mongodb://user:pswd@mongo/admin")
>>> c_users  = c["data"]["user"]
>>> users = c_users.find({}, ["_id"])
>>> users.count()
193845
>>> for u in users:
    s = u["_id"]



Traceback (most recent call last):
  File "<pyshell#24>", line 1, in <module>
    for u in users:
  File "build\bdist.win32\egg\pymongo\cursor.py", line 778, in next
    if len(self.__data) or self._refresh():
  File "build\bdist.win32\egg\pymongo\cursor.py", line 742, in _refresh
    limit, self.__id))
  File "build\bdist.win32\egg\pymongo\cursor.py", line 666, in __send_message
    **kwargs)
  File "build\bdist.win32\egg\pymongo\connection.py", line 907, in _send_message_with_response
    return self.__send_and_receive(message, sock_info)
  File "build\bdist.win32\egg\pymongo\connection.py", line 885, in __send_and_receive
    return self.__receive_message_on_socket(1, request_id, sock_info)
  File "build\bdist.win32\egg\pymongo\connection.py", line 877, in __receive_message_on_socket
    return self.__receive_data_on_socket(length - 16, sock_info)
  File "build\bdist.win32\egg\pymongo\connection.py", line 858, in __receive_data_on_socket
    chunk = sock_info.sock.recv(length)
MemoryError
>>> 
```

At this point I am not even convinced that this is pymongo's issue, and not python's, but the change seems to fix the this without any other bad side affects.
Please do not hesitate to request for more info, I'm quite eager to have it resolved in driver's mainstream code.
