### PR TITLE
Preserve order of fields on JSON

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -116,9 +116,9 @@ def dumps(obj, *args, **kwargs):
 def loads(s, *args, **kwargs):
     """Helper function that wraps :class:`json.loads`.
 
-    Automatically passes the object_hook for BSON type conversion.
+    Automatically passes the object_pairs_hook for BSON type conversion.
     """
-    kwargs['object_hook'] = lambda dct: object_hook(dct)
+    kwargs['object_pairs_hook'] = object_pairs_hook
     return json.loads(s, *args, **kwargs)
 
 
@@ -136,7 +136,8 @@ def _json_convert(obj):
         return obj
 
 
-def object_hook(dct):
+def object_pairs_hook(pairs):
+    dct = SON(pairs)
     if "$oid" in dct:
         return ObjectId(str(dct["$oid"]))
     if "$ref" in dct:

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -77,7 +77,7 @@ class MongoClient(common.BaseObject):
             self,
             host=None,
             port=None,
-            document_class=dict,
+            document_class=SON,
             tz_aware=False,
             connect=True,
             **kwargs):


### PR DESCRIPTION
I want to preserve field order on my application.

To do that, mongo has to use with ordered dicts instead of the standard `dict`.
Python's OrderedDict and Mongo's SON are good candidates for that.

As far as I can tell, there are 2 places where I need to make the change:
- On MongoClient's `document_class` (When reading from MongoDB)
- On json_util's `loads` (When parsing a JSON file)

I do both on my application, but it seems like it would be a reasonable default behavior