### PR TITLE
Document find_one_and_update return value on no match.

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -3019,9 +3019,14 @@ class Collection(common.BaseObject):
           ...    {'_id': 665}, {'$inc': {'count': 1}, '$set': {'done': True}})
           {u'_id': 665, u'done': False, u'count': 25}}
 
-        By default :meth:`find_one_and_update` returns the original version of
-        the document before the update was applied, or ``None`` if no document
-        matches the filter. To return the updated (or inserted in the case of
+        Returns ``None`` if no document matches the filter.
+
+          >>> db.test.find_one_and_update(
+          ...    {'_exists': False}, {'$inc': {'count': 1}})
+
+        When the filter matches, by default :meth:`find_one_and_update`
+        returns the original version of the document before the update was
+        applied. To return the updated (or inserted in the case of
         *upsert*) version of the document instead, use the *return_document*
         option.
 

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -3022,7 +3022,7 @@ class Collection(common.BaseObject):
         By default :meth:`find_one_and_update` returns the original version of
         the document before the update was applied, or ``None`` if no document
         matches the filter. To return the updated (or inserted in the case of
-        *upsert*), version of the document instead, use the *return_document*
+        *upsert*) version of the document instead, use the *return_document*
         option.
 
           >>> from pymongo import ReturnDocument

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -2431,10 +2431,10 @@ class Collection(common.BaseObject):
         """Watch changes on this collection.
 
         Performs an aggregation with an implicit initial ``$changeStream``
-        stage and returns a 
+        stage and returns a
         :class:`~pymongo.change_stream.CollectionChangeStream` cursor which
         iterates over changes on this collection.
-        
+
         Introduced in MongoDB 3.6.
 
         .. code-block:: python
@@ -2445,7 +2445,7 @@ class Collection(common.BaseObject):
 
         The :class:`~pymongo.change_stream.CollectionChangeStream` iterable
         blocks until the next change document is returned or an error is
-        raised. If the 
+        raised. If the
         :meth:`~pymongo.change_stream.CollectionChangeStream.next` method
         encounters a network error when retrieving a batch from the server,
         it will automatically attempt to recreate the cursor such that no

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -3030,6 +3030,9 @@ class Collection(common.BaseObject):
           ...     return_document=ReturnDocument.AFTER)
           {u'_id': u'userid', u'seq': 1}
 
+        Regardless the value of **return_document**, if no document matches
+        the filter, the return value is ``None``.
+
         You can limit the fields returned with the *projection* option.
 
           >>> db.example.find_one_and_update(
@@ -3080,8 +3083,7 @@ class Collection(common.BaseObject):
             document matches the query. Defaults to ``False``.
           - `return_document`: If
             :attr:`ReturnDocument.BEFORE` (the default),
-            returns the original document before it was updated, or ``None``
-            if no document matches. If
+            returns the original document before it was updated. If
             :attr:`ReturnDocument.AFTER`, returns the updated
             or inserted document.
           - `array_filters` (optional): A list of filters specifying which

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -3020,8 +3020,10 @@ class Collection(common.BaseObject):
           {u'_id': 665, u'done': False, u'count': 25}}
 
         By default :meth:`find_one_and_update` returns the original version of
-        the document before the update was applied. To return the updated
-        version of the document instead, use the *return_document* option.
+        the document before the update was applied, or ``None`` if no document
+        matches the filter. To return the updated (or inserted in the case of
+        *upsert*), version of the document instead, use the *return_document*
+        option.
 
           >>> from pymongo import ReturnDocument
           >>> db.example.find_one_and_update(
@@ -3029,9 +3031,6 @@ class Collection(common.BaseObject):
           ...     {'$inc': {'seq': 1}},
           ...     return_document=ReturnDocument.AFTER)
           {u'_id': u'userid', u'seq': 1}
-
-        Regardless the value of **return_document**, if no document matches
-        the filter, the return value is ``None``.
 
         You can limit the fields returned with the *projection* option.
 


### PR DESCRIPTION
Today I was implementing find_one_and_update, and I wanted to verify the behavior if no value was matched, but found the docs did not adequately document the behavior. I verified the behavior on MongoDB 3.6 and the latest pymongo and documented it here.