### PR TITLE
Utilities to convert datetime to/from milliseconds.

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -100,6 +100,23 @@ _RE_OPT_TABLE = {
 }
 
 
+def dt_utc_milliseconds(obj):
+    """Helper function to convert a datetime obj to milliseconds in utc.
+    """
+    # TODO share this code w/ bson.py?
+    if obj.utcoffset() is not None:
+        obj = obj - obj.utcoffset()
+    return int(calendar.timegm(obj.timetuple()) * 1000 +
+               obj.microsecond / 1000)
+
+
+def utc_milliseconds_dt(millis):
+    """Helper function to convert milliseconds to datetime in utc.
+    """
+    return (datetime.datetime.utcfromtimestamp(0) +
+            datetime.timedelta(milliseconds=millis)).replace(tzinfo=utc)
+
+
 def dumps(obj, *args, **kwargs):
     """Helper function that wraps :class:`json.dumps`.
 
@@ -211,12 +228,7 @@ def default(obj):
     if isinstance(obj, DBRef):
         return _json_convert(obj.as_doc())
     if isinstance(obj, datetime.datetime):
-        # TODO share this code w/ bson.py?
-        if obj.utcoffset() is not None:
-            obj = obj - obj.utcoffset()
-        millis = int(calendar.timegm(obj.timetuple()) * 1000 +
-                     obj.microsecond / 1000)
-        return {"$date": millis}
+        return {"$date": dt_utc_milliseconds(obj)}
     if isinstance(obj, (RE_TYPE, Regex)):
         flags = ""
         if obj.flags & re.IGNORECASE:

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -78,3 +78,4 @@ The following is a list of people who have contributed to
 - Anna Herlihy (aherlihy)
 - Len Buckens (buckensl)
 - ultrabug
+- Eric Stobbart (estobbart)

--- a/test/test_json_util.py
+++ b/test/test_json_util.py
@@ -90,6 +90,9 @@ class TestJsonUtil(unittest.TestCase):
         dtm = datetime.datetime(1, 1, 1, 1, 1, 1, 0, utc)
         jsn = '{"dt": {"$date": -62135593139000}}'
         self.assertEqual(dtm, json_util.loads(jsn)["dt"])
+        self.assertEqual(-62135593139000,
+                         json_util.dt_utc_milliseconds(dtm))
+        self.assertEqual(json_util.utc_milliseconds_dt(-62135593139000), dtm)
         jsn = '{"dt": {"$date": {"$numberLong": "-62135593139000"}}}'
         self.assertEqual(dtm, json_util.loads(jsn)["dt"])
 


### PR DESCRIPTION
Spawned from [SO](https://stackoverflow.com/questions/28595338/bson-json-util-datetime-encode-and-decode-best-practice) discussion