### PR TITLE
PYTHON-2163 Suppress ragged EOFs when using PyOpenSSL to match the stdlib

### DIFF
--- a/pymongo/pyopenssl_context.py
+++ b/pymongo/pyopenssl_context.py
@@ -289,8 +289,7 @@ class SSLContext(object):
         """Wrap an existing Python socket sock and return a TLS socket
         object.
         """
-        ssl_conn = _sslConn(
-            self._ctx, sock, suppress_ragged_eofs=suppress_ragged_eofs)
+        ssl_conn = _sslConn(self._ctx, sock, suppress_ragged_eofs)
         if session:
             ssl_conn.set_session(session)
         if server_side is True:


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYTHON-2163

This change does two things. First it fixes a bug where we were incorrectly not wrapping pyOpenSSL connection errors from wrap_socket. For example, before this change:
```
>>> client = MongoClient(ssl=True, serverSelectionTimeoutMS=1000).admin.command('ping')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/shane/git/mongo-python-driver/pymongo/database.py", line 737, in command
    read_preference, session) as (sock_info, slave_ok):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1322, in _socket_for_reads
    server = self._select_server(read_preference, session)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1275, in _select_server
    server = topology.select_server(server_selector)
  File "/Users/shane/git/mongo-python-driver/pymongo/topology.py", line 243, in select_server
    address))
  File "/Users/shane/git/mongo-python-driver/pymongo/topology.py", line 200, in select_servers
    selector, server_timeout, address)
  File "/Users/shane/git/mongo-python-driver/pymongo/topology.py", line 217, in _select_servers_loop
    (self._error_message(selector), timeout, self.description))
pymongo.errors.ServerSelectionTimeoutError: (-1, 'Unexpected EOF'), Timeout: 1.0s, Topology Description: <TopologyDescription id: 5efe463ec658be84f88c0e33, topology_type: Single, servers: [<ServerDescription ('localhost', 27017) server_type: Unknown, rtt: None, error=SysCallError(-1, 'Unexpected EOF')>]>
```
After this change we correctly wrap the SysCallError in `AutoReconnect("SSL handshake failed: ...")`:
```
>>> client = MongoClient(ssl=True, serverSelectionTimeoutMS=1000).admin.command('ping')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/shane/git/mongo-python-driver/pymongo/database.py", line 737, in command
    read_preference, session) as (sock_info, slave_ok):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1322, in _socket_for_reads
    server = self._select_server(read_preference, session)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1275, in _select_server
    server = topology.select_server(server_selector)
  File "/Users/shane/git/mongo-python-driver/pymongo/topology.py", line 243, in select_server
    address))
  File "/Users/shane/git/mongo-python-driver/pymongo/topology.py", line 200, in select_servers
    selector, server_timeout, address)
  File "/Users/shane/git/mongo-python-driver/pymongo/topology.py", line 217, in _select_servers_loop
    (self._error_message(selector), timeout, self.description))
pymongo.errors.ServerSelectionTimeoutError: SSL handshake failed: localhost:27017: (-1, 'Unexpected EOF'), Timeout: 1.0s, Topology Description: <TopologyDescription id: 5efe4624a92bae23d4ec5e73, topology_type: Single, servers: [<ServerDescription ('localhost', 27017) server_type: Unknown, rtt: None, error=AutoReconnect("SSL handshake failed: localhost:27017: (-1, 'Unexpected EOF')")>]>
```

Second, this change adds support for suppress_ragged_eofs=True in pyOpenSSL reads/writes. 