### PR TITLE
Fix up shutdown for periodic executors

### DIFF
--- a/pymongo/periodic_executor.py
+++ b/pymongo/periodic_executor.py
@@ -126,6 +126,9 @@ def _on_executor_deleted(ref):
 
 
 def _shutdown_executors():
+    if _EXECUTORS is None:
+        return
+
     # Copy the set. Stopping threads has the side effect of removing executors.
     executors = list(_EXECUTORS)
 


### PR DESCRIPTION
Hello.

It's from a robot test that uses loop operator. FOR    ${lengthOfSCHMCDXXXX}    IN    35    15    36

Just temporary debug messages:

_shutdown_executors set([])
_shutdown_executors None
_shutdown_executors None

We get this error when we launch tests.

```
unexpected error: Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "C:\Python27\lib\atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "C:\Python27\lib\site-packages\pymongo\periodic_executor.py", line 133, in _shutdown_executors
    executors = list(_EXECUTORS)
TypeError: 'NoneType' object is not iterable
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "C:\Python27\lib\atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "C:\Python27\lib\site-packages\pymongo\periodic_executor.py", line 133, in _shutdown_executors
    executors = list(_EXECUTORS)
TypeError: 'NoneType' object is not iterable
Error in sys.exitfunc:

[2016.04.26-15:25:09] : accessed by C:\Python27\lib\site-packages\robot\run.py
Traceback (most recent call last):
  File "C:\Python27\lib\atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "C:\Python27\lib\site-packages\pymongo\periodic_executor.py", line 133, in _shutdown_executors
    executors = list(_EXECUTORS)
TypeError: 'NoneType' object is not iterable

test finished 20160426 15:25:09
```