### PR TITLE
PYTHON-1658 Test that transaction reads ignore db/collection readConcern

### DIFF
--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -391,6 +391,9 @@ def end_sessions(sessions):
 
 def create_test(scenario_def, test):
     def run_scenario(self):
+        if test.get('skipReason'):
+            raise unittest.SkipTest(test.get('skipReason'))
+
         listener = OvertCommandListener()
         # New client, to avoid interference from pooled sessions.
         # Convert test['clientOptions'] to dict to avoid a Jython bug using "**"
@@ -561,10 +564,6 @@ def create_tests():
 
                 new_test = create_test(scenario_def, test)
                 new_test = client_context.require_transactions(new_test)
-                skip_reason = test.get('skipReason')
-                if skip_reason:
-                    new_test = client_context._require(
-                        lambda: False, skip_reason, new_test)
 
                 if 'secondary' in test_name:
                     new_test = client_context._require(

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -561,10 +561,10 @@ def create_tests():
 
                 new_test = create_test(scenario_def, test)
                 new_test = client_context.require_transactions(new_test)
-                new_test = client_context._require(
-                    lambda: not test.get('skipReason'),
-                    test.get('skipReason'),
-                    new_test)
+                skip_reason = test.get('skipReason')
+                if skip_reason:
+                    new_test = client_context._require(
+                        lambda: False, skip_reason, new_test)
 
                 if 'secondary' in test_name:
                     new_test = client_context._require(

--- a/test/transactions/bulk.json
+++ b/test/transactions/bulk.json
@@ -184,6 +184,7 @@
           },
           "result": {
             "deletedCount": 4,
+            "insertedCount": 6,
             "insertedIds": {
               "0": 1,
               "3": 3,

--- a/test/transactions/error-labels.json
+++ b/test/transactions/error-labels.json
@@ -595,6 +595,7 @@
                   }
                 }
               ],
+              "cursor": {},
               "readConcern": null,
               "lsid": "session0",
               "txnNumber": {

--- a/test/transactions/read-concern.json
+++ b/test/transactions/read-concern.json
@@ -93,6 +93,7 @@
                   }
                 }
               ],
+              "cursor": {},
               "lsid": "session0",
               "readConcern": {
                 "level": "snapshot"
@@ -128,6 +129,7 @@
                   }
                 }
               ],
+              "cursor": {},
               "lsid": "session0",
               "readConcern": null,
               "txnNumber": {
@@ -766,6 +768,783 @@
               "readConcern": {
                 "level": "snapshot"
               },
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "find",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "find",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "countDocuments ignores collection readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 2
+              }
+            }
+          },
+          "result": 3
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 2
+              }
+            }
+          },
+          "result": 3
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gte": 2
+                    }
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": null,
+                    "n": {
+                      "$sum": 1
+                    }
+                  }
+                }
+              ],
+              "cursor": {},
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gte": 2
+                    }
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": null,
+                    "n": {
+                      "$sum": 1
+                    }
+                  }
+                }
+              ],
+              "cursor": {},
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "find ignores collection readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "batchSize": 3
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "batchSize": 3
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false
+            },
+            "command_name": "find",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": {
+                "$numberLong": "42"
+              },
+              "collection": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "getMore",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "find",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": {
+                "$numberLong": "42"
+              },
+              "collection": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "getMore",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "aggregate ignores collection readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$project": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "cursor": {
+                "batchSize": 3
+              },
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": {
+                "$numberLong": "42"
+              },
+              "collection": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "getMore",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$project": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "cursor": {
+                "batchSize": 3
+              },
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": {
+                "$numberLong": "42"
+              },
+              "collection": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "getMore",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "distinct ignores collection readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "fieldName": "_id"
+          },
+          "result": [
+            1,
+            2,
+            3,
+            4
+          ]
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "fieldName": "_id"
+          },
+          "result": [
+            1,
+            2,
+            3,
+            4
+          ]
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "distinct": "test",
+              "key": "_id",
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "distinct",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "distinct": "test",
+              "key": "_id",
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "distinct",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "runCommand ignores database readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "databaseOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "command_name": "find",
+          "arguments": {
+            "session": "session0",
+            "command": {
+              "find": "test"
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "command_name": "find",
+          "arguments": {
+            "session": "session0",
+            "command": {
+              "find": "test"
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "lsid": "session0",
+              "readConcern": null,
               "txnNumber": {
                 "$numberLong": "1"
               },

--- a/test/transactions/transaction-options.json
+++ b/test/transactions/transaction-options.json
@@ -1159,6 +1159,7 @@
           },
           "result": {
             "deletedCount": 0,
+            "insertedCount": 1,
             "insertedIds": {
               "0": 1
             },


### PR DESCRIPTION
Fix: properly skip tests that include 'skipReason'.
Revendor transaction spec tests at commit 367842f1ee4b80f75664a05c6b9d5b2498cf856d