### PR TITLE
PYTHON-1852 Use TLS option names in test suite ClientContext

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -919,7 +919,7 @@ class TestClient(IntegrationTest):
         assertRaisesExactly(
             OperationFailure, lazy_client.test.collection.find_one)
 
-    @client_context.require_no_ssl
+    @client_context.require_no_tls
     def test_unix_socket(self):
         if not hasattr(socket, "AF_UNIX"):
             raise SkipTest("UNIX-sockets are not supported on this system")
@@ -1086,7 +1086,7 @@ class TestClient(IntegrationTest):
 
     @client_context.require_ipv6
     def test_ipv6(self):
-        if client_context.ssl:
+        if client_context.tls:
             if not HAVE_IPADDRESS:
                 raise SkipTest("Need the ipaddress module to test with SSL")
 

--- a/test/test_dns.py
+++ b/test/test_dns.py
@@ -40,7 +40,7 @@ class TestDNS(unittest.TestCase):
 def create_test(test_case):
 
     @client_context.require_replica_set
-    @client_context.require_ssl
+    @client_context.require_tls
     def run_test(self):
         if not _HAVE_DNSPYTHON:
             raise unittest.SkipTest("DNS tests require the dnspython module")
@@ -68,7 +68,7 @@ def create_test(test_case):
             # The replica set members must be configured as 'localhost'.
             if hostname == 'localhost':
                 copts = client_context.default_client_options.copy()
-                if client_context.ssl is True:
+                if client_context.tls is True:
                     # Our test certs don't support the SRV hosts used in these tests.
                     copts['ssl_match_hostname'] = False
 

--- a/test/test_replica_set_client.py
+++ b/test/test_replica_set_client.py
@@ -195,7 +195,7 @@ class TestReplicaSetClient(TestReplicaSetClientBase):
 
     @client_context.require_ipv6
     def test_ipv6(self):
-        if client_context.ssl:
+        if client_context.tls:
             if not HAVE_IPADDRESS:
                 raise SkipTest("Need the ipaddress module to test with SSL")
 

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -196,7 +196,7 @@ class TestSSL(IntegrationTest):
         MongoClient.PORT = cls.saved_port
         super(TestSSL, cls).tearDownClass()
 
-    @client_context.require_ssl
+    @client_context.require_tls
     def test_simple_ssl(self):
         # Expects the server to be running with ssl and with
         # no --sslPEMKeyFile or with --sslWeakCertificateValidation


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYTHON-1852

This doesn't fix all the usages of `ssl_*` (eg in test_ssl.py) but does fix a large majority of them.