### PR TITLE
PYTHON-307 Replace select with poll on platforms that support it.

### DIFF
--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -241,6 +241,14 @@ class TestPooling(_TestPoolingBase):
         with cx_pool.get_socket({}):
             pass
 
+    def test_socket_closed(self):
+        import socket
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect(('localhost', 27017))
+        self.assertFalse(socket_closed(s))
+        s.close()
+        self.assertTrue(socket_closed(s))
+
     def test_return_socket_after_reset(self):
         pool = self.create_pool()
         with pool.get_socket({}) as sock:


### PR DESCRIPTION
PyMongo sometimes has to deal with >1023 sockets, so replace select with poll. Use select when poll is not available.