### PR TITLE
PYTHON-1721 Improve GridFS file download performance

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -59,6 +59,13 @@ Changes in Version 3.8.0.dev0
 
 - :class:`~bson.objectid.ObjectId` now implements the `ObjectID specification
   version 0.2 <https://github.com/mongodb/specifications/blob/master/source/objectid.rst>`_.
+- For better performance and to better follow the GridFS spec,
+  :class:`~gridfs.grid_file.GridOut` now uses a single cursor to read all the
+  chunks in the file. Previously, each chunk in the file was queried
+  individually using :meth:`~pymongo.collection.Collection.find_one`.
+- :meth:`gridfs.grid_file.GridOut.read` now only checks for extra chunks after
+  reading the entire file. Previously, this method would check for extra
+  chunks on every call.
 
 Issues Resolved
 ...............

--- a/gridfs/__init__.py
+++ b/gridfs/__init__.py
@@ -715,9 +715,9 @@ class GridFSBucket(object):
         .. versionchanged:: 3.6
            Added ``session`` parameter.
         """
-        gout = self.open_download_stream(file_id, session=session)
-        for chunk in gout:
-            destination.write(chunk)
+        with self.open_download_stream(file_id, session=session) as gout:
+            for chunk in gout:
+                destination.write(chunk)
 
     def delete(self, file_id, session=None):
         """Given an file_id, delete this stored file's files collection document
@@ -890,10 +890,10 @@ class GridFSBucket(object):
         .. versionchanged:: 3.6
            Added ``session`` parameter.
         """
-        gout = self.open_download_stream_by_name(
-            filename, revision, session=session)
-        for chunk in gout:
-            destination.write(chunk)
+        with self.open_download_stream_by_name(
+                filename, revision, session=session) as gout:
+            for chunk in gout:
+                destination.write(chunk)
 
     def rename(self, file_id, new_filename, session=None):
         """Renames the stored file with the specified file_id.

--- a/gridfs/grid_file.py
+++ b/gridfs/grid_file.py
@@ -518,25 +518,12 @@ class GridOut(object):
             received += len(chunk_data)
             data.write(chunk_data)
 
-        # TODO: Great, but why do we do this on EVERY call to read()?
-        # Detect extra chunks.
+        # Detect extra chunks after reading the entire file.
         if size == remainder and self.__chunk_iter:
-            # Optimization: Reading the rest of the file so we can reuse the
-            # cursor to find extra chunks
             try:
                 self.__chunk_iter.next()
             except StopIteration:
                 pass
-        else:
-            num_chunks = math.ceil(int(self.length) / float(self.chunk_size))
-            chunk = self.__chunks.find_one({"files_id": self._id,
-                                            "n": {"$gte": num_chunks}},
-                                           session=self._session)
-            # According to spec, ignore extra chunks if they are empty.
-            if chunk is not None and len(chunk['data']):
-                raise CorruptGridFile(
-                    "Extra chunk found: expected %d chunks but found "
-                    "chunk with n=%d" % (num_chunks, chunk['n']))
 
         self.__position -= received - size
 

--- a/gridfs/grid_file.py
+++ b/gridfs/grid_file.py
@@ -539,8 +539,8 @@ class GridOut(object):
             # According to spec, ignore extra chunks if they are empty.
             if chunk is not None and len(chunk['data']):
                 raise CorruptGridFile(
-                    "Extra chunk found: expected %i chunks but found "
-                    "chunk with n=%i" % (num_chunks, chunk['n']))
+                    "Extra chunk found: expected %d chunks but found "
+                    "chunk with n=%d" % (num_chunks, chunk['n']))
 
         self.__position -= received - size
 
@@ -703,22 +703,22 @@ class _GridOutChunkIterator(object):
             self.close()
             raise CorruptGridFile(
                 "Missing chunk: expected chunk #%d but found "
-                "chunk with n=%i" % (self.__next_chunk, chunk["n"]))
+                "chunk with n=%d" % (self.__next_chunk, chunk["n"]))
 
         if chunk["n"] >= self.__num_chunks:
             # According to spec, ignore extra chunks if they are empty.
             if len(chunk["data"]):
                 self.close()
                 raise CorruptGridFile(
-                    "Extra chunk found: expected %i chunks but found "
-                    "chunk with n=%i" % (self.__num_chunks, chunk["n"]))
+                    "Extra chunk found: expected %d chunks but found "
+                    "chunk with n=%d" % (self.__num_chunks, chunk["n"]))
 
         expected_length = self.expected_chunk_length(chunk["n"])
         if len(chunk["data"]) != expected_length:
             self.close()
             raise CorruptGridFile(
-                "truncated chunk #%d: expected chunk length to be %i but "
-                "found chunk with length %i" % (
+                "truncated chunk #%d: expected chunk length to be %d but "
+                "found chunk with length %d" % (
                     chunk["n"], expected_length, len(chunk["data"])))
 
         self.__next_chunk += 1

--- a/gridfs/grid_file.py
+++ b/gridfs/grid_file.py
@@ -419,6 +419,11 @@ class GridOut(object):
             :class:`~pymongo.client_session.ClientSession` to use for all
             commands
 
+        .. versionchanged:: 3.8
+           For better performance and to better follow the GridFS spec,
+           :class:`GridOut` now uses a single cursor to read all the chunks in
+           the file.
+
         .. versionchanged:: 3.6
            Added ``session`` parameter.
 
@@ -501,6 +506,11 @@ class GridOut(object):
 
         :Parameters:
           - `size` (optional): the number of bytes to read
+
+        .. versionchanged:: 3.8
+           This method now only checks for extra chunks after reading the
+           entire file. Previously, this method would check for extra chunks
+           on every call.
         """
         self._ensure_file()
 
@@ -613,6 +623,12 @@ class GridOut(object):
         :class:`str` (:class:`bytes` in python 3). This can be
         useful when serving files using a webserver that handles
         such an iterator efficiently.
+
+        .. versionchanged:: 3.8
+           The iterator now raises :class:`CorruptGridFile` when encountering
+           any truncated, missing, or extra chunk in a file. The previous
+           behavior was to only raise :class:`CorruptGridFile` on a missing
+           chunk.
         """
         return GridOutIterator(self, self.__chunks, self._session)
 

--- a/gridfs/grid_file.py
+++ b/gridfs/grid_file.py
@@ -482,11 +482,7 @@ class GridOut(object):
                 self.__chunk_iter = _GridOutChunkIterator(
                     self, self.__chunks, self._session, chunk_number)
 
-            try:
-                chunk = self.__chunk_iter.next()
-            except StopIteration:
-                raise CorruptGridFile("truncated chunk")
-
+            chunk = self.__chunk_iter.next()
             chunk_data = chunk["data"][self.__position % chunk_size:]
 
             if not chunk_data:

--- a/gridfs/grid_file.py
+++ b/gridfs/grid_file.py
@@ -685,11 +685,11 @@ class _GridOutChunkIterator(object):
                                          session=self._session)
 
     def _next_with_retry(self):
-        """Return the next chunk and retry on CursorNotFound.
+        """Return the next chunk and retry once on CursorNotFound.
 
-        We retry on CursorNotFound because before PyMongo 3.8 we used
-        find_one for each chunk.
-        # TODO: add a test for this.
+        We retry on CursorNotFound to maintain backwards compatibility in
+        cases where two calls to read occur more than 10 minutes apart (the
+        server's default cursor timeout).
         """
         if self._cursor is None:
             self._create_cursor()

--- a/gridfs/grid_file.py
+++ b/gridfs/grid_file.py
@@ -674,14 +674,6 @@ class _GridOutChunkIterator(object):
             return self.__chunk_size
         return self.__length - (self.__chunk_size * (self.__num_chunks - 1))
 
-    @property
-    def next_chunk(self):
-        return self.__next_chunk
-
-    @property
-    def num_chunks(self):
-        return self.__num_chunks
-
     def __iter__(self):
         return self
 

--- a/test/test_grid_file.py
+++ b/test/test_grid_file.py
@@ -33,10 +33,11 @@ from gridfs.grid_file import (DEFAULT_CHUNK_SIZE,
 from gridfs.errors import NoFile
 from pymongo import MongoClient
 from pymongo.errors import ConfigurationError, ServerSelectionTimeoutError
+from pymongo.message import _CursorAddress
 from test import (IntegrationTest,
                   unittest,
                   qcheck)
-from test.utils import rs_or_single_client
+from test.utils import rs_or_single_client, EventListener
 
 
 class TestGridFileNoConnect(unittest.TestCase):
@@ -615,6 +616,35 @@ Bye"""))
         # w=0 is prohibited.
         with self.assertRaises(ConfigurationError):
             GridIn(rs_or_single_client(w=0).pymongo_test.fs)
+
+    def test_survive_cursor_not_found(self):
+        # By default the find command returns 101 documents in the first batch.
+        # Use 102 batches to cause a single getMore.
+        chunk_size = 1024
+        data_1024_chunks = b'd' * (102 * 1024)
+        listener = EventListener()
+        client = rs_or_single_client(event_listeners=[listener])
+        db = client.pymongo_test
+        with GridIn(client.pymongo_test.fs, chunk_size=chunk_size) as infile:
+            infile.write(data_1024_chunks)
+
+        with GridOut(db.fs, infile._id) as outfile:
+            self.assertEqual(len(outfile.readchunk()), chunk_size)
+
+            # Kill the cursor to simulate the cursor timing out on the server
+            # when an application spends a long time between two calls to
+            # readchunk().
+            client._close_cursor_now(
+                outfile._GridOut__chunk_iter._cursor.cursor_id,
+                _CursorAddress(client.address, db.fs.chunks.full_name))
+
+            # Read the rest of the file without error.
+            self.assertEqual(len(outfile.read()),
+                             len(data_1024_chunks) - chunk_size)
+
+        # Paranoid, ensure that a getMore was actually sent.
+        self.assertIn("getMore", listener.started_command_names())
+
 
 
 if __name__ == "__main__":

--- a/test/test_gridfs_spec.py
+++ b/test/test_gridfs_spec.py
@@ -163,8 +163,8 @@ def create_test(scenario_def):
 
             if test['assert'].get("error", False):
                 self.assertIsNotNone(error)
-                self.assertTrue(isinstance(error,
-                                           errors[test['assert']['error']]))
+                self.assertIsInstance(error, errors[test['assert']['error']],
+                                      test['description'])
             else:
                 self.assertIsNone(error)
 

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -571,8 +571,11 @@ class TestSession(IntegrationTest):
             for f in files:
                 f.read()
 
-        with self.assertRaisesRegex(InvalidOperation, "ended session"):
-            files[0].read()
+        for f in files:
+            # Attempt to read the file again.
+            f.seek(0)
+            with self.assertRaisesRegex(InvalidOperation, "ended session"):
+                f.read()
 
     def test_aggregate(self):
         client = self.client


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYTHON-1721

This change uses a single cursor to download all the chunks in a GridFS file instead of using individual find_one operations to read each chunk. I've also refactored the code a bit to add earlier detection of truncated chunks.  

The performance benefit of using a single cursor will vary but it should always be an improvement. 

Python 2.7 local server: negligible benefit (latency is ~0.09ms):
```
$ mongo-python-driver git:(PYTHON-1721-master-final) TEST_PATH=driver-performance-test-data python test/performance/perf_test.py TestGridFsDownload # Local repl 1 node, cursor
Running TestGridFsDownload. MEDIAN=0.322574853897
.{
    "results": [
        {
            "name": "TestGridFsDownload",
            "results": {
                "1": {
                    "ops_per_sec": 162532197.9273853
                }
            }
        }
    ]
}

----------------------------------------------------------------------
Ran 1 test in 35.708s

OK
$ mongo-python-driver git:(PYTHON-1721-master-final) gcm
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ mongo-python-driver git:(master) TEST_PATH=driver-performance-test-data python test/performance/perf_test.py TestGridFsDownload # Local repl 1 node, find_one
Running TestGridFsDownload. MEDIAN=0.326012134552
.{
    "results": [
        {
            "name": "TestGridFsDownload",
            "results": {
                "1": {
                    "ops_per_sec": 160818553.80029458
                }
            }
        }
    ]
}

----------------------------------------------------------------------
Ran 1 test in 33.828s

OK
```


Python 3.7 local server: 15% improvement:
```
$ mongo-python-driver git:(PYTHON-1721-master-final) TEST_PATH=driver-performance-test-data python3.7 test/performance/perf_test.py TestGridFsDownload # Local repl 1 node, cursor
Running TestGridFsDownload. MEDIAN=0.25183119000000076
.{
    "results": [
        {
            "name": "TestGridFsDownload",
            "results": {
                "1": {
                    "ops_per_sec": 208190256.33798516
                }
            }
        }
    ]
}

----------------------------------------------------------------------
Ran 1 test in 29.609s

OK
$ mongo-python-driver git:(PYTHON-1721-master-final) gcm
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ mongo-python-driver git:(master) TEST_PATH=driver-performance-test-data python3.7 test/performance/perf_test.py TestGridFsDownload # Local repl 1 node, cursor
Running TestGridFsDownload. MEDIAN=0.29158426900000034
.{
    "results": [
        {
            "name": "TestGridFsDownload",
            "results": {
                "1": {
                    "ops_per_sec": 179806682.23222953
                }
            }
        }
    ]
}

----------------------------------------------------------------------
Ran 1 test in 30.502s

OK
```

Now, once we run the benchmark against a server with some real world latency, using a cursor becomes much more advantageous. Let's test with an Atlas (M10) cluster.

Python 2.7, Atlas 4.0.6 replica set, 33% speed up (latency is ~5ms):
```
$ mongo-python-driver git:(PYTHON-1721-master-final) <ATLAS_ENV_VARS> TEST_PATH=driver-performance-test-data python test/performance/perf_test.py TestGridFsDownload # Atlas find cursor
test/performance/perf_test.py:114: UserWarning: Test timed out, completed 83 iterations.
  warnings.warn('Test timed out, completed %s iterations.' % i)
Running TestGridFsDownload. MEDIAN=3.35720396042
.{
    "results": [
        {
            "name": "TestGridFsDownload",
            "results": {
                "1": {
                    "ops_per_sec": 15616805.120610315
                }
            }
        }
    ]
}

----------------------------------------------------------------------
Ran 1 test in 313.563s

OK
$ mongo-python-driver git:(PYTHON-1721-master-final) gcm
M	test/__init__.py
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ mongo-python-driver git:(master) <ATLAS_ENV_VARS> TEST_PATH=driver-performance-test-data python test/performance/perf_test.py TestGridFsDownload # Atlas find_one
test/performance/perf_test.py:114: UserWarning: Test timed out, completed 65 iterations.
  warnings.warn('Test timed out, completed %s iterations.' % i)
Running TestGridFsDownload. MEDIAN=4.43294596672
.{
    "results": [
        {
            "name": "TestGridFsDownload",
            "results": {
                "1": {
                    "ops_per_sec": 11827078.514739025
                }
            }
        }
    ]
}

----------------------------------------------------------------------
Ran 1 test in 311.489s

OK
```

Python 3.7, Atlas 4.0.6 replica set: Again ~33% speed up:
```
$ mongo-python-driver git:(PYTHON-1721-master-final) <ATLAS_ENV_VARS> TEST_PATH=driver-performance-test-data python3.7 test/performance/perf_test.py TestGridFsDownload # Atlas find cursor
test/performance/perf_test.py:114: UserWarning: Test timed out, completed 91 iterations.
  warnings.warn('Test timed out, completed %s iterations.' % i)
Running TestGridFsDownload. MEDIAN=3.1946222420000083
.{
    "results": [
        {
            "name": "TestGridFsDownload",
            "results": {
                "1": {
                    "ops_per_sec": 16411580.471303768
                }
            }
        }
    ]
}

----------------------------------------------------------------------
Ran 1 test in 317.615s

OK
$ mongo-python-driver git:(PYTHON-1721-master-final) gcm
M	test/__init__.py
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ mongo-python-driver git:(master) <ATLAS_ENV_VARS> TEST_PATH=driver-performance-test-data python3.7 test/performance/perf_test.py TestGridFsDownload # Atlas find_one
test/performance/perf_test.py:114: UserWarning: Test timed out, completed 65 iterations.
  warnings.warn('Test timed out, completed %s iterations.' % i)
Running TestGridFsDownload. MEDIAN=4.296203145000021
.{
    "results": [
        {
            "name": "TestGridFsDownload",
            "results": {
                "1": {
                    "ops_per_sec": 12203519.766288832
                }
            }
        }
    ]
}

----------------------------------------------------------------------
Ran 1 test in 313.310s

OK
```