### PR TITLE
PYTHON-1684 Support sharded transactions recovery token

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Changes in Version 3.9.0
-------------------------
+Changes in Version 3.9.0.dev0
+-----------------------------
 
 Version 3.9 adds support for MongoDB 4.2. Highlights include:
 
@@ -40,8 +40,8 @@ in this release.
 
 .. _PyMongo 3.9 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=21787
 
-Changes in Version 3.8.0
-------------------------
+Changes in Version 3.8.0.dev0
+-----------------------------
 
 .. warning:: PyMongo no longer supports Python 2.6. RHEL 6 users should install
   Python 2.7 or newer from `Red Hat Software Collections

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,23 +1,14 @@
 Changelog
 =========
 
-Changes in Version 3.8.0
+Changes in Version 3.9.0
 ------------------------
 
-.. warning:: PyMongo no longer supports Python 2.6. RHEL 6 users should install
-  Python 2.7 or newer from `Red Hat Software Collections
-  <https://www.softwarecollections.org>`_. CentOS 6 users should install Python
-  2.7 or newer from `SCL
-  <https://wiki.centos.org/AdditionalResources/Repositories/SCL>`_
+Version 3.9 adds support for MongoDB 4.2. Highlights include:
 
-.. warning:: PyMongo no longer supports PyPy3 versions older than 3.5. Users
-  must upgrade to PyPy3.5+.
-
-- :class:`~bson.objectid.ObjectId` now implements the `ObjectID specification
-  version 0.2 <https://github.com/mongodb/specifications/blob/master/source/objectid.rst>`_.
-
-
-- Version 3.8.0 implements the `URI options specification`_ in the
+- Support for MongoDB 4.2 sharded transactions. Sharded transactions have
+  the same API as replica set transactions. See :ref:`transactions-ref`.
+- Implement the `URI options specification`_ in the
   :meth:`~pymongo.mongo_client.MongoClient` constructor. Consequently, there are
   a number of changes in connection options:
 
@@ -38,8 +29,31 @@ Changes in Version 3.8.0
     - ``ssl_pem_passphrase`` has been deprecated in favor of ``tlsCertificateKeyFilePassword``.
 
 
-.. _URI options specification: https://github.com/mongodb/specifications/blob/master/source/uri-options/uri-options.rst`
+.. _URI options specification: https://github.com/mongodb/specifications/blob/master/source/uri-options/uri-options.rst
 
+
+Issues Resolved
+...............
+
+See the `PyMongo 3.9 release notes in JIRA`_ for the list of resolved issues
+in this release.
+
+.. _PyMongo 3.9 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=21787
+
+Changes in Version 3.8.0
+------------------------
+
+.. warning:: PyMongo no longer supports Python 2.6. RHEL 6 users should install
+  Python 2.7 or newer from `Red Hat Software Collections
+  <https://www.softwarecollections.org>`_. CentOS 6 users should install Python
+  2.7 or newer from `SCL
+  <https://wiki.centos.org/AdditionalResources/Repositories/SCL>`_
+
+.. warning:: PyMongo no longer supports PyPy3 versions older than 3.5. Users
+  must upgrade to PyPy3.5+.
+
+- :class:`~bson.objectid.ObjectId` now implements the `ObjectID specification
+  version 0.2 <https://github.com/mongodb/specifications/blob/master/source/objectid.rst>`_.
 
 Issues Resolved
 ...............

--- a/pymongo/bulk.py
+++ b/pymongo/bulk.py
@@ -292,7 +292,7 @@ class _Bulk(object):
                 if not to_send:
                     raise InvalidOperation("cannot do an empty bulk write")
                 result = bwc.write_command(request_id, msg, to_send)
-                client._receive_cluster_time(result, session)
+                client._process_response(result, session)
 
                 # Retryable writeConcernErrors halt the execution of this run.
                 wce = result.get('writeConcernError', {})

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -493,16 +493,13 @@ class ClientSession(object):
         cmd = SON([(command_name, 1)])
         if self._transaction.recovery_token and is_commit:
             cmd['recoveryToken'] = self._transaction.recovery_token
-        try:
-            with self._client._socket_for_writes(self) as sock_info:
-                return self._client.admin._command(
-                    sock_info,
-                    cmd,
-                    session=self,
-                    write_concern=wc,
-                    parse_write_concern_error=True)
-        finally:
-            self._unpin_mongos()
+        with self._client._socket_for_writes(self) as sock_info:
+            return self._client.admin._command(
+                sock_info,
+                cmd,
+                session=self,
+                write_concern=wc,
+                parse_write_concern_error=True)
 
     def _advance_cluster_time(self, cluster_time):
         """Internal cluster time helper."""

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -484,13 +484,14 @@ class ClientSession(object):
         # subsequent commitTransaction commands should be upgraded to use
         # w:"majority" and set a default value of 10 seconds for wtimeout.
         wc = self._transaction.opts.write_concern
-        if retrying and command_name == "commitTransaction":
+        is_commit = command_name == "commitTransaction"
+        if retrying and is_commit:
             wc_doc = wc.document
             wc_doc["w"] = "majority"
             wc_doc.setdefault("wtimeout", 10000)
             wc = WriteConcern(**wc_doc)
         cmd = SON([(command_name, 1)])
-        if self._transaction.recovery_token:
+        if self._transaction.recovery_token and is_commit:
             cmd['recoveryToken'] = self._transaction.recovery_token
         try:
             with self._client._socket_for_writes(self) as sock_info:

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -75,6 +75,19 @@ transactions on the same session can be executed in sequence.
 
 .. versionadded:: 3.7
 
+Sharded Transactions
+^^^^^^^^^^^^^^^^^^^^
+
+PyMongo 3.9 adds support for transactions on sharded clusters running MongoDB
+4.2. Sharded transactions have the same API as replica set transactions.
+When running a transaction against a sharded cluster, the session is
+pinned to the mongos server selected for the first operation in the
+transaction. All subsequent operations that are part of the same transaction
+are routed to the same mongos server. When the transaction is completed, by
+running either commitTransaction or abortTransaction, the session is unpinned.
+
+.. versionadded:: 3.9
+
 .. mongodoc:: transactions
 
 Classes

--- a/pymongo/command_cursor.py
+++ b/pymongo/command_cursor.py
@@ -154,7 +154,7 @@ class CommandCursor(object):
                                          self.__collection.codec_options)
             if from_command:
                 first = docs[0]
-                client._receive_cluster_time(first, self.__session)
+                client._process_response(first, self.__session)
                 helpers._check_command_response(first)
 
         except OperationFailure as exc:

--- a/pymongo/command_cursor.py
+++ b/pymongo/command_cursor.py
@@ -149,13 +149,14 @@ class CommandCursor(object):
         reply = response.data
 
         try:
-            docs = self._unpack_response(reply,
-                                         self.__id,
-                                         self.__collection.codec_options)
-            if from_command:
-                first = docs[0]
-                client._process_response(first, self.__session)
-                helpers._check_command_response(first)
+            with client._reset_on_error(self.__address, self.__session):
+                docs = self._unpack_response(reply,
+                                             self.__id,
+                                             self.__collection.codec_options)
+                if from_command:
+                    first = docs[0]
+                    client._process_response(first, self.__session)
+                    helpers._check_command_response(first)
 
         except OperationFailure as exc:
             kill()
@@ -174,7 +175,6 @@ class CommandCursor(object):
                 listeners.publish_command_failure(
                     duration(), exc.details, "getMore", rqst_id, self.__address)
 
-            client._reset_server_and_request_check(self.address)
             raise
         except Exception as exc:
             if publish:

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -973,13 +973,14 @@ class Cursor(object):
                 raise
 
         try:
-            docs = self._unpack_response(response=reply,
-                                         cursor_id=self.__id,
-                                         codec_options=self.__codec_options)
-            if from_command:
-                first = docs[0]
-                client._process_response(first, self.__session)
-                helpers._check_command_response(first)
+            with client._reset_on_error(self.__address, self.__session):
+                docs = self._unpack_response(response=reply,
+                                             cursor_id=self.__id,
+                                             codec_options=self.__codec_options)
+                if from_command:
+                    first = docs[0]
+                    client._process_response(first, self.__session)
+                    helpers._check_command_response(first)
         except OperationFailure as exc:
             self.__killed = True
 
@@ -1009,7 +1010,6 @@ class Cursor(object):
                 listeners.publish_command_failure(
                     duration(), exc.details, cmd_name, rqst_id, self.__address)
 
-            client._reset_server_and_request_check(self.__address)
             raise
         except Exception as exc:
             if publish:

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -978,7 +978,7 @@ class Cursor(object):
                                          codec_options=self.__codec_options)
             if from_command:
                 first = docs[0]
-                client._receive_cluster_time(first, self.__session)
+                client._process_response(first, self.__session)
                 helpers._check_command_response(first)
         except OperationFailure as exc:
             self.__killed = True

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1174,8 +1174,8 @@ class MongoClient(common.BaseObject):
                                                   session._in_transaction):
                     session._pin_mongos(server)
             return server
-        except ConnectionFailure:
-            if session:
+        except PyMongoError as exc:
+            if session and exc.has_error_label("TransientTransactionError"):
                 session._unpin_mongos()
             raise
 

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1682,12 +1682,10 @@ class MongoClient(common.BaseObject):
         if cluster_time:
             command['$clusterTime'] = cluster_time
 
-    def _receive_cluster_time(self, reply, session):
-        cluster_time = reply.get('$clusterTime')
-        self._topology.receive_cluster_time(cluster_time)
+    def _process_response(self, reply, session):
+        self._topology.receive_cluster_time(reply.get('$clusterTime'))
         if session is not None:
-            session._advance_cluster_time(cluster_time)
-            session._advance_operation_time(reply.get("operationTime"))
+            session._process_response(reply)
 
     def server_info(self, session=None):
         """Get information about the MongoDB server we're connected to.

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1113,38 +1113,9 @@ class MongoClient(common.BaseObject):
 
     @contextlib.contextmanager
     def _get_socket(self, server, session):
-        try:
-            try:
-                with server.get_socket(self.__all_credentials) as sock_info:
-                    yield sock_info
-            except PyMongoError as exc:
-                if session and exc.has_error_label(
-                        "TransientTransactionError"):
-                    session._unpin_mongos()
-                raise
-        except NetworkTimeout:
-            # The socket has been closed. Don't reset the server.
-            # Server Discovery And Monitoring Spec: "When an application
-            # operation fails because of any network error besides a socket
-            # timeout...."
-            raise
-        except NotMasterError:
-            # "When the client sees a "not master" error it MUST replace the
-            # server's description with type Unknown. It MUST request an
-            # immediate check of the server."
-            self._reset_server_and_request_check(server.description.address)
-            raise
-        except ConnectionFailure:
-            # "Client MUST replace the server's description with type Unknown
-            # ... MUST NOT request an immediate check of the server."
-            self.__reset_server(server.description.address)
-            raise
-        except OperationFailure as exc:
-            if exc.code in helpers._RETRYABLE_ERROR_CODES:
-                # Do not request an immediate check since the server is likely
-                # shutting down.
-                self.__reset_server(server.description.address)
-            raise
+        with self._reset_on_error(server.description.address, session):
+            with server.get_socket(self.__all_credentials) as sock_info:
+                yield sock_info
 
     def _select_server(self, server_selector, session, address=None):
         """Select a server to run an operation on this client.
@@ -1228,28 +1199,24 @@ class MongoClient(common.BaseObject):
             and server.description.server_type != SERVER_TYPE.Mongos) or (
                 operation.read_preference != ReadPreference.PRIMARY)
 
-        return self._reset_on_error(
-            server,
-            operation.session,
-            server.send_message_with_response,
-            operation,
-            set_slave_ok,
-            self.__all_credentials,
-            self._event_listeners,
-            exhaust)
+        with self._reset_on_error(server.description.address,
+                                  operation.session):
+            return server.send_message_with_response(
+                operation,
+                set_slave_ok,
+                self.__all_credentials,
+                self._event_listeners,
+                exhaust)
 
-    def _reset_on_error(self, server, session, func, *args, **kwargs):
-        """Execute an operation. Reset the server on network error.
+    @contextlib.contextmanager
+    def _reset_on_error(self, server_address, session):
+        """Reset the server according to SDAM errors.
 
-        Returns fn()'s return value on success. On error, clears the server's
-        pool and marks the server Unknown.
-
-        Re-raises any exception thrown by fn().
+        Unpin the session on transient transaction errors.
         """
-        # TODO: refactor this with MongoClient._get_socket
         try:
             try:
-                return func(*args, **kwargs)
+                yield
             except PyMongoError as exc:
                 if session and exc.has_error_label(
                         "TransientTransactionError"):
@@ -1257,9 +1224,26 @@ class MongoClient(common.BaseObject):
                 raise
         except NetworkTimeout:
             # The socket has been closed. Don't reset the server.
+            # Server Discovery And Monitoring Spec: "When an application
+            # operation fails because of any network error besides a socket
+            # timeout...."
+            raise
+        except NotMasterError:
+            # "When the client sees a "not master" error it MUST replace the
+            # server's description with type Unknown. It MUST request an
+            # immediate check of the server."
+            self._reset_server_and_request_check(server_address)
             raise
         except ConnectionFailure:
-            self.__reset_server(server.description.address)
+            # "Client MUST replace the server's description with type Unknown
+            # ... MUST NOT request an immediate check of the server."
+            self.__reset_server(server_address)
+            raise
+        except OperationFailure as exc:
+            if exc.code in helpers._RETRYABLE_ERROR_CODES:
+                # Do not request an immediate check since the server is likely
+                # shutting down.
+                self.__reset_server(server_address)
             raise
 
     def _retry_with_session(self, retryable, func, session, bulk):

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1210,7 +1210,8 @@ class MongoClient(common.BaseObject):
 
     @contextlib.contextmanager
     def _reset_on_error(self, server_address, session):
-        """Reset the server according to SDAM errors.
+        """On "not master" or "node is recovering" errors reset the server
+        according to the SDAM spec.
 
         Unpin the session on transient transaction errors.
         """

--- a/pymongo/network.py
+++ b/pymongo/network.py
@@ -143,7 +143,7 @@ def command(sock, dbname, spec, slave_ok, is_mongos,
 
             response_doc = unpacked_docs[0]
             if client:
-                client._receive_cluster_time(response_doc, session)
+                client._process_response(response_doc, session)
             if check:
                 helpers._check_command_response(
                     response_doc, None, allowable_errors,

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -36,7 +36,8 @@ from pymongo.results import _WriteResult, BulkWriteResult
 from test import unittest, client_context, IntegrationTest, client_knobs
 from test.utils import (camel_to_snake, camel_to_upper_camel,
                         camel_to_snake_args, rs_client, single_client,
-                        wait_until, OvertCommandListener, TestCreator)
+                        wait_until, CompareType, OvertCommandListener,
+                        TestCreator)
 from test.utils_selection_tests import parse_read_preference
 
 # Location of JSON test specifications.
@@ -50,15 +51,6 @@ _TXN_TESTS_DEBUG = os.environ.get('TRANSACTION_TESTS_DEBUG')
 # 50 attempts yields a one in a quadrillion chance of a false positive
 # (1/(0.5^50)).
 UNPIN_TEST_MAX_ATTEMPTS = 50
-
-
-class CompareTrue(object):
-    """Class that compares equal to any object."""
-    def __eq__(self, other):
-        return True
-
-    def __ne__(self, other):
-        return False
 
 
 class TestTransactions(IntegrationTest):
@@ -432,7 +424,7 @@ class TestTransactions(IntegrationTest):
                         expected_read_concern['afterClusterTime'] = actual_time
             recovery_token = expected_cmd.get('recoveryToken')
             if recovery_token == 42:
-                expected_cmd['recoveryToken'] = CompareTrue()
+                expected_cmd['recoveryToken'] = CompareType(dict)
 
             # Replace lsid with a name like "session0" to match test.
             if 'lsid' in event.command:

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -113,6 +113,14 @@ class TestTransactions(IntegrationTest):
         client = clients[session._pinned_address]
         self._set_fail_point(client, fail_point)
 
+    def assert_session_pinned(self, session):
+        """Assert that the given session is pinned."""
+        self.assertIsNotNone(session._pinned_address)
+
+    def assert_session_unpinned(self, session):
+        """Assert that the given session is not pinned."""
+        self.assertIsNone(session._pinned_address)
+
     def kill_all_sessions(self):
         clients = self.mongos_clients if self.mongos_clients else [self.client]
         for client in clients:

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -52,6 +52,15 @@ _TXN_TESTS_DEBUG = os.environ.get('TRANSACTION_TESTS_DEBUG')
 UNPIN_TEST_MAX_ATTEMPTS = 50
 
 
+class CompareTrue(object):
+    """Class that compares equal to any object."""
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+
 class TestTransactions(IntegrationTest):
     @classmethod
     def setUpClass(cls):
@@ -405,6 +414,9 @@ class TestTransactions(IntegrationTest):
                         'readConcern', {}).get('afterClusterTime')
                     if actual_time is not None:
                         expected_read_concern['afterClusterTime'] = actual_time
+            recovery_token = expected_cmd.get('recoveryToken')
+            if recovery_token == 42:
+                expected_cmd['recoveryToken'] = CompareTrue()
 
             # Replace lsid with a name like "session0" to match test.
             if 'lsid' in event.command:

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -115,11 +115,12 @@ class TestTransactions(IntegrationTest):
 
     def assert_session_pinned(self, session):
         """Assert that the given session is pinned."""
-        self.assertIsNotNone(session._pinned_address)
+        self.assertIsNotNone(session._transaction.pinned_address)
 
     def assert_session_unpinned(self, session):
         """Assert that the given session is not pinned."""
         self.assertIsNone(session._pinned_address)
+        self.assertIsNone(session._transaction.pinned_address)
 
     def kill_all_sessions(self):
         clients = self.mongos_clients if self.mongos_clients else [self.client]

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -486,6 +486,8 @@ def end_sessions(sessions):
 
 def create_test(scenario_def, test, name):
     @client_context.require_transactions
+    @client_context.require_cluster_type(
+        test.get('topology', ['single', 'replicaset', 'sharded']))
     def run_scenario(self):
         if test.get('skipReason'):
             raise unittest.SkipTest(test.get('skipReason'))

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -504,7 +504,7 @@ def create_test(scenario_def, test, name):
         # Convert test['clientOptions'] to dict to avoid a Jython bug using
         # "**" with ScenarioDict.
         client_options = dict(test['clientOptions'])
-        use_multi_mongos = client_options.pop('useMultipleMongoses', False)
+        use_multi_mongos = test['useMultipleMongoses']
         if client_context.is_mongos and use_multi_mongos:
             client = rs_client(client_context.mongos_seeds(),
                                event_listeners=[listener], **client_options)

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -497,7 +497,8 @@ def create_test(scenario_def, test, name):
         # Convert test['clientOptions'] to dict to avoid a Jython bug using
         # "**" with ScenarioDict.
         client_options = dict(test['clientOptions'])
-        if client_context.is_mongos and scenario_def['require_multiple_mongoses']:
+        use_multi_mongos = client_options.pop('useMultipleMongoses', False)
+        if client_context.is_mongos and use_multi_mongos:
             client = rs_client(client_context.mongos_seeds(),
                                event_listeners=[listener], **client_options)
         else:

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -494,7 +494,7 @@ def end_sessions(sessions):
 def create_test(scenario_def, test, name):
     @client_context.require_transactions
     @client_context.require_cluster_type(
-        test.get('topology', ['single', 'replicaset', 'sharded']))
+        scenario_def.get('topology', ['single', 'replicaset', 'sharded']))
     def run_scenario(self):
         if test.get('skipReason'):
             raise unittest.SkipTest(test.get('skipReason'))

--- a/test/transactions/abort.json
+++ b/test/transactions/abort.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/bulk.json
+++ b/test/transactions/bulk.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/causal-consistency.json
+++ b/test/transactions/causal-consistency.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [

--- a/test/transactions/commit.json
+++ b/test/transactions/commit.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/commit.json
+++ b/test/transactions/commit.json
@@ -356,7 +356,6 @@
     },
     {
       "description": "write concern error on commit",
-      "skipReason": "SERVER-37458 Mongos does not yet support writeConcern on commit",
       "operations": [
         {
           "name": "startTransaction",

--- a/test/transactions/delete.json
+++ b/test/transactions/delete.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [

--- a/test/transactions/error-labels.json
+++ b/test/transactions/error-labels.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/errors.json
+++ b/test/transactions/errors.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/findOneAndDelete.json
+++ b/test/transactions/findOneAndDelete.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [

--- a/test/transactions/findOneAndReplace.json
+++ b/test/transactions/findOneAndReplace.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [

--- a/test/transactions/findOneAndUpdate.json
+++ b/test/transactions/findOneAndUpdate.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [

--- a/test/transactions/insert.json
+++ b/test/transactions/insert.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/isolation.json
+++ b/test/transactions/isolation.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/mongos-pin-auto.json
+++ b/test/transactions/mongos-pin-auto.json
@@ -63,12 +63,11 @@
             }
           },
           "result": {
-            "errorLabelsContain": [
-              "TransientTransactionError"
-            ],
             "errorLabelsOmit": [
+              "TransientTransactionError",
               "UnknownTransactionCommitResult"
-            ]
+            ],
+            "errorCodeName": "Interrupted"
           }
         },
         {
@@ -159,9 +158,6 @@
             },
             {
               "_id": 3
-            },
-            {
-              "_id": 4
             }
           ]
         }
@@ -316,7 +312,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on insertOne",
+      "description": "remain pinned after non-transient Interrupted error on insertOne insert",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -396,7 +392,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on insertMany",
+      "description": "remain pinned after non-transient Interrupted error on insertMany insert",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -481,7 +477,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on updateOne",
+      "description": "remain pinned after non-transient Interrupted error on updateOne update",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -566,7 +562,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on replaceOne",
+      "description": "remain pinned after non-transient Interrupted error on replaceOne update",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -649,7 +645,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on updateMany",
+      "description": "remain pinned after non-transient Interrupted error on updateMany update",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -736,7 +732,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on deleteOne",
+      "description": "remain pinned after non-transient Interrupted error on deleteOne delete",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -816,7 +812,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on deleteMany",
+      "description": "remain pinned after non-transient Interrupted error on deleteMany delete",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -898,7 +894,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on findOneAndDelete",
+      "description": "remain pinned after non-transient Interrupted error on findOneAndDelete findAndModify",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -978,7 +974,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on findOneAndUpdate",
+      "description": "remain pinned after non-transient Interrupted error on findOneAndUpdate findAndModify",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1064,7 +1060,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on findOneAndReplace",
+      "description": "remain pinned after non-transient Interrupted error on findOneAndReplace findAndModify",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1148,7 +1144,186 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on bulkWrite",
+      "description": "remain pinned after non-transient Interrupted error on bulkWrite insert",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on bulkWrite update",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on bulkWrite delete",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1235,7 +1410,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on find",
+      "description": "remain pinned after non-transient Interrupted error on find find",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1315,7 +1490,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on countDocuments",
+      "description": "remain pinned after non-transient Interrupted error on countDocuments aggregate",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1393,7 +1568,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on aggregate",
+      "description": "remain pinned after non-transient Interrupted error on aggregate aggregate",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1471,7 +1646,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on distinct",
+      "description": "remain pinned after non-transient Interrupted error on distinct distinct",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1549,7 +1724,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on runCommand",
+      "description": "remain pinned after non-transient Interrupted error on runCommand insert",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1635,7 +1810,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on insertOne",
+      "description": "unpin after transient connection error on insertOne insert",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1715,7 +1890,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on insertOne",
+      "description": "unpin after transient ShutdownInProgress error on insertOne insert",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1795,7 +1970,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on insertMany",
+      "description": "unpin after transient connection error on insertMany insert",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1880,7 +2055,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on insertMany",
+      "description": "unpin after transient ShutdownInProgress error on insertMany insert",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1965,7 +2140,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on updateOne",
+      "description": "unpin after transient connection error on updateOne update",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2050,7 +2225,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on updateOne",
+      "description": "unpin after transient ShutdownInProgress error on updateOne update",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2135,7 +2310,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on replaceOne",
+      "description": "unpin after transient connection error on replaceOne update",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2218,7 +2393,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on replaceOne",
+      "description": "unpin after transient ShutdownInProgress error on replaceOne update",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2301,7 +2476,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on updateMany",
+      "description": "unpin after transient connection error on updateMany update",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2388,7 +2563,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on updateMany",
+      "description": "unpin after transient ShutdownInProgress error on updateMany update",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2475,7 +2650,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on deleteOne",
+      "description": "unpin after transient connection error on deleteOne delete",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2555,7 +2730,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on deleteOne",
+      "description": "unpin after transient ShutdownInProgress error on deleteOne delete",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2635,7 +2810,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on deleteMany",
+      "description": "unpin after transient connection error on deleteMany delete",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2717,7 +2892,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on deleteMany",
+      "description": "unpin after transient ShutdownInProgress error on deleteMany delete",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2799,7 +2974,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on findOneAndDelete",
+      "description": "unpin after transient connection error on findOneAndDelete findAndModify",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2879,7 +3054,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on findOneAndDelete",
+      "description": "unpin after transient ShutdownInProgress error on findOneAndDelete findAndModify",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -2959,7 +3134,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on findOneAndUpdate",
+      "description": "unpin after transient connection error on findOneAndUpdate findAndModify",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3045,7 +3220,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on findOneAndUpdate",
+      "description": "unpin after transient ShutdownInProgress error on findOneAndUpdate findAndModify",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3131,7 +3306,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on findOneAndReplace",
+      "description": "unpin after transient connection error on findOneAndReplace findAndModify",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3215,7 +3390,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on findOneAndReplace",
+      "description": "unpin after transient ShutdownInProgress error on findOneAndReplace findAndModify",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3299,7 +3474,365 @@
       }
     },
     {
-      "description": "unpin after transient connection error on bulkWrite",
+      "description": "unpin after transient connection error on bulkWrite insert",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on bulkWrite insert",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on bulkWrite update",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on bulkWrite update",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on bulkWrite delete",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3386,7 +3919,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on bulkWrite",
+      "description": "unpin after transient ShutdownInProgress error on bulkWrite delete",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3473,7 +4006,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on find",
+      "description": "unpin after transient connection error on find find",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3553,7 +4086,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on find",
+      "description": "unpin after transient ShutdownInProgress error on find find",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3633,7 +4166,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on countDocuments",
+      "description": "unpin after transient connection error on countDocuments aggregate",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3711,7 +4244,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on countDocuments",
+      "description": "unpin after transient ShutdownInProgress error on countDocuments aggregate",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3789,7 +4322,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on aggregate",
+      "description": "unpin after transient connection error on aggregate aggregate",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3867,7 +4400,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on aggregate",
+      "description": "unpin after transient ShutdownInProgress error on aggregate aggregate",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3945,7 +4478,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on distinct",
+      "description": "unpin after transient connection error on distinct distinct",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -4023,7 +4556,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on distinct",
+      "description": "unpin after transient ShutdownInProgress error on distinct distinct",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -4101,7 +4634,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on runCommand",
+      "description": "unpin after transient connection error on runCommand insert",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -4187,7 +4720,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on runCommand",
+      "description": "unpin after transient ShutdownInProgress error on runCommand insert",
       "useMultipleMongoses": true,
       "operations": [
         {

--- a/test/transactions/mongos-pin-auto.json
+++ b/test/transactions/mongos-pin-auto.json
@@ -1315,7 +1315,7 @@
       }
     },
     {
-      "description": "remain pinned after non-transient Interrupted error on count",
+      "description": "remain pinned after non-transient Interrupted error on countDocuments",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1347,7 +1347,7 @@
               },
               "data": {
                 "failCommands": [
-                  "count"
+                  "aggregate"
                 ],
                 "errorCode": 11601
               }
@@ -1355,13 +1355,11 @@
           }
         },
         {
-          "name": "count",
+          "name": "countDocuments",
           "object": "collection",
           "arguments": {
             "session": "session0",
-            "filter": {
-              "_id": 1
-            }
+            "filter": {}
           },
           "result": {
             "errorLabelsOmit": [
@@ -3635,7 +3633,7 @@
       }
     },
     {
-      "description": "unpin after transient connection error on count",
+      "description": "unpin after transient connection error on countDocuments",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3667,7 +3665,7 @@
               },
               "data": {
                 "failCommands": [
-                  "count"
+                  "aggregate"
                 ],
                 "closeConnection": true
               }
@@ -3675,13 +3673,11 @@
           }
         },
         {
-          "name": "count",
+          "name": "countDocuments",
           "object": "collection",
           "arguments": {
             "session": "session0",
-            "filter": {
-              "_id": 1
-            }
+            "filter": {}
           },
           "result": {
             "errorLabelsContain": [
@@ -3715,7 +3711,7 @@
       }
     },
     {
-      "description": "unpin after transient ShutdownInProgress error on count",
+      "description": "unpin after transient ShutdownInProgress error on countDocuments",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -3747,7 +3743,7 @@
               },
               "data": {
                 "failCommands": [
-                  "count"
+                  "aggregate"
                 ],
                 "errorCode": 91
               }
@@ -3755,13 +3751,11 @@
           }
         },
         {
-          "name": "count",
+          "name": "countDocuments",
           "object": "collection",
           "arguments": {
             "session": "session0",
-            "filter": {
-              "_id": 1
-            }
+            "filter": {}
           },
           "result": {
             "errorLabelsContain": [

--- a/test/transactions/mongos-pin-auto.json
+++ b/test/transactions/mongos-pin-auto.json
@@ -1,0 +1,4282 @@
+{
+  "topology": [
+    "sharded"
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "remain pinned after non-transient Interrupted error on insertOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 4
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null,
+              "recoveryToken": 42
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient error within a transaction",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 4
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null,
+              "recoveryToken": 42
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on insertOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on insertMany",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "documents": [
+              {
+                "_id": 4
+              },
+              {
+                "_id": 5
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on updateOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on replaceOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "y": 1
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on updateMany",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 1
+              }
+            },
+            "update": {
+              "$set": {
+                "z": 1
+              }
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on deleteOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "deleteOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on deleteMany",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "deleteMany",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 1
+              }
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on findOneAndDelete",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "findAndModify"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndDelete",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on findOneAndUpdate",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "findAndModify"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on findOneAndReplace",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "findAndModify"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndReplace",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "y": 1
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on bulkWrite",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on find",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on count",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "count"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on aggregate",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "aggregate"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "pipeline": []
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on distinct",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "distinct"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "fieldName": "_id"
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient Interrupted error on runCommand",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "command_name": "insert",
+          "arguments": {
+            "session": "session0",
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on insertOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on insertOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on insertMany",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "documents": [
+              {
+                "_id": 4
+              },
+              {
+                "_id": 5
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on insertMany",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "documents": [
+              {
+                "_id": 4
+              },
+              {
+                "_id": 5
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on updateOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on updateOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on replaceOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "y": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on replaceOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "y": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on updateMany",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 1
+              }
+            },
+            "update": {
+              "$set": {
+                "z": 1
+              }
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on updateMany",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 1
+              }
+            },
+            "update": {
+              "$set": {
+                "z": 1
+              }
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on deleteOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "deleteOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on deleteOne",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "deleteOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on deleteMany",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "deleteMany",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 1
+              }
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on deleteMany",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "deleteMany",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 1
+              }
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on findOneAndDelete",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "findAndModify"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndDelete",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on findOneAndDelete",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "findAndModify"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndDelete",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on findOneAndUpdate",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "findAndModify"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on findOneAndUpdate",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "findAndModify"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on findOneAndReplace",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "findAndModify"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndReplace",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "y": 1
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on findOneAndReplace",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "findAndModify"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndReplace",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "y": 1
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on bulkWrite",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on bulkWrite",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on find",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on find",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on count",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "count"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on count",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "count"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on aggregate",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "aggregate"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "pipeline": []
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on aggregate",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "aggregate"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "pipeline": []
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on distinct",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "distinct"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "fieldName": "_id"
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on distinct",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "distinct"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "fieldName": "_id"
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient connection error on runCommand",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "command_name": "insert",
+          "arguments": {
+            "session": "session0",
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient ShutdownInProgress error on runCommand",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "command_name": "insert",
+          "arguments": {
+            "session": "session0",
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/transactions/mongos-pin-auto.json
+++ b/test/transactions/mongos-pin-auto.json
@@ -295,7 +295,7 @@
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null,
-              "recoveryToken": 42
+              "recoveryToken": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/test/transactions/mongos-recovery-token.json
+++ b/test/transactions/mongos-recovery-token.json
@@ -1,11 +1,16 @@
 {
-  "require_multiple_mongoses": true,
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],
   "tests": [
     {
       "description": "commitTransaction explicit retries succeed on new mongos",
+      "topology": [
+        "sharded"
+      ],
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -179,6 +184,12 @@
     },
     {
       "description": "commitTransaction retry succeeds on new mongos",
+      "topology": [
+        "sharded"
+      ],
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -304,6 +315,12 @@
     },
     {
       "description": "commitTransaction retry fails on new mongos",
+      "topology": [
+        "sharded"
+      ],
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -422,6 +439,12 @@
     },
     {
       "description": "abortTransaction sends recoveryToken",
+      "topology": [
+        "sharded"
+      ],
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",

--- a/test/transactions/mongos-recovery-token.json
+++ b/test/transactions/mongos-recovery-token.json
@@ -1,0 +1,519 @@
+{
+  "require_multiple_mongoses": true,
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "commitTransaction explicit retries succeed on new mongos",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction retry succeeds on new mongos",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "writeConcern": {
+                "w": "majority"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "failPoint",
+          "session": "session0",
+          "failPoint": {
+            "configureFailPoint": "failCommand",
+            "mode": {
+              "times": 1
+            },
+            "data": {
+              "failCommands": [
+                "commitTransaction"
+              ],
+              "writeConcernError": {
+                "code": 91,
+                "errmsg": "Replication is being shut down"
+              }
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction retry fails on new mongos",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "failPoint",
+          "session": "session0",
+          "failPoint": {
+            "configureFailPoint": "failCommand",
+            "mode": {
+              "times": 1
+            },
+            "data": {
+              "failCommands": [
+                "commitTransaction"
+              ],
+              "closeConnection": true
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorCodeName": "NoSuchTransaction"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "abortTransaction sends recoveryToken",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "failPoint",
+          "session": "session0",
+          "failPoint": {
+            "configureFailPoint": "failCommand",
+            "mode": {
+              "times": 1
+            },
+            "data": {
+              "failCommands": [
+                "abortTransaction"
+              ],
+              "closeConnection": true
+            }
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/test/transactions/mongos-recovery-token.json
+++ b/test/transactions/mongos-recovery-token.json
@@ -79,7 +79,8 @@
               },
               "startTransaction": null,
               "autocommit": false,
-              "writeConcern": null
+              "writeConcern": null,
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -98,7 +99,8 @@
               "writeConcern": {
                 "w": "majority",
                 "wtimeout": 10000
-              }
+              },
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -117,7 +119,8 @@
               "writeConcern": {
                 "w": "majority",
                 "wtimeout": 10000
-              }
+              },
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -136,7 +139,8 @@
               "writeConcern": {
                 "w": "majority",
                 "wtimeout": 10000
-              }
+              },
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -155,7 +159,8 @@
               "writeConcern": {
                 "w": "majority",
                 "wtimeout": 10000
-              }
+              },
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -259,7 +264,8 @@
               "autocommit": false,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -278,7 +284,8 @@
               "writeConcern": {
                 "w": "majority",
                 "wtimeout": 10000
-              }
+              },
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -379,7 +386,8 @@
               },
               "startTransaction": null,
               "autocommit": false,
-              "writeConcern": null
+              "writeConcern": null,
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -398,7 +406,8 @@
               "writeConcern": {
                 "w": "majority",
                 "wtimeout": 10000
-              }
+              },
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -486,7 +495,8 @@
               },
               "startTransaction": null,
               "autocommit": false,
-              "writeConcern": null
+              "writeConcern": null,
+              "recoveryToken": 42
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -502,7 +512,8 @@
               },
               "startTransaction": null,
               "autocommit": false,
-              "writeConcern": null
+              "writeConcern": null,
+              "recoveryToken": 42
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/test/transactions/mongos-recovery-token.json
+++ b/test/transactions/mongos-recovery-token.json
@@ -4,7 +4,7 @@
   "data": [],
   "tests": [
     {
-      "description": "commitTransaction explicit retries succeed on new mongos",
+      "description": "commitTransaction explicit retries succeed",
       "topology": [
         "sharded"
       ],
@@ -216,20 +216,23 @@
           }
         },
         {
-          "name": "failPoint",
-          "session": "session0",
-          "failPoint": {
-            "configureFailPoint": "failCommand",
-            "mode": {
-              "times": 1
-            },
-            "data": {
-              "failCommands": [
-                "commitTransaction"
-              ],
-              "writeConcernError": {
-                "code": 91,
-                "errmsg": "Replication is being shut down"
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
               }
             }
           }
@@ -319,7 +322,8 @@
         "sharded"
       ],
       "clientOptions": {
-        "useMultipleMongoses": true
+        "useMultipleMongoses": true,
+        "heartbeatFrequencyMS": 5000
       },
       "operations": [
         {
@@ -340,18 +344,22 @@
           }
         },
         {
-          "name": "failPoint",
-          "session": "session0",
-          "failPoint": {
-            "configureFailPoint": "failCommand",
-            "mode": {
-              "times": 1
-            },
-            "data": {
-              "failCommands": [
-                "commitTransaction"
-              ],
-              "closeConnection": true
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 7
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction",
+                  "isMaster"
+                ],
+                "closeConnection": true
+              }
             }
           }
         },
@@ -464,18 +472,21 @@
           }
         },
         {
-          "name": "failPoint",
-          "session": "session0",
-          "failPoint": {
-            "configureFailPoint": "failCommand",
-            "mode": {
-              "times": 1
-            },
-            "data": {
-              "failCommands": [
-                "abortTransaction"
-              ],
-              "closeConnection": true
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "closeConnection": true
+              }
             }
           }
         },

--- a/test/transactions/mongos-recovery-token.json
+++ b/test/transactions/mongos-recovery-token.json
@@ -388,7 +388,7 @@
       }
     },
     {
-      "description": "abortTransaction sends recoveryToken",
+      "description": "abortTransaction does not send recoveryToken",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -467,7 +467,7 @@
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null,
-              "recoveryToken": 42
+              "recoveryToken": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -484,7 +484,7 @@
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null,
-              "recoveryToken": 42
+              "recoveryToken": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/test/transactions/mongos-recovery-token.json
+++ b/test/transactions/mongos-recovery-token.json
@@ -1,13 +1,13 @@
 {
+  "topology": [
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],
   "tests": [
     {
       "description": "commitTransaction explicit retries succeed",
-      "topology": [
-        "sharded"
-      ],
       "clientOptions": {
         "useMultipleMongoses": true
       },
@@ -184,9 +184,6 @@
     },
     {
       "description": "commitTransaction retry succeeds on new mongos",
-      "topology": [
-        "sharded"
-      ],
       "clientOptions": {
         "useMultipleMongoses": true
       },
@@ -318,9 +315,6 @@
     },
     {
       "description": "commitTransaction retry fails on new mongos",
-      "topology": [
-        "sharded"
-      ],
       "clientOptions": {
         "useMultipleMongoses": true,
         "heartbeatFrequencyMS": 5000
@@ -447,9 +441,6 @@
     },
     {
       "description": "abortTransaction sends recoveryToken",
-      "topology": [
-        "sharded"
-      ],
       "clientOptions": {
         "useMultipleMongoses": true
       },

--- a/test/transactions/mongos-recovery-token.json
+++ b/test/transactions/mongos-recovery-token.json
@@ -7,7 +7,7 @@
   "data": [],
   "tests": [
     {
-      "description": "commitTransaction explicit retries succeed",
+      "description": "commitTransaction explicit retries include recoveryToken",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -26,14 +26,6 @@
           "result": {
             "insertedId": 1
           }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session0"
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session0"
         },
         {
           "name": "commitTransaction",
@@ -83,46 +75,6 @@
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null,
-              "recoveryToken": 42
-            },
-            "command_name": "commitTransaction",
-            "database_name": "admin"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "commitTransaction": 1,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": null,
-              "autocommit": false,
-              "writeConcern": {
-                "w": "majority",
-                "wtimeout": 10000
-              },
-              "recoveryToken": 42
-            },
-            "command_name": "commitTransaction",
-            "database_name": "admin"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "commitTransaction": 1,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": null,
-              "autocommit": false,
-              "writeConcern": {
-                "w": "majority",
-                "wtimeout": 10000
-              },
               "recoveryToken": 42
             },
             "command_name": "commitTransaction",

--- a/test/transactions/mongos-recovery-token.json
+++ b/test/transactions/mongos-recovery-token.json
@@ -8,9 +8,7 @@
   "tests": [
     {
       "description": "commitTransaction explicit retries succeed",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",
@@ -184,9 +182,7 @@
     },
     {
       "description": "commitTransaction retry succeeds on new mongos",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",
@@ -315,8 +311,8 @@
     },
     {
       "description": "commitTransaction retry fails on new mongos",
+      "useMultipleMongoses": true,
       "clientOptions": {
-        "useMultipleMongoses": true,
         "heartbeatFrequencyMS": 5000
       },
       "operations": [
@@ -441,9 +437,7 @@
     },
     {
       "description": "abortTransaction sends recoveryToken",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",

--- a/test/transactions/pin-mongos.json
+++ b/test/transactions/pin-mongos.json
@@ -740,8 +740,22 @@
           }
         },
         {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
           "name": "commitTransaction",
           "object": "session0"
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
         },
         {
           "name": "commitTransaction",
@@ -778,6 +792,116 @@
         {
           "name": "commitTransaction",
           "object": "session0"
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after non-transient error on commit",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ],
+            "session": "session0"
+          },
+          "result": {
+            "insertedIds": {
+              "0": 3,
+              "1": 4
+            }
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction"
+                ],
+                "errorCode": 50
+              }
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ],
+            "errorCode": 50
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
         }
       ],
       "outcome": {

--- a/test/transactions/pin-mongos.json
+++ b/test/transactions/pin-mongos.json
@@ -809,7 +809,7 @@
       }
     },
     {
-      "description": "remain pinned after errors within a transaction and commit",
+      "description": "remain pinned after errors within a transaction",
       "topology": [
         "sharded"
       ],
@@ -835,18 +835,21 @@
           }
         },
         {
-          "name": "failPoint",
-          "session": "session0",
-          "failPoint": {
-            "configureFailPoint": "failCommand",
-            "mode": {
-              "times": 1
-            },
-            "data": {
-              "failCommands": [
-                "insert"
-              ],
-              "closeConnection": true
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
             }
           }
         },
@@ -981,18 +984,21 @@
           }
         },
         {
-          "name": "failPoint",
-          "session": "session0",
-          "failPoint": {
-            "configureFailPoint": "failCommand",
-            "mode": {
-              "times": 1
-            },
-            "data": {
-              "failCommands": [
-                "insert"
-              ],
-              "closeConnection": true
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
             }
           }
         },

--- a/test/transactions/pin-mongos.json
+++ b/test/transactions/pin-mongos.json
@@ -1,5 +1,4 @@
 {
-  "require_multiple_mongoses": true,
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [
@@ -13,6 +12,9 @@
   "tests": [
     {
       "description": "countDocuments",
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -126,6 +128,9 @@
     },
     {
       "description": "distinct",
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -247,6 +252,9 @@
     },
     {
       "description": "find",
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -392,6 +400,9 @@
     },
     {
       "description": "insertOne",
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -545,6 +556,9 @@
     },
     {
       "description": "mixed read write operations",
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -705,6 +719,9 @@
     },
     {
       "description": "multiple commits",
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -793,6 +810,12 @@
     },
     {
       "description": "remain pinned after errors within a transaction and commit",
+      "topology": [
+        "sharded"
+      ],
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -907,7 +930,8 @@
               },
               "startTransaction": null,
               "autocommit": false,
-              "writeConcern": null
+              "writeConcern": null,
+              "recoveryToken": 42
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -932,6 +956,12 @@
     },
     {
       "description": "remain pinned after errors within a transaction and abort",
+      "topology": [
+        "sharded"
+      ],
+      "clientOptions": {
+        "useMultipleMongoses": true
+      },
       "operations": [
         {
           "name": "startTransaction",
@@ -1046,7 +1076,8 @@
               },
               "startTransaction": null,
               "autocommit": false,
-              "writeConcern": null
+              "writeConcern": null,
+              "recoveryToken": 42
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/test/transactions/pin-mongos.json
+++ b/test/transactions/pin-mongos.json
@@ -920,7 +920,7 @@
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null,
-              "recoveryToken": 42
+              "recoveryToken": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/test/transactions/pin-mongos.json
+++ b/test/transactions/pin-mongos.json
@@ -1,4 +1,7 @@
 {
+  "topology": [
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [
@@ -810,9 +813,6 @@
     },
     {
       "description": "remain pinned after errors within a transaction",
-      "topology": [
-        "sharded"
-      ],
       "clientOptions": {
         "useMultipleMongoses": true
       },
@@ -959,9 +959,6 @@
     },
     {
       "description": "remain pinned after errors within a transaction and abort",
-      "topology": [
-        "sharded"
-      ],
       "clientOptions": {
         "useMultipleMongoses": true
       },

--- a/test/transactions/pin-mongos.json
+++ b/test/transactions/pin-mongos.json
@@ -790,6 +790,281 @@
           ]
         }
       }
+    },
+    {
+      "description": "remain pinned after errors within a transaction and commit",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "failPoint",
+          "session": "session0",
+          "failPoint": {
+            "configureFailPoint": "failCommand",
+            "mode": {
+              "times": 1
+            },
+            "data": {
+              "failCommands": [
+                "insert"
+              ],
+              "closeConnection": true
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 4
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "remain pinned after errors within a transaction and abort",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "failPoint",
+          "session": "session0",
+          "failPoint": {
+            "configureFailPoint": "failCommand",
+            "mode": {
+              "times": 1
+            },
+            "data": {
+              "failCommands": [
+                "insert"
+              ],
+              "closeConnection": true
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 4
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/transactions/pin-mongos.json
+++ b/test/transactions/pin-mongos.json
@@ -15,9 +15,7 @@
   "tests": [
     {
       "description": "countDocuments",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",
@@ -131,9 +129,7 @@
     },
     {
       "description": "distinct",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",
@@ -255,9 +251,7 @@
     },
     {
       "description": "find",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",
@@ -403,9 +397,7 @@
     },
     {
       "description": "insertOne",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",
@@ -559,9 +551,7 @@
     },
     {
       "description": "mixed read write operations",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",
@@ -722,9 +712,7 @@
     },
     {
       "description": "multiple commits",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",
@@ -813,9 +801,7 @@
     },
     {
       "description": "remain pinned after errors within a transaction",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",
@@ -959,9 +945,7 @@
     },
     {
       "description": "remain pinned after errors within a transaction and abort",
-      "clientOptions": {
-        "useMultipleMongoses": true
-      },
+      "useMultipleMongoses": true,
       "operations": [
         {
           "name": "startTransaction",

--- a/test/transactions/pin-mongos.json
+++ b/test/transactions/pin-mongos.json
@@ -800,151 +800,7 @@
       }
     },
     {
-      "description": "remain pinned after errors within a transaction",
-      "useMultipleMongoses": true,
-      "operations": [
-        {
-          "name": "startTransaction",
-          "object": "session0"
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session0",
-            "document": {
-              "_id": 3
-            }
-          },
-          "result": {
-            "insertedId": 3
-          }
-        },
-        {
-          "name": "targetedFailPoint",
-          "object": "testRunner",
-          "arguments": {
-            "session": "session0",
-            "failPoint": {
-              "configureFailPoint": "failCommand",
-              "mode": {
-                "times": 1
-              },
-              "data": {
-                "failCommands": [
-                  "insert"
-                ],
-                "closeConnection": true
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session0",
-            "document": {
-              "_id": 4
-            }
-          },
-          "result": {
-            "errorLabelsContain": [
-              "TransientTransactionError"
-            ],
-            "errorLabelsOmit": [
-              "UnknownTransactionCommitResult"
-            ]
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session0"
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "test",
-              "documents": [
-                {
-                  "_id": 3
-                }
-              ],
-              "ordered": true,
-              "readConcern": null,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": true,
-              "autocommit": false,
-              "writeConcern": null
-            },
-            "command_name": "insert",
-            "database_name": "transaction-tests"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "test",
-              "documents": [
-                {
-                  "_id": 4
-                }
-              ],
-              "ordered": true,
-              "readConcern": null,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": null,
-              "autocommit": false,
-              "writeConcern": null
-            },
-            "command_name": "insert",
-            "database_name": "transaction-tests"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "commitTransaction": 1,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": null,
-              "autocommit": false,
-              "writeConcern": null,
-              "recoveryToken": 42
-            },
-            "command_name": "commitTransaction",
-            "database_name": "admin"
-          }
-        }
-      ],
-      "outcome": {
-        "collection": {
-          "data": [
-            {
-              "_id": 1
-            },
-            {
-              "_id": 2
-            },
-            {
-              "_id": 3
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "remain pinned after errors within a transaction and abort",
+      "description": "unpin after transient error within a transaction",
       "useMultipleMongoses": true,
       "operations": [
         {
@@ -1067,6 +923,160 @@
               "recoveryToken": 42
             },
             "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unpin after transient error within a transaction and commit",
+      "useMultipleMongoses": true,
+      "clientOptions": {
+        "heartbeatFrequencyMS": 5000
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 7
+              },
+              "data": {
+                "failCommands": [
+                  "insert",
+                  "isMaster"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorCodeName": "NoSuchTransaction"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 4
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null,
+              "recoveryToken": 42
+            },
+            "command_name": "commitTransaction",
             "database_name": "admin"
           }
         }

--- a/test/transactions/pin-mongos.json
+++ b/test/transactions/pin-mongos.json
@@ -1,4 +1,5 @@
 {
+  "require_multiple_mongoses": true,
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [

--- a/test/transactions/read-concern.json
+++ b/test/transactions/read-concern.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [

--- a/test/transactions/read-pref.json
+++ b/test/transactions/read-pref.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/reads.json
+++ b/test/transactions/reads.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [

--- a/test/transactions/retryable-abort.json
+++ b/test/transactions/retryable-abort.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/retryable-commit.json
+++ b/test/transactions/retryable-commit.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/retryable-writes.json
+++ b/test/transactions/retryable-writes.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/run-command.json
+++ b/test/transactions/run-command.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/transaction-options.json
+++ b/test/transactions/transaction-options.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/transactions/update.json
+++ b/test/transactions/update.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [

--- a/test/transactions/write-concern.json
+++ b/test/transactions/write-concern.json
@@ -1,4 +1,8 @@
 {
+  "topology": [
+    "replicaset",
+    "sharded"
+  ],
   "database_name": "transaction-tests",
   "collection_name": "test",
   "data": [],

--- a/test/utils.py
+++ b/test/utils.py
@@ -147,6 +147,19 @@ class ScenarioDict(dict):
             return ScenarioDict({})
 
 
+class CompareType(object):
+    """Class that compares equal to any object of the given type."""
+    def __init__(self, type):
+        self.type = type
+
+    def __eq__(self, other):
+        return isinstance(other, self.type)
+
+    def __ne__(self, other):
+        """Needed for Python 2."""
+        return not self.__eq__(other)
+
+
 class TestCreator(object):
     """Class to create test cases from specifications."""
     def __init__(self, create_test, test_class, test_path):


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYTHON-1684

This change implements sharded transaction support and testing for MongoDB 4.2 according to [SPEC-1168](https://jira.mongodb.org/browse/SPEC-1168).

In summary:
- sharded transactions have the same API as replica set transactions.
- On the first operation within a sharded transaction, the session is pinned to the selected mongos and all* subsequent operations are routed to the same server.
- When any command within a sharded transaction fails with a transient error, the session is unpinned so that a subsequent `abortTransaction` can complete immediately without waiting for a potentially unreachable mongos.
- The `recoveryToken` field is updated on each command response and sent along with all `commitTransaction` attempts.

To accomplish these goals, these changes refactor how Cursor/CommandCursor decode responses so that a command failure from a `find` or `getMore` can reset the server and unpin the session.