### PR TITLE
PYTHON-600: Fix a bug in Replica Set monitoring in split brain situation

### DIFF
--- a/pymongo/mongo_replica_set_client.py
+++ b/pymongo/mongo_replica_set_client.py
@@ -1189,6 +1189,8 @@ class MongoReplicaSetClient(common.BaseObject):
                 break
         else:
             if errors:
+                if rs_state.hosts:
+                    self.__rs_state = RSState(self.__make_threadlocal())
                 raise AutoReconnect(', '.join(errors))
             raise ConfigurationError('No suitable hosts found')
 


### PR DESCRIPTION
Suppose you have a Replica Set and a MongoReplicaSetClient connection to it which you don't close.
1. At some time you get a split brain situation and a part of the Replica Set nodes become isolated from others. MongoReplicaSetClient.refresh() will remove them from its RSState and will monitor only the other part of nodes.
2. After some time your host loses connection to the second part of nodes. Replica Set monitor will continue to monitor only the second part of nodes.
3. And finally after some time connection to the first part of nodes resumes but to the second part not. But the Replica Set monitor continues to monitor only the second part of nodes and your connection won't work until at least one host from the second part become available.

This Pull Request fixes the issue.
