### PR TITLE
Allow fields to be a set

### DIFF
--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -235,7 +235,7 @@ def _fields_list_to_dict(fields, option_name):
     if isinstance(fields, collections.Mapping):
         return fields
 
-    if isinstance(fields, collections.Sequence):
+    if isinstance(fields, (collections.Sequence, collections.Set)):
         if not all(isinstance(field, string_type) for field in fields):
             raise TypeError("%s must be a list of key names, each an "
                             "instance of %s" % (option_name,

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1743,6 +1743,16 @@ class TestCollection(IntegrationTest):
 
         self.assertTrue("hello" in db.test.find_one(projection=["hello"]))
         self.assertTrue("hello" not in db.test.find_one(projection=["foo"]))
+
+        self.assertTrue("hello" in db.test.find_one(projection=("hello",)))
+        self.assertTrue("hello" not in db.test.find_one(projection=("foo",)))
+
+        self.assertTrue("hello" in db.test.find_one(projection=set(["hello"])))
+        self.assertTrue("hello" not in db.test.find_one(projection=set(["foo"])))
+
+        self.assertTrue("hello" in db.test.find_one(projection=frozenset(["hello"])))
+        self.assertTrue("hello" not in db.test.find_one(projection=frozenset(["foo"])))
+
         self.assertEqual(["_id"], list(db.test.find_one(projection=[])))
 
         self.assertEqual(None, db.test.find_one({"hello": "foo"}))


### PR DESCRIPTION
It was previously possible to use a set to specify fields, but this is no longer being allowed due to new validation constraints.

It seems that the validation is being unnecessarily strict.  [PYTHON-946](https://jira.mongodb.org/browse/PYTHON-946) covered the relaxation of the validation to allow sequences; this trivial change extends that to sets as well.  (I'm presuming there was a good reason for not changing it to the more generic `collections.Collection`; otherwise, that would be a better fit.)