### PR TITLE
Allowing use of query in distinct

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1158,7 +1158,7 @@ class Collection(common.BaseObject):
                                                  self.__full_name,
                                                  to=new_name, **kwargs)
 
-    def distinct(self, key):
+    def distinct(self, key, query={}):
         """Get a list of distinct values for `key` among all documents
         in this collection.
 
@@ -1170,12 +1170,13 @@ class Collection(common.BaseObject):
 
         :Parameters:
           - `key`: name of key for which we want to get the distinct values
+          - `query`: filter for the distinct values (default ``{}``)
 
         .. note:: Requires server version **>= 1.1.0**
 
         .. versionadded:: 1.1.1
         """
-        return self.find().distinct(key)
+        return self.find(query).distinct(key)
 
     def map_reduce(self, map, reduce, out, full_response=False, **kwargs):
         """Perform a map/reduce operation on this collection.


### PR DESCRIPTION
As the documentation of mongodb shows [1], we can specify a query
when using distinct. So we can perform operations like:

&gt;&gt;&gt; db.users.distinct("country", {"status": "active"})

[1]
http://docs.mongodb.org/manual/reference/method/db.collection.distinct/#db.collection.distinct
