### PR TITLE
Fix issues found by coverity

### DIFF
--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -1031,7 +1031,7 @@ class Database(common.BaseObject):
 
             opts["roles"] = [self._default_role(read_only)]
 
-        elif read_only:
+        if read_only:
             warnings.warn("The read_only option is deprecated in MongoDB "
                           ">= 2.6, use 'roles' instead", DeprecationWarning)
 

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1211,7 +1211,7 @@ class MongoClient(common.BaseObject):
                             # not support sessions raise the last error.
                             raise last_error
                         retryable = False
-                    if is_retrying():
+                    if session and is_retrying():
                         # Reset the transaction id and retry the operation.
                         session._retry_transaction_id()
                     return func(session, sock_info, retryable)

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -357,7 +357,7 @@ class TestCursor(IntegrationTest):
         self.assertTrue(coll.find().explain())
         started = listener.results['started']
         self.assertEqual(len(started), 1)
-        self.assertNotIn("readConern", started[0].command)
+        self.assertNotIn("readConcern", started[0].command)
 
     def test_hint(self):
         db = self.db

--- a/test/utils.py
+++ b/test/utils.py
@@ -396,7 +396,7 @@ def read_from_which_host(
     if isinstance(tag_sets, dict):
         tag_sets = [tag_sets]
     if tag_sets:
-        tags = tag_sets or pref.tag_sets
+        tags = list(set(tag_sets + pref.tag_sets))
         pref = pref.__class__(tags)
 
     db.read_preference = pref


### PR DESCRIPTION
I've run coverity scan of python-pymongo 3.6.1 - see log [scan-results.txt](https://github.com/mongodb/mongo-python-driver/files/2434573/scan-results.txt)


I've guessed what is the right way to fix the issues which IMHO aren't false positive. In case of other preferences, I will change it.

` pymongo/database.py` - without this fix, `elif` is never reached.
`mongo_client.py` - `session` can be None, so it needs to be checked.
`test_cursor.py` - typo
`utils.py` - currently `pref.tag_sets" is never used. Using tags from both lists.