### PR TITLE
Change exception wrapping to use repr instead of str

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2648,13 +2648,13 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
             if (InvalidBSON) {
                 if (!PyErr_GivenExceptionMatches(etype, InvalidBSON)) {
                     /*
-                     * Raise InvalidBSON(str(e)).
+                     * Raise InvalidBSON(repr(e)).
                      */
                     Py_DECREF(etype);
                     etype = InvalidBSON;
 
                     if (evalue) {
-                        PyObject *msg = PyObject_Str(evalue);
+                        PyObject *msg = PyObject_Repr(evalue);
                         Py_DECREF(evalue);
                         evalue = msg;
                     }


### PR DESCRIPTION
I have an app that makes heavy use of pymongo. However once in a while I get a "InvalidBSON('',)" exception. I haven't been able to track the original exception because pymongo discards useful information when wrapping exceptions.