### PR TITLE
Always close cursors

### DIFF
--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1325,6 +1325,9 @@ class MongoClient(common.BaseObject):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+         
+    def __del__(self):
+        self.close()
 
     def __iter__(self):
         return self


### PR DESCRIPTION
related to: 
https://github.com/mongodb/mongo-python-driver/commit/6aaa1f71aadbc156d9f06bb79ba67b4d018db3ea#diff-3eb2775b8b87dbc3c82ece22117b5259L216
PYTHON-1269

If the mongo_client object is GC'ed without an explicit call close, the list of cursors to be closed remain open with no way of being closed.