### PR TITLE
Add ability to get BSON from a cursor

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1278,7 +1278,7 @@ class Collection(common.BaseObject):
                 res = helpers._first_batch(
                     sock_info, namespace, {"ns": self.__full_name},
                     0, slave_ok, codec_options, ReadPreference.PRIMARY)
-                data = res["data"]
+                data = res["data"].decode(codec_options)
                 cursor = {
                     "id": res["cursor_id"],
                     "firstBatch": data,

--- a/pymongo/command_cursor.py
+++ b/pymongo/command_cursor.py
@@ -102,8 +102,7 @@ class CommandCursor(object):
 
         try:
             doc = helpers._unpack_response(response.data,
-                                           self.__id,
-                                           self.__collection.codec_options)
+                                           self.__id)
         except CursorNotFound:
             self.__killed = True
             raise
@@ -122,7 +121,8 @@ class CommandCursor(object):
                 doc['starting_from'], self.__retrieved))
 
         self.__retrieved += doc["number_returned"]
-        self.__data = deque(doc["data"])
+        self.__data = deque(doc["data"].decode(
+            self.__collection.codec_options))
 
     def _refresh(self):
         """Refreshes the cursor with more data from the server.

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -175,7 +175,7 @@ class Cursor(object):
         # it anytime we change __limit.
         self.__empty = False
 
-        self.__data = deque()
+        self.__data = helpers.BSONList()
         self.__address = None
         self.__retrieved = 0
         self.__killed = False
@@ -219,7 +219,7 @@ class Cursor(object):
         be sent to the server, even if the resultant data has already been
         retrieved by this cursor.
         """
-        self.__data = deque()
+        self.__data = helpers.BSONList()
         self.__id = None
         self.__address = None
         self.__retrieved = 0
@@ -870,7 +870,7 @@ class Cursor(object):
                     doc['starting_from'], self.__retrieved))
 
         self.__retrieved += doc["number_returned"]
-        self.__data = deque(doc["data"].decode(self.__codec_options))
+        self.__data = doc["data"]
 
         if self.__limit and self.__id and self.__limit <= self.__retrieved:
             self.__die()
@@ -981,10 +981,11 @@ class Cursor(object):
         _db = self.__collection.database
         if len(self.__data) or self._refresh():
             if self.__manipulate:
-                return _db._fix_outgoing(self.__data.popleft(),
-                                         self.__collection)
+                return _db._fix_outgoing(
+                    self.__data.popleft().decode(self.__codec_options),
+                    self.__collection)
             else:
-                return self.__data.popleft()
+                return self.__data.popleft().decode(self.__codec_options)
         else:
             raise StopIteration
 

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -835,8 +835,7 @@ class Cursor(object):
 
         try:
             doc = helpers._unpack_response(response=data,
-                                           cursor_id=self.__id,
-                                           codec_options=self.__codec_options)
+                                           cursor_id=self.__id)
         except OperationFailure:
             self.__killed = True
 
@@ -871,7 +870,7 @@ class Cursor(object):
                     doc['starting_from'], self.__retrieved))
 
         self.__retrieved += doc["number_returned"]
-        self.__data = deque(doc["data"])
+        self.__data = deque(doc["data"].decode(self.__codec_options))
 
         if self.__limit and self.__id and self.__limit <= self.__retrieved:
             self.__die()

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -468,7 +468,7 @@ class Database(common.BaseObject):
             res = _first_batch(sock_info, coll.full_name,
                                criteria, 0, slave_okay,
                                CodecOptions(), ReadPreference.PRIMARY)
-            data = res["data"]
+            data = res["data"].decode(CodecOptions())
             cursor = {
                 "id": res["cursor_id"],
                 "firstBatch": data,

--- a/pymongo/monitor.py
+++ b/pymongo/monitor.py
@@ -160,4 +160,4 @@ class Monitor(object):
         sock_info.send_message(msg, max_doc_size)
         raw_response = sock_info.receive_message(1, request_id)
         result = helpers._unpack_response(raw_response)
-        return IsMaster(result['data'][0]), _time() - start
+        return IsMaster(result['data'].popleft().decode()), _time() - start

--- a/pymongo/network.py
+++ b/pymongo/network.py
@@ -46,8 +46,8 @@ def command(sock, dbname, spec, slave_ok, is_mongos, read_preference,
                                        None, codec_options)
     sock.sendall(msg)
     response = receive_message(sock, 1, request_id)
-    unpacked = helpers._unpack_response(response, codec_options=codec_options)
-    response_doc = unpacked['data'][0]
+    unpacked = helpers._unpack_response(response)
+    response_doc = unpacked['data'].popleft().decode(codec_options)
     msg = "command %s on namespace %s failed: %%s" % (
         repr(spec).replace("%", "%%"), ns)
     if check:

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -248,7 +248,7 @@ class SocketInfo(object):
         self.send_message(msg, 0)
         response = helpers._unpack_response(self.receive_message(1, request_id))
         assert response['number_returned'] == 1
-        result = response['data'][0]
+        result = bson.popleft().decode()
 
         # Raises NotMasterError or OperationFailure.
         helpers._check_command_response(result)


### PR DESCRIPTION
To avoid the deserialisation penalty when deserialising to a list of Python dictionaries is not necessary.  For my use-case I want to return BSON to my client so going via Python objects and then JSON is too expensive (~130ms for 6000 documents).

This is a partial solution to [PYTHON-472](https://jira.mongodb.org/browse/PYTHON-472).