### PR TITLE
 raise error when trying to use deprecated kwargs to create_collection

### DIFF
--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -24,7 +24,8 @@ from pymongo import common, helpers
 from pymongo.collection import Collection
 from pymongo.errors import (CollectionInvalid,
                             InvalidName,
-                            OperationFailure)
+                            OperationFailure,
+                            UnsupportedOption)
 from pymongo.son_manipulator import ObjectIdInjector
 from pymongo import read_preferences as rp
 
@@ -239,6 +240,10 @@ class Database(common.BaseObject):
         .. versionchanged:: 1.5
            deprecating `options` in favor of kwargs
         """
+        if 'options' in kwargs:
+            raise UnsupportedOption('The options kwarg has been deprecated. '
+                                    'Please pass options as kwargs')
+
         opts = {"create": True}
         opts.update(kwargs)
 

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -36,7 +36,8 @@ from pymongo.database import Database
 from pymongo.errors import (CollectionInvalid,
                             ConfigurationError,
                             InvalidName,
-                            OperationFailure)
+                            OperationFailure,
+                            UnsupportedOption)
 from pymongo.son_manipulator import (AutoReference,
                                      NamespaceInjector,
                                      ObjectIdShuffler)
@@ -91,6 +92,7 @@ class TestDatabase(unittest.TestCase):
         self.assertRaises(TypeError, db.create_collection, 5)
         self.assertRaises(TypeError, db.create_collection, None)
         self.assertRaises(InvalidName, db.create_collection, "coll..ection")
+        self.assertRaises(UnsupportedOption, db.create_collection, "test", options={})
 
         test = db.create_collection("test")
         test.save({"hello": u"world"})


### PR DESCRIPTION
Currently, if you try to do something like db.create_collection(..., options={'capped'=True}), the collection will be created but the options specified will be ignored.  

Since the options kwarg is deprecated, I suggest you raise an error rather than silently ignore it.
