### PR TITLE
Remove _id from documents during update if the document contains update operator modifiers

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -530,6 +530,10 @@ class Collection(common.BaseObject):
             if first.startswith('$'):
                 check_keys = False
 
+                # Also make sure that the document does not contain an _id
+                if '_id' in document:
+                    del document['_id']
+
         if client.max_wire_version > 1 and safe:
             # Update command
             command = SON([('update', self.name)])


### PR DESCRIPTION
This is necessary because updating docs with manipulate=True, inserts
a new object id causing OperationalError on the server.
