### PR TITLE
insert_many(): Added support for generators

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -16,7 +16,6 @@
 
 import collections
 import warnings
-from types import GeneratorType
 
 from bson.code import Code
 from bson.objectid import ObjectId
@@ -469,7 +468,7 @@ class Collection(common.BaseObject):
                                    self.write_concern.acknowledged)
 
     def insert_many(self, documents, ordered=True):
-        """Insert a list or generator of documents.
+        """Insert an iterable of documents.
 
           >>> db.test.count()
           0
@@ -480,7 +479,7 @@ class Collection(common.BaseObject):
           2
 
         :Parameters:
-          - `documents`: A list or generator of documents to insert.
+          - `documents`: A iterable of documents to insert.
           - `ordered` (optional): If ``True`` (the default) documents will be
             inserted on the server serially, in the order provided. If an error
             occurs all remaining inserts are aborted. If ``False``, documents
@@ -492,7 +491,7 @@ class Collection(common.BaseObject):
 
         .. versionadded:: 3.0
         """
-        if not isinstance(documents, (list, GeneratorType)) or not documents:
+        if not isinstance(documents, collections.Iterable) or not documents:
             raise TypeError("documents must be a non-empty list")
         inserted_ids = []
         def gen():

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -16,6 +16,7 @@
 
 import collections
 import warnings
+from types import GeneratorType
 
 from bson.code import Code
 from bson.objectid import ObjectId
@@ -468,7 +469,7 @@ class Collection(common.BaseObject):
                                    self.write_concern.acknowledged)
 
     def insert_many(self, documents, ordered=True):
-        """Insert a list of documents.
+        """Insert a list or generator of documents.
 
           >>> db.test.count()
           0
@@ -479,7 +480,7 @@ class Collection(common.BaseObject):
           2
 
         :Parameters:
-          - `documents`: A list of documents to insert.
+          - `documents`: A list or generator of documents to insert.
           - `ordered` (optional): If ``True`` (the default) documents will be
             inserted on the server serially, in the order provided. If an error
             occurs all remaining inserts are aborted. If ``False``, documents
@@ -491,7 +492,7 @@ class Collection(common.BaseObject):
 
         .. versionadded:: 3.0
         """
-        if not isinstance(documents, list) or not documents:
+        if not isinstance(documents, (list, GeneratorType)) or not documents:
             raise TypeError("documents must be a non-empty list")
         inserted_ids = []
         def gen():

--- a/test/test_bulk.py
+++ b/test/test_bulk.py
@@ -915,6 +915,17 @@ class TestBulk(BulkTestBase):
         batch.execute()
         self.assertRaises(InvalidOperation, batch.execute)
 
+    def test_generator_insert(self):
+        def gen():
+            yield {'a': 1, 'b': 1}
+            yield {'a': 1, 'b': 2}
+            yield {'a': 2, 'b': 3}
+            yield {'a': 3, 'b': 5}
+            yield {'a': 5, 'b': 8}
+
+        result = self.coll.insert_many(gen())
+        self.assertEqual(5, len(result.inserted_ids))
+
 
 class TestBulkWriteConcern(BulkTestBase):
 


### PR DESCRIPTION
While porting my application over to use the latest pymongo, I noticed that the new `insert_many()` function does not accept generators. This pull request adds a check in `insert_many()` for the Python `GeneratorType`. Also, I added a single unit test for inserting a generator.