### PR TITLE
PYTHON-1411 Reproducibility fix for mongodb-python-driver

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'PyMongo'
-copyright = u'MongoDB, Inc. 2008-{0}. MongoDB, Mongo, and the leaf logo are registered trademarks of MongoDB, Inc'.format(datetime.date.today().year)
+copyright = u'MongoDB, Inc. MongoDB, Mongo, and the leaf logo are registered trademarks of MongoDB, Inc'
 html_show_sphinx = False
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,8 +9,6 @@ sys.path[0:0] = [os.path.abspath('..')]
 
 import pymongo
 
-import datetime
-
 # -- General configuration -----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be extensions

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'PyMongo'
-copyright = u'MongoDB, Inc. MongoDB, Mongo, and the leaf logo are registered trademarks of MongoDB, Inc'
+copyright = u'MongoDB, Inc. 2008-present. MongoDB, Mongo, and the leaf logo are registered trademarks of MongoDB, Inc'
 html_show_sphinx = False
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
The copyright message constructed depends on the system current date. So the build changes everytime(Every year technically) it runs. This dependency should not be there as part of reproducible-builds effort and has been fixed by removing the date alone.