### PR TITLE
Link to createIndexes command from create_indexes documentation.

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1367,7 +1367,7 @@ class Collection(common.BaseObject):
           - `indexes`: A list of :class:`~pymongo.operations.IndexModel`
             instances.
 
-        .. note:: `create_indexes` uses the ``createIndexes`` command
+        .. note:: `create_indexes` uses the `createIndexes`_ command
            introduced in MongoDB **2.6** and cannot be used with earlier
            versions.
 
@@ -1379,6 +1379,8 @@ class Collection(common.BaseObject):
            Apply this collection's write concern automatically to this operation
            when connected to MongoDB >= 3.4.
         .. versionadded:: 3.0
+
+        .. _createIndexes: https://docs.mongodb.com/manual/reference/command/createIndexes/
         """
         if not isinstance(indexes, list):
             raise TypeError("indexes must be a list")

--- a/pymongo/operations.py
+++ b/pymongo/operations.py
@@ -225,8 +225,8 @@ class IndexModel(object):
             be a UTC datetime or the data will not expire.
           - `partialFilterExpression`: A document that specifies a filter for
             a partial index.
-          - `collation`: An instance of `~pymongo.collation.Collation` that
-            specifies the collation to use in MongoDB >= 3.4.
+          - `collation`: An instance of :class:`~pymongo.collation.Collation`
+            that specifies the collation to use in MongoDB >= 3.4.
 
         See the MongoDB documentation for a full list of supported options by
         server version.


### PR DESCRIPTION
Fix markup for Collation class in IndexModel documentation.

For https://jira.mongodb.org/browse/PYMODM-55

There was some confusion in PyMODM about how to create an index that used the "weights" property for a text index. The [PyMODM docs](https://pymodm.readthedocs.io/en/latest/api/index.html#pymodm.MongoModel) link to PyMongo's [IndexModel](http://api.mongodb.com/python/current/api/pymongo/operations.html#pymongo.operations.IndexModel). This links to [create_indexes](http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.create_indexes). From here, there's a dead end.

These changes link to the createIndexes command in the MongoDB manual, which provides a table showing all available options for the command. This also fixes some markup for the "collation" parameter in constructing an IndexModel.