### PR TITLE
Avoid failure to instantiate an OperationFailure if details is not a dict

### DIFF
--- a/pymongo/errors.py
+++ b/pymongo/errors.py
@@ -126,8 +126,13 @@ class OperationFailure(PyMongoError):
     """
 
     def __init__(self, error, code=None, details=None):
+        """
+
+        :param details: The complete error document returned by the server.
+        Error labels are expected to be provided with errorLabels key.
+        """
         error_labels = None
-        if details is not None:
+        if details is not None and isinstance(details, dict):
             error_labels = details.get('errorLabels')
         super(OperationFailure, self).__init__(
             error, error_labels=error_labels)
@@ -206,6 +211,11 @@ class BulkWriteError(OperationFailure):
     .. versionadded:: 2.7
     """
     def __init__(self, results):
+        """
+
+        :param results: The complete error document returned by the server.
+        Error labels are expected to be provided with errorLabels key.
+        """
         super(BulkWriteError, self).__init__(
             "batch op errors occurred", 65, results)
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -690,12 +690,13 @@ def setup():
 
 def teardown():
     c = client_context.client
-    c.drop_database("pymongo-pooling-tests")
-    c.drop_database("pymongo_test")
-    c.drop_database("pymongo_test1")
-    c.drop_database("pymongo_test2")
-    c.drop_database("pymongo_test_mike")
-    c.drop_database("pymongo_test_bernie")
+    if c:
+        c.drop_database("pymongo-pooling-tests")
+        c.drop_database("pymongo_test")
+        c.drop_database("pymongo_test1")
+        c.drop_database("pymongo_test2")
+        c.drop_database("pymongo_test_mike")
+        c.drop_database("pymongo_test_bernie")
 
 
 class PymongoTestRunner(unittest.TextTestRunner):


### PR DESCRIPTION
Hi,

Even if I assume OperationFailure details parameter was always expected to be a dictionary, the check was never explicit,

Prior to version 3.7.0 there was nothing preventing users to instantiate an OperationFailure (or any sub class) with details being something else than a dictionary.

This lack of validation resulted in mongomock providing a string value in this parameter, thus being incompatible with pymongo==3.7.0 or 3.7.1

This PR aim at fixing this regression.