### PR TITLE
Set tzinfo for datetime object from JSON options

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -535,7 +535,11 @@ def default(obj, json_options=DEFAULT_JSON_OPTIONS):
         if (json_options.datetime_representation ==
                 DatetimeRepresentation.ISO8601):
             if not obj.tzinfo:
-                obj = obj.replace(tzinfo=utc)
+                if json_options.tzinfo \
+                        and isinstance(json_options.tzinfo, datetime.tzinfo):
+                    obj = obj.replace(tzinfo=json_options.tzinfo)
+                else:
+                    obj = obj.replace(tzinfo=utc)
             if obj >= EPOCH_AWARE:
                 off = obj.tzinfo.utcoffset(obj)
                 if (off.days, off.seconds, off.microseconds) == (0, 0, 0):


### PR DESCRIPTION
This MR for passing tzinfo from JSON Options to datetime object while dumping BSON type use `json_util`. Usage:

```python
import datetime
from bson import json_util, tz_util

tz = tz_util.FixedOffset(-7, 'UTC')

json_util.DEFAULT_JSON_OPTIONS = json_util.JSONOptions(
        datetime_representation=json_util.DatetimeRepresentation.ISO8601,
        tz_aware = True,
        tzinfo = tz)

print json_util.dumps({ "created_at": datetime.datetime(2017, 06, 06, 17, 22, 59, 232),})

# Output {"created_at": {"$date": "2017-06-06T17:22:59.000-0007"}}
```