### PR TITLE
Raise a CorruptGridFile error if empty chunk read

### DIFF
--- a/gridfs/grid_file.py
+++ b/gridfs/grid_file.py
@@ -461,6 +461,8 @@ class GridOut(object):
         data = StringIO()
         while received < size:
             chunk_data = self.readchunk()
+            if len(chunk_data) == 0:
+                raise CorruptGridFile("error reading chunk")
             received += len(chunk_data)
             data.write(chunk_data)
 


### PR DESCRIPTION
Occasionally Pymongo would enter an infinite loop in the [GridOut.read()](https://github.com/mongodb/mongo-python-driver/blob/24f633e95c5d46aee020e293f97e72045abe3f4e/gridfs/grid_file.py#L441) function.

The loop is as following:
```python
        while received < size:
            chunk_data = self.readchunk()
            received += len(chunk_data)
            data.write(chunk_data)
```

If `self.readchunk()` returns an empty string, `received` will not be incremented, and thus the program will stuck in this loop forever. This will happen if the grid files are corrupt, with their actual total chunk size smaller than the size claimed in the metadata. This pull request raises a CorruptGridFile error when an empty chunk is read, allowing Pymongo to escape the infinite loop.