### PR TITLE
LIFO connection pool policy

### DIFF
--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -894,7 +894,9 @@ class Pool:
         # Check a socket's health with socket_closed() every once in a while.
         # Can override for testing: 0 to always check, None to never check.
         self._check_interval_seconds = 1
-
+        # LIFO pool. Sockets are ordered on idle time. Sockets claimed
+        # and returned to pool from the left side. Stale sockets removed
+        # from the right side.
         self.sockets = collections.deque()
         self.lock = threading.Lock()
         self.active_sockets = 0

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -1034,13 +1034,13 @@ class Pool:
                 with self.lock:
                     # Can raise ConnectionFailure.
                     sock_info = self.sockets.popleft()
-            except KeyError:
+            except IndexError:
                 # Can raise ConnectionFailure or CertificateError.
                 sock_info = self.connect()
             else:
                 # Can raise ConnectionFailure.
                 sock_info = self._check(sock_info)
-        except:
+        except Exception:
             self._socket_semaphore.release()
             with self.lock:
                 self.active_sockets -= 1


### PR DESCRIPTION
Current connection pool implementation is based upon python set() and prone to connection pool poisoning problem.

Python set() is unordered by definition. So each command executed withdraws random connection from pool, touching its last usage time. This scheme shows good result on persistent established loads, increasing number of connections to handle the load. But spikes of loads introduces pool poisoning problem. During the spikes of load connection pool creates new connection to handle the increased load (which is expected behavior), but when returning to normal levels connection pool cannot reduce amount of connections, because due to unordered set() commands passed to virtually all open connection, preventing them from expiration. So the amount of open connections is never decreased on particular loads.

LIFO policy implementation addresses this issue. All connections are ordered by usage time using deque. Connections are taken and returned to pool from the left side of deque. For persistent load this scheme is equal to current implementation. For the spiky loads, after handling the spikes, we have frequently used connections from the left side, while unused moved to the right side, giving them chance to expire. Deque implementation offers efficient copy-free way of expiring connections from the right side.

Using proposed implementation we've observed ~18000 of mongod connection on system start, reducing to ~4000 after several minutes.