### PR TITLE
ENH: add helper method to run tests on specific storage engines

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -226,7 +226,6 @@ class ClientContext(object):
 
             try:
                 self.cmd_line = self.client.admin.command('getCmdLineOpts')
-                self.server_status = self.client.admin.command('serverStatus')
             except pymongo.errors.OperationFailure as e:
                 msg = e.details.get('errmsg', '')
                 if e.code == 13 or 'unauthorized' in msg or 'login' in msg:
@@ -249,8 +248,8 @@ class ClientContext(object):
 
                 # May not have this if OperationFailure was raised earlier.
                 self.cmd_line = self.client.admin.command('getCmdLineOpts')
-                self.server_status = self.client.admin.command('serverStatus')
 
+            self.server_status = self.client.admin.command('serverStatus')
             self.ismaster = ismaster = self.client.admin.command('isMaster')
             self.sessions_enabled = 'logicalSessionTimeoutMinutes' in ismaster
 
@@ -427,14 +426,24 @@ class ClientContext(object):
             "Cannot connect to MongoDB on %s" % (self.pair,),
             func=func)
 
-    def require_storage_engine(self, engine):
-        """Run a test only if the server is running the specified storage
-        engine (as determined by the `db.serverStatus` command)."""
-        #server_status = self.client.admin.command("serverStatus")
-        #current_engine = server_status["storageEngine"]["name"]
+    def require_no_mmap(self, func):
+        """Run a test only if the server is not using the MMAPv1 storage
+        engine. Only works for standalone and replica sets; tests are
+        run regardless of storage engine on sharded clusters. """
+        def is_not_mmap():
+            if self.is_mongos:
+                return True
+            try:
+                storage_engine = self.server_status.get(
+                    'storageEngine').get('name')
+            except AttributeError:
+                # Raised if the storageEngine key does not exist or if
+                # self.server_status is None.
+                return False
+            return storage_engine != 'mmapv1'
+
         return self._require(
-            lambda: engine == self.server_status["storageEngine"]["name"],
-            "Storage engine must be %s" % str(engine))
+            is_not_mmap, "Storage engine must not be MMAPv1", func=func)
 
     def require_version_min(self, *ver):
         """Run a test only if the server version is at least ``version``."""

--- a/test/test_change_stream.py
+++ b/test/test_change_stream.py
@@ -54,6 +54,7 @@ class TestClusterChangeStream(IntegrationTest):
 
     @classmethod
     @client_context.require_version_min(4, 0, 0, -1)
+    @client_context.require_storage_engine("wiredTiger")
     @client_context.require_no_standalone
     def setUpClass(cls):
         super(TestClusterChangeStream, cls).setUpClass()
@@ -97,6 +98,7 @@ class TestDatabaseChangeStream(IntegrationTest):
 
     @classmethod
     @client_context.require_version_min(4, 0, 0, -1)
+    @client_context.require_storage_engine("wiredTiger")
     @client_context.require_no_standalone
     def setUpClass(cls):
         super(TestDatabaseChangeStream, cls).setUpClass()
@@ -147,6 +149,7 @@ class TestCollectionChangeStream(IntegrationTest):
 
     @classmethod
     @client_context.require_version_min(3, 5, 11)
+    @client_context.require_storage_engine("wiredTiger")
     @client_context.require_no_standalone
     def setUpClass(cls):
         super(TestCollectionChangeStream, cls).setUpClass()
@@ -645,6 +648,9 @@ def create_tests():
 
             for test in scenario_def['tests']:
                 new_test = create_test(scenario_def, test)
+                new_test = client_context.require_storage_engine(
+                    "wiredTiger")(new_test)
+
                 if 'minServerVersion' in test:
                     min_ver = tuple(
                         int(elt) for

--- a/test/test_change_stream.py
+++ b/test/test_change_stream.py
@@ -54,7 +54,7 @@ class TestClusterChangeStream(IntegrationTest):
 
     @classmethod
     @client_context.require_version_min(4, 0, 0, -1)
-    @client_context.require_storage_engine("wiredTiger")
+    @client_context.require_no_mmap
     @client_context.require_no_standalone
     def setUpClass(cls):
         super(TestClusterChangeStream, cls).setUpClass()
@@ -98,7 +98,7 @@ class TestDatabaseChangeStream(IntegrationTest):
 
     @classmethod
     @client_context.require_version_min(4, 0, 0, -1)
-    @client_context.require_storage_engine("wiredTiger")
+    @client_context.require_no_mmap
     @client_context.require_no_standalone
     def setUpClass(cls):
         super(TestDatabaseChangeStream, cls).setUpClass()
@@ -149,7 +149,7 @@ class TestCollectionChangeStream(IntegrationTest):
 
     @classmethod
     @client_context.require_version_min(3, 5, 11)
-    @client_context.require_storage_engine("wiredTiger")
+    @client_context.require_no_mmap
     @client_context.require_no_standalone
     def setUpClass(cls):
         super(TestCollectionChangeStream, cls).setUpClass()
@@ -648,8 +648,7 @@ def create_tests():
 
             for test in scenario_def['tests']:
                 new_test = create_test(scenario_def, test)
-                new_test = client_context.require_storage_engine(
-                    "wiredTiger")(new_test)
+                new_test = client_context.require_no_mmap(new_test)
 
                 if 'minServerVersion' in test:
                     min_ver = tuple(


### PR DESCRIPTION
Closes [PYTHON-1597](https://jira.mongodb.org/browse/PYTHON-1597)

This allows us to specify (with the help of a decorator on the `ClientContext`) the storage engine that the server must be running with for a given test to be executed.

### Motivation

Spec-tests introduced in [PYTHON-1565](https://jira.mongodb.org/browse/PYTHON-1565) can only be run when the server is using wired Tiger. These tests failed when the MMAPv1 engine was in use, resulting in [failures on evergreen](https://evergreen.mongodb.com/task/mongo_python_driver_tests_storage_engines__python_version~2.7_storage_engine~mmapv1_test_4.0_standalone_9b632c776c3ace91dd6fd71dd98164d77881f766_18_06_25_02_59_16).


### Comments

I chose to use the `db.serverStatus()` command to obtain storage engine information because: 

1) other drivers already follow this approach in their test infrastructure (e.g. PHP)
2) inferring storage engine information from the output of `serverStatus` seemed to present fewer ambiguities than the output of `getCmdLineOpts`. The latter tends to be confusing because the `getCmdLineOpts['parsed']` dict seems to always contain the `wiredTiger` key and we need to check whether the `engine` key has been set to `mmapv1` to ascertain the storage engine. This seemed a bit counter-intuitive to me but if you're not a fan of calling `serverStatus`, I can use the `cmd_line` information as well.