### PR TITLE
Cursor.__deepcopy() does not support lists and causes (obscure) application crashes

### DIFF
--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -861,5 +861,10 @@ class Cursor(object):
                 value = self.__deepcopy(value, memo)
             elif not isinstance(value, RE_TYPE):
                 value = copy.deepcopy(value, memo)
-            y[copy.deepcopy(key, memo)] = value
+            if isinstance(x, dict) :
+                y[copy.deepcopy(key, memo)] = value
+            else : # list case
+                if key == 0 :
+                    y = []
+                y += value
         return y


### PR DESCRIPTION
The method pymongo.cursor.Cursor.__deepcopy() was apparently created avoid copying regex'es in a deep copy. It works to copy dicts but does nothing for the list case. I found this behavior to be the cause of (obscure) "cannot deepcopy this pattern object" crashes when using Flask-admin with mongoengine. The failure was the result of query criteria containing a list that contained regex'es. In that list case __deepcopy() just calls copy.deepcopy() which fails on the regex'es.

The submitted patch enables __deepcopy to copy lists in addition to dicts. My goal in writing the patch was to implement the list case while minimizing logic changes to the original code as I did not want to unintentionally introduce any new problems. So the code may appear a bit clumsy. But it is perfectly functional and solves the failing case.

I hope this helps. Thanks for all the good work! -Juan
