### PR TITLE
Make sure Travis tests both native and compiled BSON implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ python:
 services:
   - mongodb
 
-script: PYMONGO_MUST_CONNECT=1 python setup.py test
+script: PYMONGO_MUST_CONNECT=1 sh -c 'python setup.py --no_ext test && python setup.py test'
 


### PR DESCRIPTION
Currently, Travis only ever checks the compiled BSON implementation.

This change makes it run the whole test suite twice: once with the native implementation, and again with the compiled implementation. This is especially important when making changes to the BSON module, as I have done in #392.