### PR TITLE
Make ObjectId json serializable

### DIFF
--- a/bson/objectid.py
+++ b/bson/objectid.py
@@ -287,3 +287,8 @@ class ObjectId(object):
         .. versionadded:: 1.1
         """
         return hash(self.__id)
+        
+    def __json__(self, **kwargs):
+        """Make :class:`ObjectId` json serializable.
+        """
+        return str(self)


### PR DESCRIPTION
This is good for frameworks that automatically takes the **json** function of a class to serialize an object.
