### PR TITLE
PYTHON-1579: Allow unencoded sub-delimiters in usernames and passwords

### DIFF
--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -26,9 +26,9 @@ except ImportError:
 from bson.py3compat import abc, iteritems, string_type, PY3
 
 if PY3:
-    from urllib.parse import quote, quote_plus, unquote, unquote_plus
+    from urllib.parse import quote_plus, unquote, unquote_plus
 else:
-    from urllib import quote, quote_plus, unquote, unquote_plus
+    from urllib import quote_plus, unquote, unquote_plus
 
 from pymongo.common import (
     get_validated_options, URI_OPTIONS_DEPRECATION_MAP, INTERNAL_URI_OPTION_NAME_MAP)

--- a/test/connection_string/test/invalid-uris.json
+++ b/test/connection_string/test/invalid-uris.json
@@ -190,15 +190,6 @@
       "options": null
     },
     {
-      "description": "Username with password containing an unescaped colon",
-      "uri": "mongodb://alice:foo:bar@127.0.0.1",
-      "valid": false,
-      "warning": null,
-      "hosts": null,
-      "auth": null,
-      "options": null
-    },
-    {
       "description": "Username containing an unescaped at-sign",
       "uri": "mongodb://alice@@127.0.0.1",
       "valid": false,
@@ -246,6 +237,33 @@
     {
       "description": "Host with unescaped slash",
       "uri": "mongodb:///tmp/mongodb-27017.sock/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "mongodb+srv with multiple service names",
+      "uri": "mongodb+srv://test5.test.mongodb.com,test6.test.mongodb.com",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "mongodb+srv with port number",
+      "uri": "mongodb+srv://test7.test.mongodb.com:27018",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped percent sign",
+      "uri": "mongodb://alice%foo:bar@127.0.0.1",
       "valid": false,
       "warning": null,
       "hosts": null,

--- a/test/connection_string/test/valid-auth.json
+++ b/test/connection_string/test/valid-auth.json
@@ -241,6 +241,27 @@
       }
     },
     {
+      "description": "Subdelimiters in user/pass don't need escaping (MONGODB-CR)",
+      "uri": "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=MONGODB-CR",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "!$&'()*+,;=",
+        "password": "!$&'()*+,;=",
+        "db": "admin"
+      },
+      "options": {
+        "authmechanism": "MONGODB-CR"
+      }
+    },
+    {
       "description": "Escaped username (MONGODB-X509)",
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509",
       "valid": true,

--- a/test/connection_string/test/valid-host_identifiers.json
+++ b/test/connection_string/test/valid-host_identifiers.json
@@ -132,18 +132,18 @@
     },
     {
       "description": "UTF-8 hosts",
-      "uri": "mongodb://b\u00fccher.example.com,uml\u00e4ut.example.com/",
+      "uri": "mongodb://bücher.example.com,umläut.example.com/",
       "valid": true,
       "warning": false,
       "hosts": [
         {
           "type": "hostname",
-          "host": "b\u00fccher.example.com",
+          "host": "bücher.example.com",
           "port": null
         },
         {
           "type": "hostname",
-          "host": "uml\u00e4ut.example.com",
+          "host": "umläut.example.com",
           "port": null
         }
       ],

--- a/test/test_uri_spec.py
+++ b/test/test_uri_spec.py
@@ -63,9 +63,6 @@ def run_scenario_in_dir(target_workdir):
 
 def create_test(test, test_workdir):
     def run_scenario(self):
-        # if test['description'].startswith('Subdelimiters'):
-        #     import ipdb; ipdb.set_trace()
-
         compressors = (test.get('options') or {}).get('compressors', [])
         if 'snappy' in compressors and not _HAVE_SNAPPY:
             self.skipTest('This test needs the snappy module.')

--- a/test/test_uri_spec.py
+++ b/test/test_uri_spec.py
@@ -63,6 +63,9 @@ def run_scenario_in_dir(target_workdir):
 
 def create_test(test, test_workdir):
     def run_scenario(self):
+        # if test['description'].startswith('Subdelimiters'):
+        #     import ipdb; ipdb.set_trace()
+
         compressors = (test.get('options') or {}).get('compressors', [])
         if 'snappy' in compressors and not _HAVE_SNAPPY:
             self.skipTest('This test needs the snappy module.')


### PR DESCRIPTION
Closes [PYTHON-1579](https://jira.mongodb.org/browse/PYTHON-1579). 