### PR TITLE
Remove Travis workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,3 @@ services:
 
 script: PYMONGO_MUST_CONNECT=1 python setup.py test
 
-install:
-    # Temporary solution for Travis CI multiprocessing issue #943
-    # https://github.com/travis-ci/travis-ci/issues/943
-    - sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm
-    # Work around https://github.com/travis-ci/travis-ci/issues/5485
-    - travis_retry pip install setuptools==29.0.1


### PR DESCRIPTION
Looks like https://github.com/travis-ci/travis-ci/issues/943 was fixed.
https://github.com/travis-ci/travis-ci/issues/5485 isn't needed since we don't support Python 3.2 . 