### PR TITLE
Adding support for uri option: maxpoolsize

### DIFF
--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -212,6 +212,7 @@ VALIDATORS = {
     'journal': validate_boolean,
     'connecttimeoutms': validate_timeout_or_none,
     'sockettimeoutms': validate_timeout_or_none,
+    'maxpoolsize': validate_positive_integer,
     'ssl': validate_boolean,
     'ssl_keyfile': validate_readable,
     'ssl_certfile': validate_readable,

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -259,8 +259,8 @@ class MongoClient(common.BaseObject):
             options[option] = value
         options.update(opts)
 
-        self.__max_pool_size = common.validate_positive_integer(
-                                                'max_pool_size', max_pool_size)
+        self.__max_pool_size = options.get('maxpoolsize',
+            common.validate_positive_integer('max_pool_size', max_pool_size))
 
         self.__cursor_manager = CursorManager(self)
 


### PR DESCRIPTION
I've changed default value to 100, because the manual says.
http://docs.mongodb.org/manual/reference/connection-string/#uri.maxPoolSize

Let me know if I should to add a "`.. versionchanged::`" directive about this change in the doc comment of the property.
