### PR TITLE
PYTHON-1371 - The tailable cursor cannot get document through __getitem__(index) on MongoDB v3.4

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -79,3 +79,4 @@ The following is a list of people who have contributed to
 - Len Buckens (buckensl)
 - ultrabug
 - Shane Harvey (ShaneHarvey)
+- Cao Siyang (caosiyang)

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -590,6 +590,7 @@ class Cursor(object):
             clone = self.clone()
             clone.skip(index + self.__skip)
             clone.limit(-1)  # use a hard limit
+            clone.__query_flags &= ~CursorType.TAILABLE  # PYTHON-1371
             for doc in clone:
                 return doc
             raise IndexError("no such item for Cursor instance")

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -590,7 +590,7 @@ class Cursor(object):
             clone = self.clone()
             clone.skip(index + self.__skip)
             clone.limit(-1)  # use a hard limit
-            clone.__query_flags &= ~CursorType.TAILABLE  # PYTHON-1371
+            clone.__query_flags &= ~CursorType.TAILABLE_AWAIT  # PYTHON-1371
             for doc in clone:
                 return doc
             raise IndexError("no such item for Cursor instance")

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -1135,9 +1135,42 @@ class TestCursor(IntegrationTest):
 
         # __getitem__(index)
         cursor2 = db.test.find(cursor_type=CursorType.TAILABLE)
+
         self.assertEqual(4, cursor2[0]["x"])
         self.assertEqual(5, cursor2[1]["x"])
         self.assertEqual(6, cursor2[2]["x"])
+        
+        cursor2.rewind()
+        self.assertEqual([4], [doc["x"] for doc in cursor2[0:1]])
+        cursor2.rewind()
+        self.assertEqual([5], [doc["x"] for doc in cursor2[1:2]])
+        cursor2.rewind()
+        self.assertEqual([6], [doc["x"] for doc in cursor2[2:3]])
+        cursor2.rewind()
+        self.assertEqual([4, 5], [doc["x"] for doc in cursor2[0:2]])
+        cursor2.rewind()
+        self.assertEqual([5, 6], [doc["x"] for doc in cursor2[1:3]])
+        cursor2.rewind()
+        self.assertEqual([4, 5, 6], [doc["x"] for doc in cursor2[0:3]])
+
+        cursor3 = db.test.find(cursor_type=CursorType.TAILABLE_AWAIT)
+
+        self.assertEqual(4, cursor3[0]["x"])
+        self.assertEqual(5, cursor3[1]["x"])
+        self.assertEqual(6, cursor3[2]["x"])
+
+        cursor3.rewind()
+        self.assertEqual([4], [doc["x"] for doc in cursor3[0:1]])
+        cursor3.rewind()
+        self.assertEqual([5], [doc["x"] for doc in cursor3[1:2]])
+        cursor3.rewind()
+        self.assertEqual([6], [doc["x"] for doc in cursor3[2:3]])
+        cursor3.rewind()
+        self.assertEqual([4, 5], [doc["x"] for doc in cursor3[0:2]])
+        cursor3.rewind()
+        self.assertEqual([5, 6], [doc["x"] for doc in cursor3[1:3]])
+        cursor3.rewind()
+        self.assertEqual([4, 5, 6], [doc["x"] for doc in cursor3[0:3]])
 
     def test_distinct(self):
         self.db.drop_collection("test")

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -1133,6 +1133,12 @@ class TestCursor(IntegrationTest):
 
         self.assertEqual(3, db.test.count())
 
+        # __getitem__(index)
+        cursor2 = db.test.find(cursor_type=CursorType.TAILABLE)
+        self.assertEqual(4, cursor2[0]["x"])
+        self.assertEqual(5, cursor2[1]["x"])
+        self.assertEqual(6, cursor2[2]["x"])
+
     def test_distinct(self):
         self.db.drop_collection("test")
 


### PR DESCRIPTION
Fix issue and add test case.