### PR TITLE
Pass current field name to raw BSON decoder

### DIFF
--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -134,7 +134,7 @@ def _get_string(data, position, obj_end, opts, dummy):
                          opts.unicode_decode_error_handler, True)[0], end + 1
 
 
-def _get_object(data, position, obj_end, opts, dummy):
+def _get_object(data, position, obj_end, opts, element_name):
     """Decode a BSON subdocument to opts.document_class or bson.dbref.DBRef."""
     obj_size = _UNPACK_INT(data[position:position + 4])[0]
     end = position + obj_size - 1
@@ -143,7 +143,7 @@ def _get_object(data, position, obj_end, opts, dummy):
     if end >= obj_end:
         raise InvalidBSON("invalid object length")
     if _raw_document_class(opts.document_class):
-        return (opts.document_class(data[position:end + 1], opts),
+        return (opts.document_class(data[position:end + 1], opts, element_name),
                 position + obj_size)
 
     obj = _elements_to_dict(data, position + 4, end, opts)

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -1769,8 +1769,8 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
 
             if (options->is_raw_bson) {
                 value = PyObject_CallFunction(
-                    options->document_class, BYTES_FORMAT_STRING "O",
-                    buffer + *position, size, options->options_obj);
+                    options->document_class, BYTES_FORMAT_STRING "OO",
+                    buffer + *position, size, options->options_obj, name);
                 if (!value) {
                     goto invalid;
                 }

--- a/bson/raw_bson.py
+++ b/bson/raw_bson.py
@@ -35,13 +35,14 @@ class RawBSONDocument(collections.Mapping):
     __slots__ = ('__raw', '__inflated_doc', '__codec_options')
     _type_marker = _RAW_BSON_DOCUMENT_MARKER
 
-    def __init__(self, bson_bytes, codec_options=DEFAULT_CODEC_OPTIONS):
+    def __init__(self, bson_bytes, codec_options=DEFAULT_CODEC_OPTIONS, element_name=None):
         """Create a new :class:`RawBSONDocument`.
 
         :Parameters:
           - `bson_bytes`: the BSON bytes that compose this document
           - `codec_options` (optional): An instance of
             :class:`~bson.codec_options.CodecOptions`.
+          - `element_name` (optional): the current BSON document field name
         """
         self.__raw = bson_bytes
         self.__inflated_doc = None


### PR DESCRIPTION
This PR makes both python and c BSON decoder implementation pass current decoding field name to raw BSON decoder (e.g. RawBSONDocument). It is needed to add some name-dependent decoding behaviour.
In addition to context sharing between decoding levels from #324 it can give custom BSON decoder such feature like decoding map (e.g. `foo` array would be decoded to `FooClass` object, and the inner `foo.bar` array would be wrapped by `BarClass`)