### PR TITLE
PYTHON-1009 Switch from "Monotime" to "monotonic"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Optional packages:
   performance on Python older than 2.7.8, or on Python 3 before Python 3.4.
 - `pykerberos <https://pypi.python.org/pypi/pykerberos>`_ is required for
   the GSSAPI authentication mechanism.
-- `Monotime <https://pypi.python.org/pypi/Monotime>`_ adds support for
+- `monotonic <https://pypi.python.org/pypi/monotonic>`_ adds support for
   a monotonic clock, which improves reliability in environments
   where clock adjustments are frequent. Not needed in Python 3.3+.
 - `wincertstore <https://pypi.python.org/pypi/wincertstore>`_ adds support

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -21,7 +21,7 @@ packages:
   performance on Python older than 2.7.8, or on Python 3 before Python 3.4.
 - `pykerberos <https://pypi.python.org/pypi/pykerberos>`_ is required for
   the GSSAPI authentication mechanism.
-- `Monotime <https://pypi.python.org/pypi/Monotime>`_ adds support for
+- `monotonic <https://pypi.python.org/pypi/monotonic>`_ adds support for
   a monotonic clock, which improves reliability in environments
   where clock adjustments are frequent. Not needed in Python 3.3+.
 - `wincertstore <https://pypi.python.org/pypi/wincertstore>`_ adds support

--- a/pymongo/monotonic.py
+++ b/pymongo/monotonic.py
@@ -25,8 +25,12 @@ except ImportError:
     pass
 
 try:
-    # Monotime or Python 3.3+.
-    from time import monotonic as time
+    # From https://pypi.python.org/pypi/monotinic.
+    from monotonic import monotonic as time
 except ImportError:
-    # Not monotonic.
-    from time import time
+    try:
+        # Monotime or Python 3.3+.
+        from time import monotonic as time
+    except ImportError:
+        # Not monotonic.
+        from time import time


### PR DESCRIPTION
This implements the same try order as tornado, and updated docs to recommend monotonic only.