### PR TITLE
Allow Sequences as parameters to projection, keys, fields.

### DIFF
--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -280,12 +280,13 @@ def _fields_list_to_dict(fields, option_name):
     """
     if isinstance(fields, collections.Mapping):
         return fields
-    elif isinstance(fields, collections.Sequence):
+
+    if isinstance(fields, collections.Sequence):
         if not all(isinstance(field, string_type) for field in fields):
             raise TypeError("%s must be a list of key names, each an "
                             "instance of %s" % (option_name,
                                                 string_type.__name__))
         return dict.fromkeys(fields, 1)
-    else:
-        raise TypeError("%s must be a mapping or "
-                        "list of key names" % (option_name,))
+
+    raise TypeError("%s must be a mapping or "
+                    "list of key names" % (option_name,))

--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -281,14 +281,11 @@ def _fields_list_to_dict(fields, option_name):
     if isinstance(fields, collections.Mapping):
         return fields
     elif isinstance(fields, list):
-        as_dict = {}
-        for field in fields:
-            if not isinstance(field, string_type):
-                raise TypeError("%s must be a list of key names, each an "
-                                "instance of %s" % (option_name,
-                                                    string_type.__name__))
-            as_dict[field] = 1
-        return as_dict
+        if not all(isinstance(field, string_type) for field in fields):
+            raise TypeError("%s must be a list of key names, each an "
+                            "instance of %s" % (option_name,
+                                                string_type.__name__))
+        return dict.fromkeys(fields, 1)
     else:
         raise TypeError("%s must be a mapping or "
                         "list of key names" % (option_name,))

--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -270,7 +270,7 @@ def _check_write_command_response(results):
 
 
 def _fields_list_to_dict(fields, option_name):
-    """Takes a list of field names and returns a matching dictionary.
+    """Takes a sequence of field names and returns a matching dictionary.
 
     ["a", "b"] becomes {"a": 1, "b": 1}
 
@@ -280,7 +280,7 @@ def _fields_list_to_dict(fields, option_name):
     """
     if isinstance(fields, collections.Mapping):
         return fields
-    elif isinstance(fields, list):
+    elif isinstance(fields, collections.Sequence):
         if not all(isinstance(field, string_type) for field in fields):
             raise TypeError("%s must be a list of key names, each an "
                             "instance of %s" % (option_name,


### PR DESCRIPTION
This PR represents my recommendation for addressing [PYTHON-946](https://jira.mongodb.org/browse/PYTHON-946). I made a couple of minor style changes which I believe makes the code clearer and more concise, but feel free to omit those commits or otherwise re-implement my suggestion.

I also understand that one might want to instead of being more lenient about the input types, simply document the more rigid expectation.