### PR TITLE
Improve the check for legal utf8 in the bson module.

### DIFF
--- a/bson/encoding_helpers.c
+++ b/bson/encoding_helpers.c
@@ -78,7 +78,7 @@ static unsigned char isLegalUTF8(const unsigned char* source, int length) {
             /* no fall-through in this inner switch */
             case 0xE0: if (a < 0xA0) return 0; break;
             case 0xF0: if (a < 0x90) return 0; break;
-            case 0xF4: if (a > 0x8F) return 0; break;
+            case 0xF4: if ((a > 0x8F) || (a < 0x80)) return 0; break;
             default:  if (a < 0x80) return 0;
         }
         case 1: if (*source >= 0x80 && *source < 0xC2) return 0;


### PR DESCRIPTION
As discussed here https://jira.mongodb.org/browse/PYTHON-1504 I make a pull request to bring the 'isLegalUTF8' check in line with the python behaviour.

I also added two tests.
* one which tries all bit combinations within the 244 range
* one which tries just a few samples to trigger the problem.

I think the first one is the better one, since it goes much deeper, with the negative side effect of letting the test suite run for more than 5 minutes. Which is typically not acceptable, so I disabled it via 'return' at the top of it.

I enabled 'allow edits from maintainers' on my branch here. So feel free to adjust the unittests to your needs before merging.