### PR TITLE
Use a standard version variable name (specified by PEP8)

### DIFF
--- a/pymongo/__init__.py
+++ b/pymongo/__init__.py
@@ -77,7 +77,7 @@ def get_version_string():
         return '.'.join(map(str, version_tuple[:-1])) + version_tuple[-1]
     return '.'.join(map(str, version_tuple))
 
-version = get_version_string()
+__version__ = version = get_version_string()
 """Current version of PyMongo."""
 
 from pymongo.collection import ReturnDocument


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0008/#version-bookkeeping