### PR TITLE
Check _RAW_BSON_DOCUMENT_MARKER at CodecOptions.document_class first

### DIFF
--- a/bson/codec_options.py
+++ b/bson/codec_options.py
@@ -69,8 +69,8 @@ class CodecOptions(_options_base):
                 tz_aware=False, uuid_representation=PYTHON_LEGACY,
                 unicode_decode_error_handler="strict",
                 tzinfo=None):
-        if not (issubclass(document_class, MutableMapping) or
-                _raw_document_class(document_class)):
+        if not (_raw_document_class(document_class) or
+                issubclass(document_class, MutableMapping)):
             raise TypeError("document_class must be dict, bson.son.SON, "
                             "bson.raw_bson.RawBSONDocument, or a "
                             "sublass of collections.MutableMapping")


### PR DESCRIPTION
Hi there.
I'm trying to implement custom BSON decoding logic, that decodes data to different object types. And I need to store some decoder state at different recursion level. I think it would be handy if `CodecOptions` would allow `document_class` to be either class or instance, having a special `_type_marker` attribute. For that I've reordered conditions because `issubclass` call fails when it's called on non-class object.
