### PR TITLE
PYTHON-1624 Fix failing $out test on MongoDB latest

### DIFF
--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1616,9 +1616,8 @@ class TestCollection(IntegrationTest):
         self.assertEqual([{'foo': [1, 2]}], list(result))
 
         # Test write concern.
-        out_pipeline = [pipeline, {'$out': 'output-collection'}]
         with self.write_concern_collection() as coll:
-            coll.aggregate(out_pipeline)
+            coll.aggregate([{'$out': 'output-collection'}])
 
     def test_aggregate_raw_bson(self):
         db = self.db


### PR DESCRIPTION
There's no need to project out the _id field in this test. I opened [SERVER-36598](https://jira.mongodb.org/browse/SERVER-36598) for the server bug.