### PR TITLE
DOCSP-9413: replace references to google groups with community forums

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ Support / Feedback
 For issues with, questions about, or feedback for PyMongo, please look into
 our `support channels <http://www.mongodb.org/about/support>`_. Please
 do not email any of the PyMongo developers directly with issues or
-questions - you're more likely to get an answer on the `mongodb-user
-<http://groups.google.com/group/mongodb-user>`_ list on Google Groups.
+questions - you're more likely to get an answer on the `MongoDB Community
+Forums <https://community.mongodb.com/>`_.
 
 Bugs / Feature Requests
 =======================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,7 +53,10 @@ everything you need to know to use **PyMongo**.
 
 Getting Help
 ------------
-If you're having trouble or have questions about PyMongo, the best place to ask is the `MongoDB user group <http://groups.google.com/group/mongodb-user>`_. Once you get an answer, it'd be great if you could work it back into this documentation and contribute!
+If you're having trouble or have questions about PyMongo, ask your question in
+our `MongoDB Community Forums <https://community.mongodb.com/>`_.  Once you
+get an answer, it'd be great if you could work it back into this documentation
+and contribute!
 
 Issues
 ------


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-9413

Remove all references to google groups from Python driver docs.