### PR TITLE
matched_count should return a non 0 number if self.upserted_id is not none.

### DIFF
--- a/pymongo/results.py
+++ b/pymongo/results.py
@@ -111,7 +111,7 @@ class UpdateResult(_WriteResult):
         """The number of documents matched for this update."""
         self._raise_if_unacknowledged("matched_count")
         if self.upserted_id is not None:
-            return 0
+            return 1
         return self.__raw_result.get("n", 0)
 
     @property


### PR DESCRIPTION
The case that is incorrect here is that when a document is matched, but the data was the same so the upsert didn't happen. 

Also not sure here why n wasn't checked first.