### PR TITLE
Allow to skip key checking in bulk operation

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -69,3 +69,4 @@ The following is a list of people who have contributed to
 - Yuchen Ying (yegle)
 - Kyle Erf (3rf)
 - Luke Lovett (lovett89)
+- Kimmo Koskinen (viesti)

--- a/test/test_bulk.py
+++ b/test/test_bulk.py
@@ -181,6 +181,21 @@ class TestBulk(BulkTestBase):
         bulk.insert({'a.b': 1})
         self.assertRaises(InvalidDocument, bulk.execute)
 
+    def test_insert_check_keys_false(self):
+        bulk = self.coll.initialize_ordered_bulk_op()
+        bulk.insert({'a.b': 1})
+        result = bulk.execute(check_keys=False)
+        self.assertEqualResponse(
+            {'nMatched': 0,
+             'nModified': 0,
+             'nUpserted': 0,
+             'nInserted': 1,
+             'nRemoved': 0,
+             'upserted': [],
+             'writeErrors': [],
+             'writeConcernErrors': []},
+            result)
+
     def test_update(self):
         self.coll.insert([{}, {}])
 


### PR DESCRIPTION
Since this is already present in normal insert/update, being able to skip key checking in bulk operation would be neat too.
