### PR TITLE
PYTHON-2064 Collect crash dumps from mongo-orchestration

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -165,6 +165,24 @@ functions:
           set -o xtrace
           ${PREPARE_SHELL}
           find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
+    - command: archive.targz_pack
+      params:
+        target: "mongo-coredumps.tgz"
+        source_dir: "./"
+        include:
+          - "./**.core"
+          - "./**.mdmp" # Windows: minidumps
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongo-coredumps.tgz
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/coredumps/${task_id}-${execution}-mongodb-coredumps.tar.gz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: Core Dumps - Execution
+        optional: true
     - command: s3.put
       params:
         aws_key: ${aws_key}
@@ -236,6 +254,34 @@ functions:
       params:
         script: |
           set -o xtrace
+
+          # Enable core dumps if enabled on the machine
+          # Copied from https://github.com/mongodb/mongo/blob/master/etc/evergreen.yml
+          if [ -f /proc/self/coredump_filter ]; then
+            # Set the shell process (and its children processes) to dump ELF headers (bit 4),
+            # anonymous shared mappings (bit 1), and anonymous private mappings (bit 0).
+            echo 0x13 > /proc/self/coredump_filter
+
+            if [ -f /sbin/sysctl ]; then
+              # Check that the core pattern is set explicitly on our distro image instead
+              # of being the OS's default value. This ensures that coredump names are consistent
+              # across distros and can be picked up by Evergreen.
+              core_pattern=$(/sbin/sysctl -n "kernel.core_pattern")
+              if [ "$core_pattern" = "dump_%e.%p.core" ]; then
+                echo "Enabling coredumps"
+                ulimit -c unlimited
+              fi
+            fi
+          fi
+
+          if [ $(uname -s) == "Darwin" ]; then
+              core_pattern_mac=$(/usr/sbin/sysctl -n "kern.corefile")
+              if [ "$core_pattern_mac" = "dump_%N.%P.core" ]; then
+                echo "Enabling coredumps"
+                ulimit -c unlimited
+              fi
+          fi
+
           ${PREPARE_SHELL}
           MONGODB_VERSION=${VERSION} \
             TOPOLOGY=${TOPOLOGY} \


### PR DESCRIPTION
Collect crash dumps from mongo-orchestration. Minidumps are enabled by default on Windows. Core dumps need to be enabled in the current executing shell via ulimit.
