### PR TITLE
`__str__` method of ObjectId return <type 'str'>

### DIFF
--- a/bson/objectid.py
+++ b/bson/objectid.py
@@ -244,7 +244,10 @@ class ObjectId(object):
             self.__id = oid
 
     def __str__(self):
-        return binascii.hexlify(self.__id).decode()
+        return binascii.hexlify(self.__id)
+
+    def __unicode__(self):
+        return self.__str__().decode()
 
     def __repr__(self):
         return "ObjectId('%s')" % (str(self),)


### PR DESCRIPTION
As Python supports both `__str__` and `__unicode__` method for objects' string conversion,
it is suggested to return `<type 'str'>` for `__str__`, and `<type 'unicode'>` for `__unicode__`.

This is my understanding about the difference between this two methods.
So I think it would be better to return str explicitly for `__str__`,
and add `__unicode__` for possible use.

I have encountered a problem when I formatting strings with ObjectId:

``` python
>>> '%s %s' % ('\xe5\x90\x8d\xe5\xad\x97', ObjectId())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 0: ordinal not in range(128)
```

The reason why this problem happen is because Python tried to encode every argument since he found an unicode in the arguments, but the first one has already been encoded as utf8, the re-encode action then cause error.
