### PR TITLE
Make MongoClient serializable

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1669,6 +1669,9 @@ class Collection(common.BaseObject):
     def __setstate__(self, dict):
         self.__dict__ = dict
 
+    def __getnewargs__(self):
+        return (self.__database, self.__name)
+
     def next(self):
         raise TypeError("'Collection' object is not iterable")
 

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1663,6 +1663,12 @@ class Collection(common.BaseObject):
     def __iter__(self):
         return self
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, dict):
+        self.__dict__ = dict
+
     def next(self):
         raise TypeError("'Collection' object is not iterable")
 

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -933,6 +933,15 @@ class Database(common.BaseObject):
         result = self.command("$eval", code, args=args)
         return result.get("retval", None)
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, dict):
+        self.__dict__ = dict
+
+    def __getnewargs__(self):
+        return (self.__connection, self.__name)
+
     def __call__(self, *args, **kwargs):
         """This is only here so that some API misusages are easier to debug.
         """
@@ -995,15 +1004,6 @@ class SystemJS(object):
 
     def __getitem__(self, name):
         return self.__getattr__(name)
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, dict):
-        self.__dict__ = dict
-
-    def __getnewargs__(self):
-        return (self.__connection, self.__name)
 
     def list(self):
         """Get a list of the names of the functions stored in this database.

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -996,6 +996,15 @@ class SystemJS(object):
     def __getitem__(self, name):
         return self.__getattr__(name)
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, dict):
+        self.__dict__ = dict
+
+    def __getnewargs__(self):
+        return (self.__connection, self.__name)
+
     def list(self):
         """Get a list of the names of the functions stored in this database.
 

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1485,5 +1485,15 @@ class MongoClient(common.BaseObject):
     def __iter__(self):
         return self
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, dict):
+        self.__dict__ = dict
+
+    def __getnewargs__(self):
+        return (self.host, self.port, self.__max_pool_size,
+                self.__document_class, self.__tz_aware)
+
     def next(self):
         raise TypeError("'MongoClient' object is not iterable")

--- a/pymongo/thread_util.py
+++ b/pymongo/thread_util.py
@@ -74,6 +74,10 @@ class Ident(object):
         """
         raise NotImplementedError
 
+# We watch for thread-death using a weakref callback to a thread local.
+# Weakrefs are permitted on subclasses of object but not object() itself.
+class ThreadVigil(object):
+    pass
 
 class ThreadIdent(Ident):
     def __init__(self):
@@ -84,11 +88,6 @@ class ThreadIdent(Ident):
         else:
             self._lock = DummyLock()
 
-    # We watch for thread-death using a weakref callback to a thread local.
-    # Weakrefs are permitted on subclasses of object but not object() itself.
-    class ThreadVigil(object):
-        pass
-
     def _make_vigil(self):
         # Threadlocals in Python <= 2.7.0 have race conditions when setting
         # attributes and possibly when getting them, too, leading to weakref
@@ -97,7 +96,7 @@ class ThreadIdent(Ident):
         try:
             vigil = getattr(self._local, 'vigil', None)
             if not vigil:
-                self._local.vigil = vigil = ThreadIdent.ThreadVigil()
+                self._local.vigil = vigil = ThreadVigil()
         finally:
             self._lock.release()
 


### PR DESCRIPTION
While serializing a MongoClient is hardly a common use case, it seems that major serialization frameworks don't work with MongoClient. These changes make MongoClient, Database and Collection serializable with ```dill```, an extension of ```pickle```.