### PR TITLE
[gridfs] more closely implement io.IOBase

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -85,3 +85,4 @@ The following is a list of people who have contributed to
 - Jagrut Trivedi(Jagrut)
 - Shrey Batra(shreybatra)
 - Felipe Rodrigues(fbidu)
+- Terence Honles (terencehonles)


### PR DESCRIPTION
[PYTHON-1695](https://jira.mongodb.org/browse/PYTHON-1695)

I'm testing out moving our system to using Python3.7. We have an instance where we are using [ZipFile](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile) on a `GridOut` instance. Because [seekable()](https://www.python.org/dev/peps/pep-3116/#raw-i-o) is defined as part of the IO API the ZipFile implementation does not handle an `AttributeError` coming from accessing the `seekable` method.

This appears to be a change in the `ZipFile` implementation between Python3.6 and Python3.7.

The `GridOut` implementation is relatively close to implementing `io.IOBase` so I figured I would close the gap, have it subclass `io.IOBase` and also note where it diverges from the `io.IOBase` behavior.

I don't use `ZipFile` against a `GridIn` instance and it diverges from `io.IOBase` in that it doesn't return the number of bytes written so I refrained from making it a subclass of `io.IOBase`