### PR TITLE
Provide a docstring to MongoClient

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -84,3 +84,4 @@ The following is a list of people who have contributed to
 - TaoBeier(tao12345666333)
 - Jagrut Trivedi(Jagrut)
 - Shrey Batra(shreybatra)
+- Felipe Rodrigues(fbidu)

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -75,8 +75,15 @@ from pymongo.write_concern import DEFAULT_WRITE_CONCERN
 
 
 class MongoClient(common.BaseObject):
-    """Class that provides a full featured client for a MongoDB
-    instance, a replica set, or a set of mongoses."""
+    """
+    A client-side representation of a MongoDB cluster.
+
+    Instances can represent either a standalone MongoDB server, a replica
+    set, or a sharded cluster. Instances of this class are responsible for
+    maintaining up-to-date state of the cluster, and possibly cache
+    resources related to this, including background threads for monitoring,
+    and connection pools.
+    """
     HOST = "localhost"
     PORT = 27017
     # Define order to retrieve options from ClientOptions for __repr__.

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -75,6 +75,8 @@ from pymongo.write_concern import DEFAULT_WRITE_CONCERN
 
 
 class MongoClient(common.BaseObject):
+    """Class that provides a full featured client for a MongoDB
+    instance, a replica set, or a set of mongoses."""
     HOST = "localhost"
     PORT = 27017
     # Define order to retrieve options from ClientOptions for __repr__.


### PR DESCRIPTION
Hello, first time contributor here!

I was doing a little debugging on an old code of mine and started to read around the documentation available. To my surprise, MongoClient's docstring was set to 

```
A base class that provides attributes and methods common
to multiple pymongo classes.

SHOULD NOT BE USED BY DEVELOPERS EXTERNAL TO MONGODB.
```

Confused, I went on researching and found out that MongoClient inherits from a base class and does not provide a new docstring, cause the parent's docstring to be displayed.
