### PR TITLE
Remove legacy Python 2.4 support code

### DIFF
--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -41,39 +41,6 @@ SRV_SCHEME_LEN = len(SRV_SCHEME)
 DEFAULT_PORT = 27017
 
 
-# def _partition(entity, sep):
-#     """Python2.4 doesn't have a partition method so we provide
-#     our own that mimics str.partition from later releases.
-#
-#     Split the string at the first occurrence of sep, and return a
-#     3-tuple containing the part before the separator, the separator
-#     itself, and the part after the separator. If the separator is not
-#     found, return a 3-tuple containing the string itself, followed
-#     by two empty strings.
-#     """
-#     parts = entity.split(sep, 1)
-#     if len(parts) == 2:
-#         return parts[0], sep, parts[1]
-#     else:
-#         return entity, '', ''
-#
-#
-# def _rpartition(entity, sep):
-#     """Python2.4 doesn't have an rpartition method so we provide
-#     our own that mimics str.rpartition from later releases.
-#
-#     Split the string at the last occurrence of sep, and return a
-#     3-tuple containing the part before the separator, the separator
-#     itself, and the part after the separator. If the separator is not
-#     found, return a 3-tuple containing two empty strings, followed
-#     by the string itself.
-#     """
-#     idx = entity.rfind(sep)
-#     if idx == -1:
-#         return '', '', entity
-#     return entity[:idx], sep, entity[idx + 1:]
-
-
 def parse_userinfo(userinfo):
     """Validates the format of user information in a MongoDB URI.
     Reserved characters like ':', '/', '+' and '@' must be escaped

--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -41,37 +41,37 @@ SRV_SCHEME_LEN = len(SRV_SCHEME)
 DEFAULT_PORT = 27017
 
 
-def _partition(entity, sep):
-    """Python2.4 doesn't have a partition method so we provide
-    our own that mimics str.partition from later releases.
-
-    Split the string at the first occurrence of sep, and return a
-    3-tuple containing the part before the separator, the separator
-    itself, and the part after the separator. If the separator is not
-    found, return a 3-tuple containing the string itself, followed
-    by two empty strings.
-    """
-    parts = entity.split(sep, 1)
-    if len(parts) == 2:
-        return parts[0], sep, parts[1]
-    else:
-        return entity, '', ''
-
-
-def _rpartition(entity, sep):
-    """Python2.4 doesn't have an rpartition method so we provide
-    our own that mimics str.rpartition from later releases.
-
-    Split the string at the last occurrence of sep, and return a
-    3-tuple containing the part before the separator, the separator
-    itself, and the part after the separator. If the separator is not
-    found, return a 3-tuple containing two empty strings, followed
-    by the string itself.
-    """
-    idx = entity.rfind(sep)
-    if idx == -1:
-        return '', '', entity
-    return entity[:idx], sep, entity[idx + 1:]
+# def _partition(entity, sep):
+#     """Python2.4 doesn't have a partition method so we provide
+#     our own that mimics str.partition from later releases.
+#
+#     Split the string at the first occurrence of sep, and return a
+#     3-tuple containing the part before the separator, the separator
+#     itself, and the part after the separator. If the separator is not
+#     found, return a 3-tuple containing the string itself, followed
+#     by two empty strings.
+#     """
+#     parts = entity.split(sep, 1)
+#     if len(parts) == 2:
+#         return parts[0], sep, parts[1]
+#     else:
+#         return entity, '', ''
+#
+#
+# def _rpartition(entity, sep):
+#     """Python2.4 doesn't have an rpartition method so we provide
+#     our own that mimics str.rpartition from later releases.
+#
+#     Split the string at the last occurrence of sep, and return a
+#     3-tuple containing the part before the separator, the separator
+#     itself, and the part after the separator. If the separator is not
+#     found, return a 3-tuple containing two empty strings, followed
+#     by the string itself.
+#     """
+#     idx = entity.rfind(sep)
+#     if idx == -1:
+#         return '', '', entity
+#     return entity[:idx], sep, entity[idx + 1:]
 
 
 def parse_userinfo(userinfo):
@@ -95,7 +95,7 @@ def parse_userinfo(userinfo):
             quote_fn = "urllib.quote_plus"
         raise InvalidURI("Username and password must be escaped according to "
                          "RFC 3986, use %s()." % quote_fn)
-    user, _, passwd = _partition(userinfo, ":")
+    user, _, passwd = userinfo.partition(":")
     # No password is expected with GSSAPI authentication.
     if not user:
         raise InvalidURI("The empty string is not valid username.")
@@ -365,7 +365,7 @@ def parse_uri(uri, default_port=DEFAULT_PORT, validate=True, warn=False):
     collection = None
     options = {}
 
-    host_part, _, path_part = _partition(scheme_free, '/')
+    host_part, _, path_part = scheme_free.partition('/')
     if not host_part:
         host_part = path_part
         path_part = ""
@@ -375,7 +375,7 @@ def parse_uri(uri, default_port=DEFAULT_PORT, validate=True, warn=False):
                          "the host list and any options.")
 
     if '@' in host_part:
-        userinfo, _, hosts = _rpartition(host_part, '@')
+        userinfo, _, hosts = host_part.rpartition('@')
         user, passwd = parse_userinfo(userinfo)
     else:
         hosts = host_part
@@ -427,7 +427,7 @@ def parse_uri(uri, default_port=DEFAULT_PORT, validate=True, warn=False):
         if path_part[0] == '?':
             opts = unquote_plus(path_part[1:])
         else:
-            dbase, _, opts = map(unquote_plus, _partition(path_part, '?'))
+            dbase, _, opts = map(unquote_plus, path_part.partition('?'))
             if '.' in dbase:
                 dbase, collection = dbase.split('.', 1)
 

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -20,9 +20,7 @@ import warnings
 
 sys.path[0:0] = [""]
 
-from pymongo.uri_parser import (_partition,
-                                _rpartition,
-                                parse_userinfo,
+from pymongo.uri_parser import (parse_userinfo,
                                 split_hosts,
                                 split_options,
                                 parse_uri)
@@ -34,14 +32,6 @@ from test import unittest
 
 
 class TestURI(unittest.TestCase):
-
-    def test_partition(self):
-        self.assertEqual(('foo', ':', 'bar'), _partition('foo:bar', ':'))
-        self.assertEqual(('foobar', '', ''), _partition('foobar', ':'))
-
-    def test_rpartition(self):
-        self.assertEqual(('fo:o:', ':', 'bar'), _rpartition('fo:o::bar', ':'))
-        self.assertEqual(('', '', 'foobar'), _rpartition('foobar', ':'))
 
     def test_validate_userinfo(self):
         self.assertRaises(InvalidURI, parse_userinfo,


### PR DESCRIPTION
I found this little snippet of code that supported some Python 2.4 behavior hanging around in the `uri_parser` module. I think we can safely remove it now.