### PR TITLE
Debug logging

### DIFF
--- a/pymongo/mongo_replica_set_client.py
+++ b/pymongo/mongo_replica_set_client.py
@@ -1549,10 +1549,10 @@ class MongoReplicaSetClient(common.BaseObject):
             if not exhaust and "network_timeout" in kwargs:
                 sock_info.sock.settimeout(kwargs['network_timeout'])
 
-            self.log_protocol('>>>', msg)
+            self.log_protocol('>>>', '[__send_and_receive send]')
             sock_info.sock.sendall(data)
             response = self.__recv_msg(1, rqst_id, sock_info)
-            self.log_protocol('<<<', '[__send_and_receive data]')
+            self.log_protocol('<<<', '[__send_and_receive receive]')
 
             if not exhaust:
                 if "network_timeout" in kwargs:

--- a/pymongo/mongo_replica_set_client.py
+++ b/pymongo/mongo_replica_set_client.py
@@ -1949,4 +1949,5 @@ class MongoReplicaSetClient(common.BaseObject):
         return self[self.__default_database_name]
 
     def log_protocol(self, prefix, message):
-        print('{}{}'.format(prefix, message))
+        if LOG_PROTOCOL:
+            print('{}{}'.format(prefix, message))

--- a/pymongo/mongo_replica_set_client.py
+++ b/pymongo/mongo_replica_set_client.py
@@ -1203,6 +1203,9 @@ class MongoReplicaSetClient(common.BaseObject):
                         writer = node
 
             except (ConnectionFailure, socket.error), why:
+                self.log_protocol('[refresh]',
+                                  'error connecting to {}: {}'.
+                                  format(node, why))
                 if member:
                     member.discard_socket(sock_info)
                 errors.append("%s:%d: %s" % (node[0], node[1], str(why)))
@@ -1258,7 +1261,10 @@ class MongoReplicaSetClient(common.BaseObject):
                                   'adding {} to members'.format(host))
                 members[host] = new_member
 
-            except (ConnectionFailure, socket.error):
+            except (ConnectionFailure, socket.error), why:
+                self.log_protocol('[refresh]',
+                                  'error connecting to {}: {}'.
+                                  format(host, why))
                 if member:
                     member.discard_socket(sock_info)
                 continue


### PR DESCRIPTION
Hi,

I don't intend for this PR to be pulled as-is; it's incomplete (e.g., I only implemented it for replica set client, not plain client) and I'm sure y'all would want to tweak the idea a bit before accepting it. I'm just submitting it as a food-for-thought PR to get your thoughts on the idea behind it.

We were having an issue where many of our ephemeral MongoDB client instances were unable to connect to the primary on one of our replicasets. This issue was proving very difficult to debug, since (a) there's no logging of the internals of mongo_replica_set_client.py's communication with servers or replicaset state refreshes, and (b) we run over SSL which makes debugging via network captures rather challenging.

To address this, what I ended up doing that enabled us to finally track down the problem (current running theory is stale arp cache entries on the MongoDB servers preventing packets from the servers from making it back to the clients) was adding the changes shown in this PR: modifying mongo_replica_set_client.py to log protocol exchanges as well as the process of refreshing replicaset state.

The specific, key discovery this enabled us to make was that [this code](https://github.com/mongodb/mongo-python-driver/blob/master/pymongo/mongo_replica_set_client.py#L1219) silently throws away errors, so were never being informed by pymongo that connections to our primary were timing out. So at the very least, even if you don't think any of the logging stuff shown here is a good idea, I'd say something needs to be done to make that information accessible to users rather than throwing it away.

Thanks,

Jonathan Kamens
