### PR TITLE
Cursors now support setting comments

### DIFF
--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -144,6 +144,7 @@ class Cursor(object):
         self.__max_scan = max_scan
         self.__explain = False
         self.__hint = None
+        self.__comment = None
         self.__as_class = as_class
         self.__slave_okay = slave_okay
         self.__manipulate = manipulate
@@ -269,6 +270,8 @@ class Cursor(object):
             operators["$explain"] = True
         if self.__hint:
             operators["$hint"] = self.__hint
+        if self.__comment:
+            operators["$comment"] = self.__comment
         if self.__snapshot:
             operators["$snapshot"] = True
         if self.__max_scan:
@@ -626,6 +629,8 @@ class Cursor(object):
         command['slave_okay'] = self.__slave_okay
         use_master = not self.__slave_okay and not self.__read_preference
         command['_use_master'] = use_master
+        if self.__comment:
+            command['$comment'] = self.__comment
 
         if with_limit_and_skip:
             if self.__limit:
@@ -681,6 +686,8 @@ class Cursor(object):
         options['slave_okay'] = self.__slave_okay
         use_master = not self.__slave_okay and not self.__read_preference
         options['_use_master'] = use_master
+        if self.__comment:
+            options['$comment'] = self.__comment
 
         database = self.__collection.database
         return database.command("distinct",
@@ -729,6 +736,17 @@ class Cursor(object):
             return self
 
         self.__hint = helpers._index_document(index)
+        return self
+
+    def comment(self, comment):
+        """Adds a 'comment', to the cursor.
+
+        http://docs.mongodb.org/manual/reference/operator/comment/
+
+        :Parameters:
+          - `comment`: A string or document
+        """
+        self.__comment = comment
         return self
 
     def where(self, code):

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -26,13 +26,16 @@ from nose.plugins.skip import SkipTest
 from bson.code import Code
 from bson.son import SON
 from pymongo import (ASCENDING,
-                     DESCENDING)
+                     DESCENDING,
+                     ALL,
+                     OFF)
 from pymongo.database import Database
 from pymongo.errors import (InvalidOperation,
                             OperationFailure)
 from test import version
 from test.test_client import get_client
 from test.utils import is_mongos
+from contextlib import contextmanager
 
 
 class TestCursor(unittest.TestCase):
@@ -860,6 +863,38 @@ with self.db.test.find() as c2:
 self.assertFalse(c2.alive)
 """
         self.assertTrue(c1.alive)
+
+    def test_comment(self):
+        @contextmanager
+        def new_profile():
+            self.db.set_profiling_level(OFF)
+            self.db.system.profile.drop()
+            self.db.set_profiling_level(ALL)
+            yield
+            self.db.set_profiling_level(OFF)
+
+        with new_profile():
+            matching = list(self.db.test.find({'type': 'string'}).comment('foo'))
+            op = self.db.system.profile.find({'ns': 'pymongo_test.test',
+                                              'op': 'query',
+                                              'query.$comment': 'foo'})
+            self.assertEqual(op.count(), 1)
+
+        with new_profile():
+            self.db.test.find({'type': 'string'}).comment('foo').count()
+            op = self.db.system.profile.find({'ns': 'pymongo_test.$cmd',
+                                              'op': 'command',
+                                              'command.count': 'test',
+                                              'command.$comment': 'foo'})
+            self.assertEqual(op.count(), 1)
+
+        with new_profile():
+            self.db.test.find({'type': 'string'}).comment('foo').distinct('type')
+            op = self.db.system.profile.find({'ns': 'pymongo_test.$cmd',
+                                              'op': 'command',
+                                              'command.distinct': 'test',
+                                              'command.$comment': 'foo'})
+            self.assertEqual(op.count(), 1)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I added support for setting a comment on a cursor. The comment is currently propagated during queries, counts, and distinct commands: 

```
db.foo.find({}).comment('bar')
db.foo.find({}).comment('bar').count()
db.foo.find({}).comment('bar').distinct('zot')
```

For the count and distinct commands I'm currently just adding a '$comment' property to the command itself. This appears to work in practice and the comment is stored in the profile collection. I tested this with mongo 2.4.6, but I was unsure if the general approach was correct there.
