### PR TITLE
Fix compatibility issues with Python >= 3.6

### DIFF
--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -34,8 +34,8 @@ from pymongo.son_manipulator import SONManipulator
 from pymongo.write_concern import WriteConcern
 
 
-_INDEX_REGEX = {"name": {"$regex": "^(?!.*\$)"}}
-_SYSTEM_FILTER = {"filter": {"name": {"$regex": "^(?!system\.)"}}}
+_INDEX_REGEX = {"name": {"$regex": r"^(?!.*\$)"}}
+_SYSTEM_FILTER = {"filter": {"name": {"$regex": r"^(?!system\.)"}}}
 
 
 def _check_name(name):

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -1217,7 +1217,7 @@ class TestCursor(IntegrationTest):
             raise SkipTest("SERVER-4754 - This test uses profiling.")
 
         # MongoDB 3.1.5 changed the ns for commands.
-        regex = {'$regex': 'pymongo_test.(\$cmd|test)'}
+        regex = {'$regex': r'pymongo_test.(\$cmd|test)'}
 
         if client_context.version.at_least(3, 5, 8, -1):
             query_key = "command.comment"

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """MongoDB benchmarking suite."""
+from __future__ import print_function
 
 import time
 import sys
@@ -87,7 +88,7 @@ def timed(name, function, args=[], setup=None):
         function(*args)
         times.append(time.time() - start)
     best_time = min(times)
-    print "%s%d" % (name + (60 - len(name)) * ".", per_trial / best_time)
+    print("{:s}{:d}".format(name + (60 - len(name)) * ".", per_trial / best_time))
     return best_time
 
 


### PR DESCRIPTION
- \$ and \. trigger SyntaxError in Python 3.6
- % format operator is not compatible with Python 3.6