### PR TITLE
Use codec options in aggregate command

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1802,6 +1802,7 @@ class Collection(common.BaseObject):
 
         command_kwargs = {
             'pipeline': pipeline,
+            'codec_options': self.codec_options,
             'read_preference': self.read_preference,
             'tag_sets': self.tag_sets,
             'secondary_acceptable_latency_ms': (


### PR DESCRIPTION
Before this the aggregate command ignored the codec options. this resulted in in aggregate command returning documents with naive datetime objects despite the tz_aware attribute in the collections codec options being set to True.