### PR TITLE
Monitor threads can die unexpectedly with forks

### DIFF
--- a/pymongo/mongo_replica_set_client.py
+++ b/pymongo/mongo_replica_set_client.py
@@ -329,7 +329,7 @@ class MonitorThread(Monitor, threading.Thread):
         """Override Monitor's schedule_refresh method
         raise exception as warning if thread is dead
         """
-        if not self.is_alive():
+        if not self.isAlive():
             raise Exception("Monitor thread died unexpectedly, used with fork?")
         super(MonitorThread, self).schedule_refresh()
 


### PR DESCRIPTION
Monitor thread will die if created before a double fork.

Developer should avoid creating MongoReplicaSetClient instance before forking, however there is no any warning about this behavior.
But I think nothing we can do but throw an exception as warning, this might help saving time trouble shooting.

This happened to my system. Monitor thread died and refresh() was never called when a failover happens.
And as a result, error message will stay as "No replica set primary available for query with ReadPreference PRIMARY", even after failover is completed, which is confusing. Hope this change/idea will be a bit more helpful in such cases.
