### PR TITLE
resolve unicode decode error when creating index

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1277,8 +1277,10 @@ class Collection(common.BaseObject):
         cmd = SON([('createIndexes', self.name),
                    ('indexes', list(gen_indexes()))])
         with self._socket_for_writes() as sock_info:
-            self._command(
-                sock_info, cmd, read_preference=ReadPreference.PRIMARY)
+            self._command(sock_info,
+                          cmd,
+                          codec_options=_UNICODE_REPLACE_CODEC_OPTIONS,
+                          read_preference=ReadPreference.PRIMARY)
         return names
 
     def __create_index(self, keys, index_options):

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -34,6 +34,7 @@ from pymongo.command_cursor import CommandCursor
 from pymongo.cursor import Cursor
 from pymongo.errors import ConfigurationError, InvalidName, OperationFailure
 from pymongo.helpers import _check_write_command_response
+from pymongo.helpers import _UNICODE_REPLACE_CODEC_OPTIONS
 from pymongo.operations import _WriteOp, IndexModel
 from pymongo.read_concern import DEFAULT_READ_CONCERN
 from pymongo.read_preferences import ReadPreference
@@ -1294,8 +1295,10 @@ class Collection(common.BaseObject):
         with self._socket_for_writes() as sock_info:
             cmd = SON([('createIndexes', self.name), ('indexes', [index])])
             try:
-                self._command(
-                    sock_info, cmd, read_preference=ReadPreference.PRIMARY)
+                self._command(sock_info,
+                              cmd,
+                              codec_options=_UNICODE_REPLACE_CODEC_OPTIONS,
+                              read_preference=ReadPreference.PRIMARY)
             except OperationFailure as exc:
                 if exc.code in common.COMMAND_NOT_FOUND_CODES:
                     index["ns"] = self.__full_name


### PR DESCRIPTION
[unicode decode error when creating index.
](https://jira.mongodb.org/browse/PYTHON-1128)

When creating a index in Mongo shell, I got the correct exception:

```
> db.case_detail.createIndex({'案号': 1}, {background: true})
{
	"createdCollectionAutomatically" : false,
	"numIndexesBefore" : 9,
	"errmsg" : "exception: Btree::insert: key too large to index, failing guangdong_courts.case_detail.$案号_1 5360 { : \"（2015）佛明法民一初字第653号当事人:原告:杨瑞芳,被告:李永清\n案由:民间借贷纠纷\n开庭时间:2015-11-3 15:00\n开庭地��...\" }",
	"code" : 17280,
	"ok" : 0
}
```


But when I use pymongo, I got this error:

```
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
/mongo-python-driver/bson/__init__.py in decode_all(data, codec_options)
    806                                               obj_end,
--> 807                                               codec_options))
    808             position += obj_size

/mongo-python-driver/bson/__init__.py in _elements_to_dict(data, position, obj_end, opts)
    343     result = opts.document_class()
--> 344     for key, value in _iterate_elements(data, position, obj_end, opts):
    345         result[key] = value

/mongo-python-driver/bson/__init__.py in _iterate_elements(data, position, obj_end, opts)
    336     while position < end:
--> 337         (key, value, position) = _element_to_dict(data, position, obj_end, opts)
    338         yield key, value

/mongo-python-driver/bson/__init__.py in _element_to_dict(data, position, obj_end, opts)
    325                                                         obj_end, opts,
--> 326                                                         element_name)
    327     except KeyError:

/mongo-python-driver/bson/__init__.py in _get_string(data, position, obj_end, opts, dummy)
    131     return _utf_8_decode(data[position:end],
--> 132                          opts.unicode_decode_error_handler, True)[0], end + 1
    133

UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 255-256: invalid continuation byte

```

The PR will fix this error:


```
---------------------------------------------------------------------------
OperationFailure                          Traceback (most recent call last)
<ipython-input-1-23271a2da0b5> in <module>()
      5
      6 mongo = MongoClient()
----> 7 mongo['test']['case_detail'].create_index(u'案号', background=True)

/mongo-python-driver/pymongo/collection.py in create_index(self, keys, **kwargs)
   1388         keys = helpers._index_list(keys)
   1389         name = kwargs.setdefault("name", helpers._gen_index_name(keys))
-> 1390         self.__create_index(keys, kwargs)
   1391         return name
   1392

/mongo-python-driver/pymongo/collection.py in __create_index(self, keys, index_options)
   1299                               cmd,
   1300                               codec_options=_UNICODE_REPLACE_CODEC_OPTIONS,
-> 1301                               read_preference=ReadPreference.PRIMARY)
   1302             except OperationFailure as exc:
   1303                 if exc.code in common.COMMAND_NOT_FOUND_CODES:

/mongo-python-driver/pymongo/collection.py in _command(self, sock_info, command, slave_ok, read_preference, codec_options, check, allowable_errors, read_concern)
    207                                  check,
    208                                  allowable_errors,
--> 209                                  read_concern=read_concern)
    210
    211     def __create(self, options):

/mongo-python-driver/pymongo/pool.py in command(self, dbname, spec, slave_ok, read_preference, codec_options, check, allowable_errors, check_keys, read_concern)
    237                            check, allowable_errors, self.address,
    238                            check_keys, self.listeners, self.max_bson_size,
--> 239                            read_concern)
    240         except OperationFailure:
    241             raise

/mongo-python-driver/pymongo/network.py in command(sock, dbname, spec, slave_ok, is_mongos, read_preference, codec_options, check, allowable_errors, address, check_keys, listeners, max_bson_size, read_concern)
    100         response_doc = unpacked['data'][0]
    101         if check:
--> 102             helpers._check_command_response(response_doc, None, allowable_errors)
    103     except Exception as exc:
    104         if publish:

/mongo-python-driver/pymongo/helpers.py in _check_command_response(response, msg, allowable_errors)
    203
    204             msg = msg or "%s"
--> 205             raise OperationFailure(msg % errmsg, code, response)
    206
    207

OperationFailure: exception: Btree::insert: key too large to index, failing test.case_detail.$案号_1 5360 { : "（2015）佛明法民一初字第653号当事人:原告:杨瑞芳,被告:李永清
案由:民间借贷纠纷
开庭时间:2015-11-3 15:00
开庭地�..." }
```

So it may be a good idea to use `_UNICODE_REPLACE_CODEC_OPTIONS`. 
