### PR TITLE
Add support for Unix local domain sockets PYTHON-297

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -59,3 +59,5 @@ The following is a list of people who have contributed to
 - Mike O'Brien (mpobrien)
 - T Dampier (dampier)
 - Michael Henson (hensom)
+- Devaev Maxim (mdevaev)
+- James Blackburn (jamesblackburn)

--- a/pymongo/connection.py
+++ b/pymongo/connection.py
@@ -675,7 +675,7 @@ class Connection(common.BaseObject):
         """Get a SocketInfo from the pool.
         """
         host, port = (self.__host, self.__port)
-        if host is None or port is None:
+        if host is None or (port is None and '/' not in host):
             host, port = self.__find_node()
 
         try:

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -19,7 +19,7 @@ import time
 import threading
 import weakref
 
-from pymongo.errors import ConnectionFailure
+from pymongo.errors import ConnectionFailure, ConfigurationError
 
 
 have_ssl = True
@@ -161,6 +161,17 @@ class BasePool:
         # is 'localhost' (::1 is fine). Avoids slow connect issues
         # like PYTHON-356.
         family = socket.AF_INET
+
+        # Unix domain sockets
+        if '/' in host:
+            if not hasattr(socket, "AF_UNIX"):
+                raise ConfigurationError(
+                            "UNIX-sockets are not supported on this system")
+            sock = socket.socket(socket.AF_UNIX)
+            sock.settimeout(self.conn_timeout or 20.0)
+            sock.connect(host)
+            return sock
+
         if socket.has_ipv6 and host != 'localhost':
             family = socket.AF_UNSPEC
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -423,6 +423,14 @@ class TestConnection(unittest.TestCase):
         dbs = connection.database_names()
         self.assertTrue("pymongo_test" in dbs)
         self.assertTrue("pymongo_test_bernie" in dbs)
+        
+    def test_unix_domain_socket(self):
+        try:
+            connection = Connection("/tmp/mongodb-27017.sock")
+            connection.database_names()
+        except:
+            # Possibly the OS doesn't support unix domain sockets
+            raise SkipTest("No Unix domain sockets")
 
     def test_fsync_lock_unlock(self):
         c = get_connection()


### PR DESCRIPTION
Rebase:
https://github.com/mongodb/mongo-python-driver/pull/95
against master.

Add a test.
