### PR TITLE
Add $numberLong to defaults

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -271,4 +271,6 @@ def default(obj):
             ('$type', "00")])
     if isinstance(obj, uuid.UUID):
         return {"$uuid": obj.hex}
+    if isinstance(obj, Int64):
+        return {'$numberLong': str(obj)}
     raise TypeError("%r is not JSON serializable" % obj)


### PR DESCRIPTION
Type information for INT64 types are lost when using dumps. By default the type should be retained.