### PR TITLE
Crash in Cursor.__del__ when creating a cursor with invalid arguments

### DIFF
--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -291,7 +291,13 @@ class Cursor(object):
     def __die(self, synchronous=False):
         """Closes this cursor.
         """
-        already_killed = self.__killed
+        # the __init__ might not have run completely here (or at all)
+        try:
+            already_killed = self.__killed
+        except AttributeError:
+            # __init__ did not run to completion (or at all)
+            return
+
         self.__killed = True
         if self.__id and not already_killed:
             if self.__exhaust and self.__exhaust_mgr:

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -35,7 +35,7 @@ from pymongo import (monitoring,
                      ALL,
                      OFF)
 from pymongo.collation import Collation
-from pymongo.cursor import CursorType
+from pymongo.cursor import Cursor, CursorType
 from pymongo.errors import (ConfigurationError,
                             ExecutionTimeout,
                             InvalidOperation,
@@ -1408,6 +1408,12 @@ class TestCursor(IntegrationTest):
             assertCursorKilled()
         else:
             self.assertEqual(0, len(results["started"]))
+
+    def test_delete_not_initialized(self):
+        # Creating a cursor with invalid arguments will not run __init__
+        # but will still call __del__
+        cursor = Cursor.__new__(Cursor)  # Skip calling __init__
+        cursor.__del__()  # no error
 
 
 class TestRawBatchCursor(IntegrationTest):


### PR DESCRIPTION
If the constructor of Cursor is called with unexpected arguments (ie when calling a `find` wrongly), the `__init__` method does not run at all, but `__del__` is still called and will (of course) crash.

This leads to some noise in the logged error on top of the real TypeError:
```
>>> pymongo.cursor.Cursor(wrong=1)
Exception ignored in: <function Cursor.__del__ at 0x1048129d8>
Traceback (most recent call last):
  File "/Users/arthur/dev/.venvs/Users--arthur--dev--dragonstone/lib/python3.7/site-packages/pymongo/cursor.py", line 241, in __del__
    self.__die()
  File "/Users/arthur/dev/.venvs/Users--arthur--dev--dragonstone/lib/python3.7/site-packages/pymongo/cursor.py", line 298, in __die
    already_killed = self.__killed
AttributeError: 'Cursor' object has no attribute '_Cursor__killed'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() got an unexpected keyword argument 'wrong'
```


This PR might not be the best way to solve this, a `__new__` could also work for instance. Let me know if this looks acceptable and if there should also be a regression test.

Thanks!