### PR TITLE
fix bug monitoring._to_micros

### DIFF
--- a/pymongo/monitoring.py
+++ b/pymongo/monitoring.py
@@ -446,7 +446,7 @@ class ServerListener(_EventListener):
 
 def _to_micros(dur):
     """Convert duration 'dur' to microseconds."""
-    return int(dur.total_seconds() * 10e5)
+    return int(dur.total_seconds() * 10e3)
 
 
 def _validate_event_listeners(option, listeners):


### PR DESCRIPTION
When I check the code, I found `dur` here is timedelta object
And here `dur.total_seconds() * 10e5` I don't really understand why you use `10e5`, maybe it's a writing mistake.
So, fixed it.