### PR TITLE
fix bug with dupplicates ObjectId in bulk insert

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -534,6 +534,7 @@ class Collection(common.BaseObject):
         .. versionadded:: 3.0
         """
         common.validate_is_mutable_mapping("document", document)
+        document = document.copy()
         if "_id" not in document:
             document["_id"] = ObjectId()
         with self._socket_for_writes() as sock_info:
@@ -571,6 +572,7 @@ class Collection(common.BaseObject):
             """A generator that validates documents and handles _ids."""
             for document in documents:
                 common.validate_is_mutable_mapping("document", document)
+                document = document.copy()
                 if "_id" not in document:
                     document["_id"] = ObjectId()
                 inserted_ids.append(document["_id"])


### PR DESCRIPTION
without this fix we get errors:
```
>> dbs.coll.insert_many([{'x':1}]*10)

raise BulkWriteError(full_result)
pymongo.errors.BulkWriteError: batch op errors occurred
```
or
```
>> for i in range(1000):
>>     data = {'x':1}
>>     dbs.coll.insert_one(data)

raise DuplicateKeyError(error.get("errmsg"), 11000, error)
pymongo.errors.DuplicateKeyError: insertDocument :: caused by :: 11000 E11000 duplicate key error index: dbs.coll.$_id_  dup key: { : ObjectId('56008f92c341cf5ab45db695') }
```


