### PR TITLE
allow ssl_cert_reqs options to be passed as string

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -75,3 +75,4 @@ The following is a list of people who have contributed to
 - Can Zhang (cannium)
 - Sergey Azovskov (last-g)
 - Heewa Barfchin (heewa)
+- Len Buckens (buckensl)

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -126,6 +126,9 @@ def validate_cert_reqs(option, value):
     if HAS_SSL:
         if value in (ssl.CERT_NONE, ssl.CERT_OPTIONAL, ssl.CERT_REQUIRED):
             return value
+        elif isinstance(value, basestring) and hasattr(ssl, value) and \
+                        getattr(ssl, value) in (ssl.CERT_NONE, ssl.CERT_OPTIONAL, ssl.CERT_REQUIRED):
+            return getattr(ssl, value)
         raise ConfigurationError("The value of %s must be one of: "
                                  "`ssl.CERT_NONE`, `ssl.CERT_OPTIONAL` or "
                                  "`ssl.CERT_REQUIRED" % (option,))

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -27,11 +27,13 @@ from bson.code import Code
 from bson.objectid import ObjectId
 from bson.son import SON
 from pymongo.connection import Connection
+from pymongo import common
 from pymongo.mongo_client import MongoClient
 from pymongo.mongo_replica_set_client import MongoReplicaSetClient
 from pymongo.errors import ConfigurationError, OperationFailure
 from test import host, port, pair, version, skip_restricted_localhost
 from test.utils import catch_warnings, drop_collections
+from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
 
 have_uuid = True
 try:
@@ -519,6 +521,20 @@ class TestCommon(unittest.TestCase):
             self.assertTrue(coll.insert(doc))
         finally:
             ctx.exit()
+
+    def test_validate_cert_reqs(self):
+        self.assertRaises(ConfigurationError, common.validate_cert_reqs, 'ssl_cert_reqs', 3)
+        self.assertRaises(ConfigurationError, common.validate_cert_reqs, 'ssl_cert_reqs', -1)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', None), None)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', CERT_NONE), CERT_NONE)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', CERT_OPTIONAL), CERT_OPTIONAL)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', CERT_REQUIRED), CERT_REQUIRED)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', 0), CERT_NONE)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', 1), CERT_OPTIONAL)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', 2), CERT_REQUIRED)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', 'CERT_NONE'), CERT_NONE)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', 'CERT_OPTIONAL'), CERT_OPTIONAL)
+        self.assertEqual(common.validate_cert_reqs('ssl_cert_reqs', 'CERT_REQUIRED'), CERT_REQUIRED)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://jira.mongodb.org/browse/PYTHON-842