### PR TITLE
Enable collapsiblesidebar in document.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -81,6 +81,7 @@ db = connection.doctest_test
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
 html_theme = 'default'
+html_theme_options = {'collapsiblesidebar': True}
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
This feature is enabled in the Python documentation http://docs.python.org/. It makes docs look more pretty. You could click that left arrow in the middle of the screen to collapse sidebar.
