### PR TITLE
Preserve different Decimal128 NaNs to JSON

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -835,7 +835,7 @@ def default(obj, json_options=DEFAULT_JSON_OPTIONS):
         else:
             return {"$uuid": obj.hex}
     if isinstance(obj, Decimal128):
-        return {"$numberDecimal": str(obj)}
+        return {"$numberDecimal": str(obj.to_decimal())}
     if isinstance(obj, bool):
         return obj
     if (json_options.json_mode == JSONMode.CANONICAL and


### PR DESCRIPTION
According to the doc of Decimal128, all NaN values will be represent as `Decimal128('NaN')` for matching the behavior of MongoDB's Decimal128 implementation, but this behavior also affect the serialization to JSON.