### PR TITLE
Add: ability to bulk insert using a generator

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -334,15 +334,14 @@ class Collection(common.BaseObject):
             docs = [docs]
 
         if manipulate:
-            docs = [self.__database._fix_incoming(doc, self) for doc in docs]
+            docs = (self.__database._fix_incoming(doc, self) for doc in docs)
 
         safe, options = self._get_write_mode(safe, **kwargs)
-        message._do_batched_insert(self.__full_name, docs,
-                                   check_keys, safe, options,
-                                   continue_on_error, self.uuid_subtype,
-                                   self.database.connection)
+        ids = message._do_batched_insert(self.__full_name, docs,
+                                         check_keys, safe, options,
+                                         continue_on_error, self.uuid_subtype,
+                                         self.database.connection)
 
-        ids = [doc.get("_id", None) for doc in docs]
         if return_one:
             return ids[0]
         else:

--- a/pymongo/message.py
+++ b/pymongo/message.py
@@ -210,7 +210,9 @@ def _do_batched_insert(collection_name, docs, check_keys,
     begin += bson._make_c_string(collection_name)
     message_length = len(begin)
     data = [begin]
+    ids = []
     for doc in docs:
+        ids.append(doc.get("_id", None))
         encoded = bson.BSON.encode(doc, check_keys, uuid_subtype)
         encoded_length = len(encoded)
         if encoded_length > client.max_bson_size:
@@ -238,7 +240,7 @@ def _do_batched_insert(collection_name, docs, check_keys,
                 last_error = exc
             # With unacknowledged writes just return at the first error.
             elif not safe:
-                return
+                return ids
             # With acknowledged writes raise immediately.
             else:
                 raise
@@ -250,5 +252,6 @@ def _do_batched_insert(collection_name, docs, check_keys,
     # Re-raise any exception stored due to continue_on_error
     if last_error is not None:
         raise last_error
+    return ids
 if _use_c:
     _do_batched_insert = _cmessage._do_batched_insert

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -761,7 +761,9 @@ class TestCollection(unittest.TestCase):
         self.assertTrue(isinstance(id, list))
         self.assertEqual(1, len(id))
 
-        self.assertRaises(InvalidOperation, db.test.insert, [])
+        # InvalidOperation: empty list
+        # OperationFailure: exhausted generator
+        self.assertRaises((InvalidOperation, OperationFailure), db.test.insert, [])
 
     def test_insert_multiple_with_duplicate(self):
         db = self.db


### PR DESCRIPTION
This PR add support to bulk insert using a generator.

The function `_do_batched_insert` at `message.py` already handles bulk insertion of a long list very well.

This PR passes all test.
