### PR TITLE
Add more operators for Decimal128

### DIFF
--- a/bson/decimal128.py
+++ b/bson/decimal128.py
@@ -349,3 +349,43 @@ class Decimal128(object):
 
     def __ne__(self, other):
         return not self == other
+
+    def __add__(self, other):
+        if isinstance(other, Decimal128):
+            return Decimal128(self.to_decimal() + other.to_decimal())
+        return NotImplemented
+
+    def __sub__(self, other):
+        if isinstance(other, Decimal128):
+            return Decimal128(self.to_decimal() - other.to_decimal())
+        return NotImplemented
+
+    def __mul__(self, other):
+        if isinstance(other, Decimal128):
+            return Decimal128(self.to_decimal() * other.to_decimal())
+        return NotImplemented
+
+    def __div__(self, other):
+        if isinstance(other, Decimal128):
+            return Decimal128(self.to_decimal() / other.to_decimal())
+        return NotImplemented
+
+    def __lt__(self, other):
+        if isinstance(other, Decimal128):
+            return self.to_decimal() < other.to_decimal()
+        return NotImplemented
+
+    def __le__(self, other):
+        if isinstance(other, Decimal128):
+            return self.to_decimal() <= other.to_decimal()
+        return NotImplemented
+
+    def __ge__(self, other):
+        if isinstance(other, Decimal128):
+            return self.to_decimal() >= other.to_decimal()
+        return NotImplemented
+
+    def __gt__(self, other):
+        if isinstance(other, Decimal128):
+            return self.to_decimal() > other.to_decimal()
+        return NotImplemented

--- a/bson/decimal128.py
+++ b/bson/decimal128.py
@@ -365,9 +365,14 @@ class Decimal128(object):
             return Decimal128(self.to_decimal() * other.to_decimal())
         return NotImplemented
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, Decimal128):
             return Decimal128(self.to_decimal() / other.to_decimal())
+        return NotImplemented
+
+    def __floordiv__(self, other):
+        if isinstance(other, Decimal128):
+            return Decimal128(self.to_decimal() // other.to_decimal())
         return NotImplemented
 
     def __lt__(self, other):

--- a/bson/decimal128.py
+++ b/bson/decimal128.py
@@ -370,6 +370,10 @@ class Decimal128(object):
             return Decimal128(self.to_decimal() / other.to_decimal())
         return NotImplemented
 
+    def __div__(self, other):
+        # mapping __div__ to __truediv_ for Python 2 compatiblity
+        return self.__truediv__(other)
+
     def __floordiv__(self, other):
         if isinstance(other, Decimal128):
             return Decimal128(self.to_decimal() // other.to_decimal())

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -83,3 +83,4 @@ The following is a list of people who have contributed to
 - Zhecong Kwok (gzcf)
 - TaoBeier(tao12345666333)
 - Jagrut Trivedi(Jagrut)
+- Jakob Schlyter (jschlyter)

--- a/test/test_decimal128.py
+++ b/test/test_decimal128.py
@@ -79,6 +79,22 @@ class TestDecimal128(unittest.TestCase):
         self.assertEqual("Infinity", str(ctx.copy().create_decimal("1E6145")))
         self.assertEqual("0E-6176", str(ctx.copy().create_decimal("1E-6177")))
 
+    def test_operators(self):
+        a = Decimal128(Decimal(1984))
+        b = Decimal128(Decimal(42))
+        c = Decimal128(Decimal(2))
+        d = Decimal128(Decimal(2.0))
+        self.assertEqual(a + b, Decimal128('2026'))
+        self.assertEqual(a - b, Decimal128('1942'))
+        self.assertEqual(a * b, Decimal128('83328'))
+        self.assertEqual(a / c, Decimal128('992'))
+        self.assertEqual(a // b, Decimal128('47'))
+        self.assertFalse(a < b)
+        self.assertFalse(a <= b)
+        self.assertTrue(a > b)
+        self.assertTrue(a >= b)
+        self.assertEqual(c, d)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
While writing tests for an application using Decimal128 for storing currency, I discovered that `mongomock` didn't support several operations (e.g., $inc) on Decimal128 values as `bson.decimal128` didn't support them. This PR adds support for basic operators for Decimal128 so that `mongomock` is once again happy.

Ref: https://jira.mongodb.org/browse/PYTHON-1473