### PR TITLE
Update docs to use list_collection_names method

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -142,7 +142,7 @@ of the collections in our database:
 
 .. doctest::
 
-  >>> db.collection_names(include_system_collections=False)
+  >>> db.list_collection_names(include_system_collections=False)
   [u'posts']
 
 Getting a Single Document With :meth:`~pymongo.collection.Collection.find_one`


### PR DESCRIPTION
I encountered DeprecationWarning: collection_names is deprecated.

This is a simple name change, but we could also explain the
deprecation in detail in an aside or blockquote.