### PR TITLE
Added cursor find command for chaining

### DIFF
--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -614,6 +614,22 @@ class Cursor(object):
         self.__min = SON(spec)
         return self
 
+    def find(self, filters):
+        """Adds additional filters to the dictionary of filters
+        provided when the cursor was initialised.
+
+        Enables chaining, e.g. cursor.find({'x': 0}).find({'y':0}) will
+        filter by {'x': 0, 'y':0)
+
+        Raises :class:`ValueError` if the argument not a dictionary.
+
+        :Parameters:
+          - `filters`: a dictionary of filters and values
+        """
+        self.__check_okay_to_chain()
+        self.__spec.update(filters)
+        return self
+
     def sort(self, key_or_list, direction=None):
         """Sorts this cursor's results.
 

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -348,6 +348,48 @@ class TestCursor(IntegrationTest):
         # "cursor" pre MongoDB 2.7.6, "executionStats" post
         self.assertTrue("cursor" in b or "executionStats" in b)
 
+    def test_find(self):
+        db = self.db
+        db.test.delete_many({})
+        exclude = {'_id': 0}
+        self.assertRaises(ValueError, db.test.find( {}, exclude ).find, 's')
+        db.test.insert_many([{"x": i, "y": 0} for i in range(10)])
+        db.test.insert_many([{"x": i, "y": 1} for i in range(10)])
+        cursor = db.test.find({}, exclude)
+        self.assertEqual(20, cursor.count())
+        self.assertEqual(next(cursor), {"x": 0, "y": 0})
+        self.assertRaises(InvalidOperation, cursor.find, {'y': 0})
+        cursor = cursor.clone()
+        cursor.find({"x": 1})
+        self.assertEqual(2, cursor.count())
+        self.assertEqual(next(cursor), {"x": 1, "y": 0})
+        cursor = cursor.clone()
+        cursor.find({"y": 1})
+        self.assertEqual(1, cursor.count())
+        self.assertEqual(next(cursor), {"x": 1, "y": 1})
+        cursor = cursor.clone()
+        cursor.find({"x": 20})
+        self.assertEqual(0, cursor.count())
+        cursor = db.test.find({"y": 0}, exclude)
+        cursor.find({"x": 2})
+        self.assertEqual(1, cursor.count())
+        self.assertEqual(next(cursor), {"x": 2, "y": 0})
+        cursor = db.test.find({"x": 0}, exclude)
+        cursor.find({"x": 1, "y": 1})
+        self.assertEqual(1, cursor.count())
+        self.assertEqual(next(cursor), {"x": 1, "y": 1})
+        cursor = db.test.find({"x": 0}, exclude).find({"y": 1})
+        self.assertEqual(1, cursor.count())
+        self.assertEqual(next(cursor), {"x": 0, "y": 1})
+        cursor = db.test.find({"x": 0}, exclude).find({"y": 1})
+        self.assertEqual(1, cursor.count())
+        self.assertEqual(next(cursor), {"x": 0, "y": 1})
+        cursor = db.test.find({"x": 0}, exclude).find({"y": 1}).find({"x": 5})
+        self.assertTrue(1, cursor.count())
+        self.assertEqual(next(cursor), {"x": 5, "y": 1})
+        cursor = db.test.find({"x": 0}, exclude).find({"y": 1}).find({"z": 11})
+        self.assertEqual(0, cursor.count())
+
     def test_hint(self):
         db = self.db
         self.assertRaises(TypeError, db.test.find().hint, 5.5)


### PR DESCRIPTION
Enables filter chaining on the cursor similar to how many ORM's are implemented.