### PR TITLE
[PYTHON-2061] bson: check for negative entry size in read_file_iter.

### DIFF
--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -1166,6 +1166,9 @@ def decode_file_iter(file_obj, codec_options=DEFAULT_CODEC_OPTIONS):
         elif len(size_data) != 4:
             raise InvalidBSON("cut off in middle of objsize")
         obj_size = _UNPACK_INT_FROM(size_data, 0)[0] - 4
+        if obj_size < 0:
+            raise InvalidBSON(
+                "invalid objsize: {!r} -> {}".format(size_data, obj_size))
         elements = size_data + file_obj.read(obj_size)
         yield _bson_to_dict(elements, codec_options)
 

--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -1166,10 +1166,7 @@ def decode_file_iter(file_obj, codec_options=DEFAULT_CODEC_OPTIONS):
         elif len(size_data) != 4:
             raise InvalidBSON("cut off in middle of objsize")
         obj_size = _UNPACK_INT_FROM(size_data, 0)[0] - 4
-        if obj_size < 0:
-            raise InvalidBSON(
-                "invalid objsize: {!r} -> {}".format(size_data, obj_size))
-        elements = size_data + file_obj.read(obj_size)
+        elements = size_data + file_obj.read(max(0, obj_size))
         yield _bson_to_dict(elements, codec_options)
 
 

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -86,3 +86,4 @@ The following is a list of people who have contributed to
 - Shrey Batra(shreybatra)
 - Felipe Rodrigues(fbidu)
 - Terence Honles (terencehonles)
+- Paul Fisher (thetorpedodog)

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -58,6 +58,21 @@ if PY3:
     long = int
 
 
+class StrictStringIO(object):
+    """Read-only buffer enforcing non-negative read sizes, like real files."""
+
+    def __init__(self, contents):
+        self.buffer = StringIO(contents)
+
+    def read(self, size=-1):
+        if size is not None and size < -1:
+            raise ValueError("read length must be non-negative or -1")
+        return self.buffer.read(size)
+
+    # Only .read() is implemented, because that is the only method
+    # that bson reading calls.
+
+
 class NotADict(abc.MutableMapping):
     """Non-dict type that implements the mapping protocol."""
 
@@ -291,7 +306,7 @@ class TestBSON(unittest.TestCase):
                             b"\x6f\x20\x77\x6F\x72\x6C\x64\x00\x00"
                             b"\x05\x00\x00\x00\x00")))
         self.assertEqual([{"test": u"hello world"}, {}],
-                         list(decode_file_iter(StringIO(
+                         list(decode_file_iter(StrictStringIO(
                             b"\x1B\x00\x00\x00\x0E\x74\x65\x73\x74"
                             b"\x00\x0C\x00\x00\x00\x68\x65\x6C\x6C"
                             b"\x6f\x20\x77\x6F\x72\x6C\x64\x00\x00"
@@ -333,14 +348,15 @@ class TestBSON(unittest.TestCase):
         # an object size of first object.
         # NOTE: decode_all and decode_iter don't care, not sure if they should?
         self.assertRaises(InvalidBSON, list,
-                          decode_file_iter(StringIO(b"\x1B")))
+                          decode_file_iter(StrictStringIO(b"\x1B")))
 
         # An object size that's too small to even include the object size,
         # but is correctly encoded, along with a correct EOO (and no data).
         data = b"\x01\x00\x00\x00\x00"
         self.assertRaises(InvalidBSON, decode_all, data)
         self.assertRaises(InvalidBSON, list, decode_iter(data))
-        self.assertRaises(InvalidBSON, list, decode_file_iter(StringIO(data)))
+        self.assertRaises(
+            InvalidBSON, list, decode_file_iter(StrictStringIO(data)))
 
         # One object, but with object size listed smaller than it is in the
         # data.
@@ -350,7 +366,8 @@ class TestBSON(unittest.TestCase):
                 b"\x05\x00\x00\x00\x00")
         self.assertRaises(InvalidBSON, decode_all, data)
         self.assertRaises(InvalidBSON, list, decode_iter(data))
-        self.assertRaises(InvalidBSON, list, decode_file_iter(StringIO(data)))
+        self.assertRaises(
+            InvalidBSON, list, decode_file_iter(StrictStringIO(data)))
 
         # One object, missing the EOO at the end.
         data = (b"\x1B\x00\x00\x00\x0E\x74\x65\x73\x74"
@@ -359,7 +376,8 @@ class TestBSON(unittest.TestCase):
                 b"\x05\x00\x00\x00")
         self.assertRaises(InvalidBSON, decode_all, data)
         self.assertRaises(InvalidBSON, list, decode_iter(data))
-        self.assertRaises(InvalidBSON, list, decode_file_iter(StringIO(data)))
+        self.assertRaises(
+            InvalidBSON, list, decode_file_iter(StrictStringIO(data)))
 
         # One object, sized correctly, with a spot for an EOO, but the EOO
         # isn't 0x00.
@@ -369,7 +387,8 @@ class TestBSON(unittest.TestCase):
                 b"\x05\x00\x00\x00\xFF")
         self.assertRaises(InvalidBSON, decode_all, data)
         self.assertRaises(InvalidBSON, list, decode_iter(data))
-        self.assertRaises(InvalidBSON, list, decode_file_iter(StringIO(data)))
+        self.assertRaises(
+            InvalidBSON, list, decode_file_iter(StrictStringIO(data)))
 
     def test_data_timestamp(self):
         self.assertEqual({"test": Timestamp(4, 20)},


### PR DESCRIPTION
This is a cut at [bug 2061](https://jira.mongodb.org/projects/PYTHON/issues/PYTHON-2061). I’m a little unsure about whether the test change I’ve done is the best way to do it—the solution I have seems…OK, but not ideal.

I’m open to any feedback about this. Thanks!