### PR TITLE
PYTHON-2082 Unpin session after RetryableWriteErrors from commitTransaction

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -842,7 +842,6 @@ class TestSampleShellCommands(IntegrationTest):
 
 
 class TestTransactionExamples(IntegrationTest):
-    @client_context.require_version_max(4, 4, 99)  # PYTHON-2154 skip on 4.5+
     @client_context.require_transactions
     def test_transactions(self):
         # Transaction examples

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -415,13 +415,7 @@ def create_test(scenario_def, test, name):
     @client_context.require_test_commands
     @client_context.require_transactions
     def run_scenario(self):
-        try:
-            self.run_scenario(scenario_def, test)
-        except OperationFailure as exc:
-            if (client_context.version.at_least(4, 5) and
-                    client_context.is_mongos and exc.code == 13388):
-                self.skipTest('PYTHON-2189 Ignoring StaleConfig error: %r' % (
-                    exc.details))
+        self.run_scenario(scenario_def, test)
 
     return run_scenario
 


### PR DESCRIPTION
[PYTHON-2154](https://jira.mongodb.org/browse/PYTHON-2154) [PYTHON-2189](https://jira.mongodb.org/browse/PYTHON-2189) Remove 4.5 transaction test workarounds

Explanation: The StaleConfig change in PYTHON-2189 accidentally causes the test_transactions suite to ignore _any_ failed test because there was a missing `raise` statement. Now that we're no longer masking test failures, this test began to fail:
```
ERROR: test_transactions_mongos_recovery_token_commitTransaction_retry_succeeds_on_new_mongos (test.test_transactions.TestTransactions)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/test/__init__.py", line 442, in wrap
    return f(*args, **kwargs)
  File "/Users/shane/git/mongo-python-driver/test/__init__.py", line 442, in wrap
    return f(*args, **kwargs)
  File "/Users/shane/git/mongo-python-driver/test/__init__.py", line 442, in wrap
    return f(*args, **kwargs)
  File "/Users/shane/git/mongo-python-driver/test/test_transactions.py", line 418, in run_scenario
    self.run_scenario(scenario_def, test)
  File "/Users/shane/git/mongo-python-driver/test/utils_spec_runner.py", line 584, in run_scenario
    self.run_test_ops(sessions, collection, test)
  File "/Users/shane/git/mongo-python-driver/test/utils_spec_runner.py", line 497, in run_test_ops
    self.run_operations(sessions, collection, test['operations'])
  File "/Users/shane/git/mongo-python-driver/test/utils_spec_runner.py", line 403, in run_operations
    result = self.run_operation(sessions, collection, op.copy())
  File "/Users/shane/git/mongo-python-driver/test/utils_spec_runner.py", line 346, in run_operation
    result = cmd(**dict(arguments))
  File "/Users/shane/git/mongo-python-driver/pymongo/client_session.py", line 615, in commit_transaction
    _reraise_with_unknown_commit(exc)
  File "/Users/shane/git/mongo-python-driver/pymongo/client_session.py", line 597, in commit_transaction
    self._finish_transaction_with_retry("commitTransaction")
  File "/Users/shane/git/mongo-python-driver/pymongo/client_session.py", line 655, in _finish_transaction_with_retry
    return self._client._retry_internal(True, func, self, None)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1406, in _retry_internal
    raise last_error
WriteConcernError: Replication is being shut down
```

This test failure is caused by PYTHON-2082. In particular, we neglected to unpin the session on retryable commitTransaction errors. To fix the bug we unpin the session on all errors with the RetryableWriteError label.

I've already tested this change here: https://evergreen.mongodb.com/version/5efb9809c9ec447c47b57365