### PR TITLE
Fix removed argument 'lifetime'

### DIFF
--- a/pymongo/srv_resolver.py
+++ b/pymongo/srv_resolver.py
@@ -54,8 +54,7 @@ class _SrvResolver(object):
 
     def get_options(self):
         try:
-            results = resolver.query(self.__fqdn, 'TXT',
-                                     lifetime=self.__connect_timeout)
+            results = resolver.query(self.__fqdn, 'TXT')
         except (resolver.NoAnswer, resolver.NXDOMAIN):
             # No TXT records
             return None
@@ -69,8 +68,7 @@ class _SrvResolver(object):
 
     def _resolve_uri(self, encapsulate_errors):
         try:
-            results = resolver.query('_mongodb._tcp.' + self.__fqdn, 'SRV',
-                                     lifetime=self.__connect_timeout)
+            results = resolver.query('_mongodb._tcp.' + self.__fqdn, 'SRV')
         except Exception as exc:
             if not encapsulate_errors:
                 # Raise the original error.


### PR DESCRIPTION
The argument 'lifetime' was removed from resolver.query(), srv_resolver.py crashed when trying to sent it.