### PR TITLE
set stacklevel as appropriate when issuing DeprecationWarning's

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -798,7 +798,7 @@ class Collection(common.BaseObject):
         if 'ttl' in kwargs:
             cache_for = kwargs.pop('ttl')
             warnings.warn("ttl is deprecated. Please use cache_for instead.",
-                          DeprecationWarning)
+                          DeprecationWarning, stacklevel=2)
 
         keys = helpers._index_list(key_or_list)
         index_doc = helpers._index_document(keys)
@@ -1361,7 +1361,7 @@ class Collection(common.BaseObject):
                   isinstance(sort, dict) and len(sort) == 1):
                 warnings.warn("Passing mapping types for `sort` is deprecated,"
                               " use a list of (key, direction) pairs instead",
-                              DeprecationWarning)
+                              DeprecationWarning, stacklevel=2)
                 kwargs['sort'] = sort
             else:
                 raise TypeError("sort must be a list of (key, direction) "

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -407,7 +407,8 @@ class BaseObject(object):
     def __set_slave_okay(self, value):
         """Property setter for slave_okay"""
         warnings.warn("slave_okay is deprecated. Please use "
-                      "read_preference instead.", DeprecationWarning)
+                      "read_preference instead.", DeprecationWarning,
+                      stacklevel=2)
         self.__slave_okay = validate_boolean('slave_okay', value)
 
     slave_okay = property(__get_slave_okay, __set_slave_okay)
@@ -481,7 +482,7 @@ class BaseObject(object):
         """Property setter for safe"""
         warnings.warn("safe is deprecated. Please use the"
                       " 'w' write_concern option instead.",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         self.__safe = validate_boolean('safe', value)
 
     safe = property(__get_safe, __set_safe)
@@ -496,7 +497,8 @@ class BaseObject(object):
         .. versionadded:: 2.0
         """
         warnings.warn("get_lasterror_options is deprecated. Please use "
-                      "write_concern instead.", DeprecationWarning)
+                      "write_concern instead.", DeprecationWarning,
+                      stacklevel=2)
         return self.__write_concern.copy()
 
     def set_lasterror_options(self, **kwargs):
@@ -516,7 +518,8 @@ class BaseObject(object):
         .. versionadded:: 2.0
         """
         warnings.warn("set_lasterror_options is deprecated. Please use "
-                      "write_concern instead.", DeprecationWarning)
+                      "write_concern instead.", DeprecationWarning,
+                      stacklevel=2)
         for key, value in kwargs.iteritems():
             self.__set_safe_option(key, value)
 
@@ -536,7 +539,8 @@ class BaseObject(object):
         .. versionadded:: 2.0
         """
         warnings.warn("unset_lasterror_options is deprecated. Please use "
-                      "write_concern instead.", DeprecationWarning)
+                      "write_concern instead.", DeprecationWarning,
+                      stacklevel=2)
         if len(options):
             for option in options:
                 self.__write_concern.pop(option, None)
@@ -575,7 +579,8 @@ class BaseObject(object):
 
         if safe is not None:
             warnings.warn("The safe parameter is deprecated. Please use "
-                          "write concern options instead.", DeprecationWarning)
+                          "write concern options instead.", DeprecationWarning,
+                          stacklevel=3)
             validate_boolean('safe', safe)
 
         # Passed options override collection level defaults.

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -306,7 +306,8 @@ class MongoClient(common.BaseObject):
         super(MongoClient, self).__init__(**options)
         if self.slave_okay:
             warnings.warn("slave_okay is deprecated. Please "
-                          "use read_preference instead.", DeprecationWarning)
+                          "use read_preference instead.", DeprecationWarning,
+                          stacklevel=2)
 
         if _connect:
             try:
@@ -793,7 +794,8 @@ class MongoClient(common.BaseObject):
            Deprecated support for external cursor managers.
         """
         warnings.warn("Support for external cursor managers is deprecated "
-                      "and will be removed in PyMongo 3.0.", DeprecationWarning)
+                      "and will be removed in PyMongo 3.0.",
+                      DeprecationWarning, stacklevel=2)
         manager = manager_class(self)
         if not isinstance(manager, CursorManager):
             raise TypeError("manager_class must be a subclass of "

--- a/pymongo/mongo_replica_set_client.py
+++ b/pymongo/mongo_replica_set_client.py
@@ -493,7 +493,8 @@ class MongoReplicaSetClient(common.BaseObject):
         super(MongoReplicaSetClient, self).__init__(**self.__opts)
         if self.slave_okay:
             warnings.warn("slave_okay is deprecated. Please "
-                          "use read_preference instead.", DeprecationWarning)
+                          "use read_preference instead.", DeprecationWarning,
+                          stacklevel=2)
 
         try:
             self.refresh()


### PR DESCRIPTION
The attached patch sets stacklevel as appropriate when issuing DeprecationWarning's.  This will help users of pymongo see the places where their code must be updated.
