### PR TITLE
PYTHON-2012 FLE GA changes

### DIFF
--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -19,6 +19,7 @@ may be made before the final release.**
 """
 
 import contextlib
+import os
 import subprocess
 import uuid
 import weakref
@@ -150,7 +151,9 @@ class _EncryptionIO(MongoCryptCallback):
         self._spawned = True
         args = [self.opts._mongocryptd_spawn_path or 'mongocryptd']
         args.extend(self.opts._mongocryptd_spawn_args)
-        subprocess.Popen(args)
+        # Silence mongocryptd output, users should pass --logpath.
+        with open(os.devnull, 'wb') as devnull:
+            subprocess.Popen(args, stdout=devnull, stderr=devnull)
 
     def mark_command(self, database, cmd):
         """Mark a command for encryption.

--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -415,15 +415,17 @@ class ClientEncryption(object):
         :Parameters:
           - `kms_provider`: The KMS provider to use. Supported values are
             "aws" and "local".
-          - `master_key`: The `master_key` identifies a KMS-specific key used
-            to encrypt the new data key. If the kmsProvider is "local" the
-            `master_key` is not applicable and may be omitted.
-            If the `kms_provider` is "aws", `master_key` is required and must
-            have the following fields:
+          - `master_key`: Identifies a KMS-specific key used to encrypt the
+            new data key. If the kmsProvider is "local" the `master_key` is
+            not applicable and may be omitted. If the `kms_provider` is "aws"
+            it is required and has the following fields::
 
-              - `region` (string): The AWS region as a string.
-              - `key` (string): The Amazon Resource Name (ARN) to the AWS
-                customer master key (CMK).
+              - `region` (string): Required. The AWS region, e.g. "us-east-1".
+              - `key` (string): Required. The Amazon Resource Name (ARN) to
+                 the AWS customer.
+              - `endpoint` (string): Optional. An alternate host to send KMS
+                requests to. May include port number, e.g.
+                "kms.us-east-1.amazonaws.com:443".
 
           - `key_alt_names` (optional): An optional list of string alternate
             names used to reference a key. If a key is created with alternate
@@ -437,7 +439,9 @@ class ClientEncryption(object):
                                         algorithm=Algorithm.Random)
 
         :Returns:
-          The ``_id`` of the created data key document.
+          The ``_id`` of the created data key document as a
+          :class:`~bson.binary.Binary` with subtype
+          :data:`~bson.binary.UUID_SUBTYPE`.
         """
         self._check_closed()
         with _wrap_encryption_errors():

--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -57,6 +57,7 @@ from pymongo.mongo_client import MongoClient
 from pymongo.pool import _configured_socket, PoolOptions
 from pymongo.read_concern import ReadConcern
 from pymongo.ssl_support import get_ssl_context
+from pymongo.uri_parser import parse_host
 from pymongo.write_concern import WriteConcern
 
 
@@ -111,11 +112,12 @@ class _EncryptionIO(MongoCryptCallback):
         """
         endpoint = kms_context.endpoint
         message = kms_context.message
+        host, port = parse_host(endpoint, _HTTPS_PORT)
         ctx = get_ssl_context(None, None, None, None, None, None, True)
         opts = PoolOptions(connect_timeout=_KMS_CONNECT_TIMEOUT,
                            socket_timeout=_KMS_CONNECT_TIMEOUT,
                            ssl_context=ctx)
-        conn = _configured_socket((endpoint, _HTTPS_PORT), opts)
+        conn = _configured_socket((host, port), opts)
         try:
             conn.sendall(message)
             while kms_context.bytes_needed > 0:

--- a/test/client-side-encryption/spec/aggregate.json
+++ b/test/client-side-encryption/spec/aggregate.json
@@ -143,7 +143,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -155,7 +154,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -189,7 +187,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -255,7 +256,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -277,7 +277,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -311,7 +310,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/basic.json
+++ b/test/client-side-encryption/spec/basic.json
@@ -137,7 +137,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -149,7 +148,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -183,7 +181,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -275,7 +276,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -287,7 +287,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -321,7 +320,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/bulk.json
+++ b/test/client-side-encryption/spec/bulk.json
@@ -171,7 +171,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -183,7 +182,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -217,7 +215,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/bypassAutoEncryption.json
+++ b/test/client-side-encryption/spec/bypassAutoEncryption.json
@@ -196,7 +196,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -366,7 +369,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/count.json
+++ b/test/client-side-encryption/spec/count.json
@@ -142,7 +142,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -154,7 +153,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -188,7 +186,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/countDocuments.json
+++ b/test/client-side-encryption/spec/countDocuments.json
@@ -143,7 +143,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -155,7 +154,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -189,7 +187,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/delete.json
+++ b/test/client-side-encryption/spec/delete.json
@@ -144,7 +144,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -156,7 +155,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -190,7 +188,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -268,7 +269,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -280,7 +280,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -314,7 +313,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/distinct.json
+++ b/test/client-side-encryption/spec/distinct.json
@@ -154,7 +154,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -166,7 +165,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -200,7 +198,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/explain.json
+++ b/test/client-side-encryption/spec/explain.json
@@ -148,7 +148,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -160,7 +159,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -194,7 +192,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/find.json
+++ b/test/client-side-encryption/spec/find.json
@@ -153,7 +153,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -165,7 +164,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -199,7 +197,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -294,7 +295,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -306,7 +306,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -340,7 +339,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/findOneAndDelete.json
+++ b/test/client-side-encryption/spec/findOneAndDelete.json
@@ -141,7 +141,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -153,7 +152,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -187,7 +185,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/findOneAndReplace.json
+++ b/test/client-side-encryption/spec/findOneAndReplace.json
@@ -140,7 +140,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -152,7 +151,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -186,7 +184,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/findOneAndUpdate.json
+++ b/test/client-side-encryption/spec/findOneAndUpdate.json
@@ -142,7 +142,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -154,7 +153,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -188,7 +186,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/getMore.json
+++ b/test/client-side-encryption/spec/getMore.json
@@ -163,7 +163,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -184,7 +183,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -218,7 +216,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/insert.json
+++ b/test/client-side-encryption/spec/insert.json
@@ -124,7 +124,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -136,7 +135,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -170,7 +168,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -250,7 +251,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -262,7 +262,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -296,7 +295,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/keyAltName.json
+++ b/test/client-side-encryption/spec/keyAltName.json
@@ -124,7 +124,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -136,7 +135,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -165,7 +163,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/localKMS.json
+++ b/test/client-side-encryption/spec/localKMS.json
@@ -107,7 +107,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -119,7 +118,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },

--- a/test/client-side-encryption/spec/localSchema.json
+++ b/test/client-side-encryption/spec/localSchema.json
@@ -140,7 +140,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -174,7 +173,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/missingKey.json
+++ b/test/client-side-encryption/spec/missingKey.json
@@ -133,7 +133,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -145,7 +144,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "different"
               },
@@ -179,7 +177,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/replaceOne.json
+++ b/test/client-side-encryption/spec/replaceOne.json
@@ -141,7 +141,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -153,7 +152,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -187,7 +185,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/types.json
+++ b/test/client-side-encryption/spec/types.json
@@ -107,7 +107,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -141,7 +140,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -256,7 +258,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -290,7 +291,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -405,7 +409,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -439,7 +442,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -654,7 +660,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -688,7 +693,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -803,7 +811,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -837,7 +844,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -1051,7 +1061,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -1085,7 +1094,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -1206,7 +1218,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -1240,7 +1251,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -1359,7 +1373,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -1393,7 +1406,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/updateMany.json
+++ b/test/client-side-encryption/spec/updateMany.json
@@ -157,7 +157,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -169,7 +168,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -203,7 +201,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/test/client-side-encryption/spec/updateOne.json
+++ b/test/client-side-encryption/spec/updateOne.json
@@ -143,7 +143,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -155,7 +154,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -189,7 +187,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -310,7 +311,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -380,7 +380,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYTHON-2012
This PR depends on https://github.com/mongodb/libmongocrypt/pull/65. I need to wait until the libmongocrypt changes are merged before running a patch build. The tests pass locally.

Changes:
- silence mongocryptd output
- Resync spec tests
- Add prose test for custom endpoint for create_data_key
- Update the prose test of Data key and double encryption to check command started events
- Document 'endpoint' support
- Document that create_data_key returns a Binary with UUID subtype.

The only part left is the changes to bulk write batching and bson command size limits which I will put up as a separate review.