### PR TITLE
Allow empty projection dictionary in find queries

### DIFF
--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -159,7 +159,7 @@ class Cursor(object):
         if batch_size < 0:
             raise ValueError("batch_size must be >= 0")
 
-        if projection is not None:
+        if projection not in (None, {}):
             if not projection:
                 projection = {"_id": 1}
             projection = helpers._fields_list_to_dict(projection, "projection")


### PR DESCRIPTION
The current code that verifies pymongo query projections does not replicate MongoDB shell's behavior when the projection is an empty dictionary.

```
> db.test.find({}, {})
{ "_id" : ObjectId("5cec99eb81f850232d377fe1"), "value" : 0 }
{ "_id" : ObjectId("5cec99ec81f850232d377fe2"), "value" : 1 }
{ "_id" : ObjectId("5cec99ec81f850232d377fe3"), "value" : 2 }
```

PyMongo verifies if the projection is not None, but before converting it to a proper dictionary with ` helpers._fields_list_to_dict`, any projection whose boolean value is False gets replaced with `{"id": 1}`. In the case of an empty dictionary, this is annoying, as it prevents creating a projection variable with an empty dictionary and optionally adding values to it.
```python
>>> list(coll.find({}, {}))
[{'_id': ObjectId('5cec99eb81f850232d377fe1')},
 {'_id': ObjectId('5cec99ec81f850232d377fe2')},
 {'_id': ObjectId('5cec99ec81f850232d377fe3')}]
```

Simple problematic use case:
```python
# In the scope of a request
projection = {}
if not args['verbose']:
    projection['out'] = 0
return list(coll.find({}, projection))
```
Not so elegant workaround to bypass this problem:
```python
coll.find({}, projection or None)
```

# :man_juggling: :snake: 