### PR TITLE
Move sock.settimeout() call to before the SSL handshake occurs

### DIFF
--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -882,6 +882,7 @@ def _configured_socket(address, options):
     Sets socket's SSL and timeout options.
     """
     sock = _create_connection(address, options)
+    sock.settimeout(options.socket_timeout)
     ssl_context = options.ssl_context
 
     if ssl_context is not None:
@@ -918,7 +919,6 @@ def _configured_socket(address, options):
                 sock.close()
                 raise
 
-    sock.settimeout(options.socket_timeout)
     return sock
 
 


### PR DESCRIPTION
On a heavily loaded virtual machine running multiple docker containers I have been encountering an intermittent SSL handshake timeout error.   The error was was being raised in `pool.py` in the `_configured_socket()` function on the line where `ssl_context.wrap_socket()` is called.

This patch moves the `sock.settimeout()` call to before the `wrap_socket()` calls so that the SSL handshake process uses the configured timeout.
