### PR TITLE
Don't change readpreference value at uri parsing

### DIFF
--- a/pymongo/client_options.py
+++ b/pymongo/client_options.py
@@ -22,7 +22,7 @@ from pymongo.errors import ConfigurationError
 from pymongo.monitoring import _EventListeners
 from pymongo.pool import PoolOptions
 from pymongo.read_concern import ReadConcern
-from pymongo.read_preferences import make_read_preference
+from pymongo.read_preferences import make_read_preference, read_pref_mode_from_name
 from pymongo.ssl_support import get_ssl_context
 from pymongo.write_concern import WriteConcern
 
@@ -42,7 +42,8 @@ def _parse_read_preference(options):
     if 'read_preference' in options:
         return options['read_preference']
 
-    mode = options.get('readpreference', 0)
+    name = options.get('readpreference', 'primary')
+    mode = read_pref_mode_from_name(name)
     tags = options.get('readpreferencetags')
     max_staleness = options.get('maxstalenessseconds', -1)
     return make_read_preference(mode, tags, max_staleness)

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -28,7 +28,7 @@ from pymongo.auth import MECHANISMS
 from pymongo.errors import ConfigurationError
 from pymongo.monitoring import _validate_event_listeners
 from pymongo.read_concern import ReadConcern
-from pymongo.read_preferences import (read_pref_mode_from_name,
+from pymongo.read_preferences import (_MONGOS_MODES,
                                       _ServerMode)
 from pymongo.ssl_support import validate_cert_reqs
 from pymongo.write_concern import WriteConcern
@@ -302,13 +302,12 @@ def validate_read_preference(dummy, value):
     return value
 
 
-def validate_read_preference_mode(dummy, name):
+def validate_read_preference_mode(dummy, value):
     """Validate read preference mode for a MongoReplicaSetClient.
     """
-    try:
-        return read_pref_mode_from_name(name)
-    except ValueError:
-        raise ValueError("%s is not a valid read preference" % (name,))
+    if value not in _MONGOS_MODES:
+        raise ValueError("%s is not a valid read preference" % (value,))
+    return value
 
 
 def validate_auth_mechanism(option, value):

--- a/pymongo/read_preferences.py
+++ b/pymongo/read_preferences.py
@@ -102,6 +102,12 @@ class _ServerMode(object):
         return self.__class__.__name__
 
     @property
+    def mongos_mode(self):
+        """The mongos mode of this read preference.
+        """
+        return self.__mongos_mode
+
+    @property
     def document(self):
         """Read preference as a document.
         """

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -202,6 +202,11 @@ class ClientUnitTest(unittest.TestCase):
             MongoClient('mongodb://host/?'
                         'readpreference=primary&readpreferencetags=dc:east')
 
+    def test_readpreference(self):
+        c = rs_or_single_client("mongodb://host", connect=False,
+                                readpreference=ReadPreference.NEAREST.mongos_mode)
+        self.assertEqual(c.read_preference, ReadPreference.NEAREST)
+
     def test_metadata(self):
         metadata = _METADATA.copy()
         metadata['application'] = {'name': 'foobar'}

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -338,7 +338,7 @@ class TestURI(unittest.TestCase):
             res, parse_uri("mongodb://localhost/test.name/with \"delimiters"))
 
         res = copy.deepcopy(orig)
-        res['options'] = {'readpreference': ReadPreference.SECONDARY.mode}
+        res['options'] = {'readpreference': ReadPreference.SECONDARY.mongos_mode}
         self.assertEqual(res, parse_uri(
             "mongodb://localhost/?readPreference=secondary"))
 
@@ -395,7 +395,7 @@ class TestURI(unittest.TestCase):
                                    "@localhost/foo?authMechanism=GSSAPI"))
 
         res = copy.deepcopy(orig)
-        res['options'] = {'readpreference': ReadPreference.SECONDARY.mode,
+        res['options'] = {'readpreference': ReadPreference.SECONDARY.mongos_mode,
                           'readpreferencetags': [
                               {'dc': 'west', 'use': 'website'},
                               {'dc': 'east', 'use': 'website'}]}
@@ -409,7 +409,7 @@ class TestURI(unittest.TestCase):
                                    "readpreferencetags=dc:east,use:website"))
 
         res = copy.deepcopy(orig)
-        res['options'] = {'readpreference': ReadPreference.SECONDARY.mode,
+        res['options'] = {'readpreference': ReadPreference.SECONDARY.mongos_mode,
                           'readpreferencetags': [
                               {'dc': 'west', 'use': 'website'},
                               {'dc': 'east', 'use': 'website'},


### PR DESCRIPTION
For some reason [validate_read_preference_mode](https://github.com/mongodb/mongo-python-driver/blob/master/pymongo/common.py#L305) returns value, that is not valid to be validated again. This PR fixes this problem and allows `MongoClient` options could be parsed outside of it and passed as keyword arguments like celery mongo backend [does it](https://github.com/celery/celery/blob/master/celery/backends/mongodb.py#L77).