### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/doc/examples/gevent.rst
+++ b/doc/examples/gevent.rst
@@ -47,5 +47,5 @@ handler to end background greenlets when your application receives SIGHUP:
 Applications using uWSGI prior to 1.9.16 are affected by this issue,
 or newer uWSGI versions with the ``-gevent-wait-for-hub`` option.
 See `the uWSGI changelog for details
-<http://uwsgi-docs.readthedocs.org/en/latest/Changelog-1.9.16.html#important-change-in-the-gevent-plugin-shutdown-reload-procedure>`_.
+<https://uwsgi-docs.readthedocs.io/en/latest/Changelog-1.9.16.html#important-change-in-the-gevent-plugin-shutdown-reload-procedure>`_.
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -373,7 +373,7 @@ How can I use PyMongo from Django?
 framework. Django includes an ORM, :mod:`django.db`. Currently,
 there's no official MongoDB backend for Django.
 
-`django-mongodb-engine <https://django-mongodb-engine.readthedocs.org/>`_
+`django-mongodb-engine <https://django-mongodb-engine.readthedocs.io/>`_
 is an unofficial MongoDB backend that supports Django aggregations, (atomic)
 updates, embedded objects, Map/Reduce and GridFS. It allows you to use most
 of Django's built-in features, including the ORM, admin, authentication, site

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -80,7 +80,7 @@ Manga
   github <http://github.com/wladston/manga>`_.
   
 MotorEngine
-  `MotorEngine <http://motorengine.readthedocs.org/>`_ is a port of
+  `MotorEngine <https://motorengine.readthedocs.io/>`_ is a port of
   MongoEngine to Motor, for asynchronous access with Tornado.
   It implements the same modeling APIs to be data-portable, meaning that a
   model defined in MongoEngine can be read in MotorEngine. The source is
@@ -92,10 +92,10 @@ This section lists tools and adapters that have been designed to work with
 various Python frameworks and libraries.
 
 * `Django MongoDB Engine
-  <http://django-mongodb-engine.readthedocs.org/en/latest/>`_ is a MongoDB
+  <https://django-mongodb-engine.readthedocs.io/en/latest/>`_ is a MongoDB
   database backend for Django that completely integrates with its ORM.
   For more information `see the tutorial
-  <http://django-mongodb-engine.readthedocs.org/en/latest/tutorial.html>`_.
+  <https://django-mongodb-engine.readthedocs.io/en/latest/tutorial.html>`_.
 * `mango <http://github.com/vpulim/mango>`_ provides MongoDB backends for
   Django sessions and authentication (bypassing :mod:`django.db` entirely).
 * `Django MongoEngine


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.