### PR TITLE
PYTHON-600: Fix a bug in Replica Set monitoring in split brain situation

### DIFF
--- a/pymongo/mongo_replica_set_client.py
+++ b/pymongo/mongo_replica_set_client.py
@@ -641,6 +641,7 @@ class MongoReplicaSetClient(common.BaseObject):
         """
         self.__opts = {}
         self.__seeds = set()
+        self.__last_seeds = set()
         self.__index_cache = {}
         self.__auth_credentials = {}
 
@@ -1127,6 +1128,7 @@ class MongoReplicaSetClient(common.BaseObject):
             # Try first those hosts we think are up, then the down ones.
             nodes = sorted(
                 rs_state.hosts, key=lambda host: rs_state.get(host).up)
+            nodes.extend(self.__last_seeds - rs_state.hosts)
         else:
             nodes = self.__seeds
 
@@ -1186,6 +1188,7 @@ class MongoReplicaSetClient(common.BaseObject):
                     member.pool.discard_socket(sock_info)
                 errors.append("%s:%d: %s" % (node[0], node[1], str(why)))
             if hosts:
+                self.__last_seeds = set(hosts)
                 break
         else:
             if errors:


### PR DESCRIPTION
Suppose you have a Replica Set and a MongoReplicaSetClient connection to it which you don't close.
1. At some time you get a split brain situation and a part of the Replica Set nodes become isolated from others. MongoReplicaSetClient.refresh() will remove them from its RSState and will monitor only the other part of nodes.
2. After some time your host loses connection to the second part of nodes. Replica Set monitor will continue to monitor only the second part of nodes.
3. And finally after some time connection to the first part of nodes resumes but to the second part not. But the Replica Set monitor continues to monitor only the second part of nodes and your connection won't work until at least one host from the second part become available.

This Pull Request fixes the issue.
