### PR TITLE
Add generator versions of decode_all in bson module.

### DIFF
--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -519,6 +519,82 @@ if _use_c:
     decode_all = _cbson.decode_all
 
 
+def decode_iter(data, as_class=dict,
+                tz_aware=True, uuid_subtype=OLD_UUID_SUBTYPE):
+    """Decode BSON data to multiple documents as a generator. Works
+    similarly to the decode_all function, but yields one document
+    at a time.
+
+    `data` must be a string of concatenated, valid, BSON-encoded
+    documents.
+
+    :Parameters:
+      - `data`: BSON data
+      - `as_class` (optional): the class to use for the resulting
+        documents
+      - `tz_aware` (optional): if ``True``, return timezone-aware
+        :class:`~datetime.datetime` instances
+
+    .. versionadded:: 2.5
+    """
+    position = 0
+    end = len(data) - 1
+    while position < end:
+        obj_size = struct.unpack("<i", data[position:position + 4])[0]
+        if len(data) - position < obj_size:
+            raise InvalidBSON("objsize too large")
+        if data[position + obj_size - 1:position + obj_size] != ZERO:
+            raise InvalidBSON("bad eoo")
+        elements = data[position + 4:position + obj_size - 1]
+        position += obj_size
+
+        yield _elements_to_dict(elements, as_class, tz_aware, uuid_subtype)
+
+
+def decode_file_iter(file_obj, as_class=dict, tz_aware=True,
+                     uuid_subtype=OLD_UUID_SUBTYPE):
+    """Decode bson data from a file to multiple documents as a generator. Works
+    similarly to the decode_all function, but reads from the file object in
+    chunks and parses bson in chunks, yielding one document at a time.
+
+    :Parameters:
+      - `file_obj`: A file object containing BSON data.
+      - `as_class` (optional): the class to use for the resulting
+        documents
+      - `tz_aware` (optional): if ``True``, return timezone-aware
+        :class:`~datetime.datetime` instances
+
+    .. versionadded:: 2.5
+    """
+    while True:
+        # Read size of next object.
+        size_data = file_obj.read(4)
+        if len(size_data) == 0:
+            break  # Finished with file normaly.
+        elif len(size_data) != 4:
+            raise InvalidBSON("cut off in middle of objsize")
+        obj_size = struct.unpack("<i", size_data)[0]
+        if obj_size < 5:
+            # The obj_size should at least be big enough to encode the
+            # obj_size and EOO itself, even on a zero-sized elements.
+            raise InvalidBSON("objsize too small")
+
+        # Actual data for elements is total size - size_prefix - suffix, but
+        # we read the suffix together with the element to reduce number of
+        # reads.
+        elements_size = obj_size - 4
+
+        # Read object itself and the EOO in one read (to reduce num reads).
+        elements = file_obj.read(elements_size)
+        if len(elements) != elements_size:
+            raise InvalidBSON("objsize too large")
+        if elements[-1] != ZERO:
+            raise InvalidBSON("bad eoo")
+
+        yield _elements_to_dict(elements[:-1], as_class,
+                                tz_aware, uuid_subtype)
+
+
 def is_valid(bson):
     """Check that the given string represents valid :class:`BSON` data.
 

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -20,6 +20,7 @@ import unittest
 import datetime
 import re
 import sys
+from StringIO import StringIO
 try:
     import uuid
     should_test_uuid = True
@@ -32,6 +33,8 @@ from nose.plugins.skip import SkipTest
 import bson
 from bson import (BSON,
                   decode_all,
+                  decode_iter,
+                  decode_file_iter,
                   is_valid)
 from bson.binary import Binary, UUIDLegacy
 from bson.code import Code
@@ -41,7 +44,8 @@ from bson.py3compat import b
 from bson.son import SON
 from bson.timestamp import Timestamp
 from bson.errors import (InvalidDocument,
-                         InvalidStringData)
+                         InvalidStringData,
+                         InvalidBSON)
 from bson.max_key import MaxKey
 from bson.min_key import MinKey
 from bson.tz_util import (FixedOffset,
@@ -89,6 +93,61 @@ class TestBSON(unittest.TestCase):
                                       "\x00\x0C\x00\x00\x00\x68\x65\x6C\x6C"
                                       "\x6f\x20\x77\x6F\x72\x6C\x64\x00\x00"
                                       "\x05\x00\x00\x00\x00")))
+        self.assertEqual([{"test": u"hello world"}, {}],
+                         list(decode_iter(
+                            b("\x1B\x00\x00\x00\x0E\x74\x65\x73\x74"
+                              "\x00\x0C\x00\x00\x00\x68\x65\x6C\x6C"
+                              "\x6f\x20\x77\x6F\x72\x6C\x64\x00\x00"
+                              "\x05\x00\x00\x00\x00"))))
+        self.assertEqual([{"test": u"hello world"}, {}],
+                         list(decode_file_iter(StringIO(
+                            b("\x1B\x00\x00\x00\x0E\x74\x65\x73\x74"
+                              "\x00\x0C\x00\x00\x00\x68\x65\x6C\x6C"
+                              "\x6f\x20\x77\x6F\x72\x6C\x64\x00\x00"
+                              "\x05\x00\x00\x00\x00")))))
+
+    def test_invalid_decodes(self):
+        # Invalid object size (not enough bytes in document for even
+        # an object size of first object.
+        # NOTE: decode_all and decode_iter don't care, not sure if they should?
+        self.assertRaises(InvalidBSON, list,
+                          decode_file_iter(StringIO(b("\x1B"))))
+
+        # An object size that's too small to even include the object size,
+        # but is correctly encoded, along with a correct EOO (and no data).
+        data = b("\x01\x00\x00\x00\x00")
+        self.assertRaises(InvalidBSON, decode_all, data)
+        self.assertRaises(InvalidBSON, list, decode_iter(data))
+        self.assertRaises(InvalidBSON, list, decode_file_iter(StringIO(data)))
+
+        # One object, but with object size listed smaller than it is in the
+        # data.
+        data = b("\x1A\x00\x00\x00\x0E\x74\x65\x73\x74"
+                 "\x00\x0C\x00\x00\x00\x68\x65\x6C\x6C"
+                 "\x6f\x20\x77\x6F\x72\x6C\x64\x00\x00"
+                 "\x05\x00\x00\x00\x00")
+        self.assertRaises(InvalidBSON, decode_all, data)
+        self.assertRaises(InvalidBSON, list, decode_iter(data))
+        self.assertRaises(InvalidBSON, list, decode_file_iter(StringIO(data)))
+
+        # One object, missing the EOO at the end.
+        data = b("\x1B\x00\x00\x00\x0E\x74\x65\x73\x74"
+                 "\x00\x0C\x00\x00\x00\x68\x65\x6C\x6C"
+                 "\x6f\x20\x77\x6F\x72\x6C\x64\x00\x00"
+                 "\x05\x00\x00\x00")
+        self.assertRaises(InvalidBSON, decode_all, data)
+        self.assertRaises(InvalidBSON, list, decode_iter(data))
+        self.assertRaises(InvalidBSON, list, decode_file_iter(StringIO(data)))
+
+        # One object, sized correctly, with a spot for an EOO, but the EOO
+        # isn't 0x00.
+        data = b("\x1B\x00\x00\x00\x0E\x74\x65\x73\x74"
+                 "\x00\x0C\x00\x00\x00\x68\x65\x6C\x6C"
+                 "\x6f\x20\x77\x6F\x72\x6C\x64\x00\x00"
+                 "\x05\x00\x00\x00\xFF")
+        self.assertRaises(InvalidBSON, decode_all, data)
+        self.assertRaises(InvalidBSON, list, decode_iter(data))
+        self.assertRaises(InvalidBSON, list, decode_file_iter(StringIO(data)))
 
     def test_data_timestamp(self):
         self.assertEqual({"test": Timestamp(4, 20)},


### PR DESCRIPTION
When decoding large collections of bson documents, the python representation
of dicts are time and space costly, so it's sometimes useful to generate and
consume the documents iteratively. This patch adds two new functions to do
that: decode_iter and decode_file_iter. The first is given all the bson data,
but yields one document at a time, while the second reads from a file object
enough to yield one document at a time (to avoid reading in an entire file).
