### PR TITLE
Fall back to sha1 if md5 is not available

### DIFF
--- a/bson/objectid.py
+++ b/bson/objectid.py
@@ -35,7 +35,12 @@ from bson.tz_util import utc
 def _machine_bytes():
     """Get the machine portion of an ObjectId.
     """
-    machine_hash = hashlib.md5()
+    try:
+        machine_hash = hashlib.md5()
+    except ValueError:
+        # md5 isn't available in FIPS mode
+        machine_hash = hashlib.sha1()
+
     if PY3:
         # gethostname() returns a unicode string in python 3.x
         # while update() requires a byte string.


### PR DESCRIPTION
In FIPS mode, md5 is not available. In such cases, fall back to sha1.
See https://docs.python.org/3/library/hashlib.html for more info.

This change is based on [something similar to what celery
did](https://github.com/celery/kombu/pull/711/commits/7e164f7f5e12521812a10ac268d8bec8e51e3a13).

This is needed for https://jira.mongodb.org/browse/PYTHON-1520.