### PR TITLE
allow ssl_match_hostname option to be passed as string

### DIFF
--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -398,7 +398,7 @@ VALIDATORS = {
     'ssl_certfile': validate_readable,
     'ssl_cert_reqs': validate_cert_reqs,
     'ssl_ca_certs': validate_readable,
-    'ssl_match_hostname': validate_boolean,
+    'ssl_match_hostname': validate_boolean_or_string,
     'read_preference': validate_read_preference,
     'readpreference': validate_read_preference_mode,
     'readpreferencetags': validate_read_preference_tags,

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -102,6 +102,10 @@ class TestURI(unittest.TestCase):
         self.assertRaises(ValueError, split_options, 'connectTimeoutMS=0.0')
         self.assertRaises(ValueError, split_options, 'connectTimeoutMS=1e100000')
         self.assertRaises(ValueError, split_options, 'connectTimeoutMS=-1e100000')
+        self.assertRaises(ValueError, split_options, 'ssl=foo')
+        self.assertTrue(split_options('ssl=true'))
+        self.assertRaises(ValueError, split_options, 'ssl_match_hostname=foo')
+        self.assertTrue(split_options('ssl_match_hostname=true'))
 
         # On most platforms float('inf') and float('-inf') represent
         # +/- infinity, although on Python 2.4 and 2.5 on Windows those


### PR DESCRIPTION
Fixes https://jira.mongodb.org/browse/PYTHON-934