### PR TITLE
PYTHON-2165 Deprecate MongoClient is_locked, fsync, and unlock helpers

### DIFF
--- a/doc/api/pymongo/mongo_client.rst
+++ b/doc/api/pymongo/mongo_client.rst
@@ -34,7 +34,6 @@
       .. autoattribute:: read_preference
       .. autoattribute:: write_concern
       .. autoattribute:: read_concern
-      .. autoattribute:: is_locked
       .. automethod:: start_session
       .. automethod:: list_databases
       .. automethod:: list_database_names
@@ -43,9 +42,10 @@
       .. automethod:: get_default_database
       .. automethod:: get_database
       .. automethod:: server_info
+      .. automethod:: watch
       .. automethod:: close_cursor
       .. automethod:: kill_cursors
       .. automethod:: set_cursor_manager
-      .. automethod:: watch
+      .. autoattribute:: is_locked
       .. automethod:: fsync
       .. automethod:: unlock

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -46,6 +46,12 @@ Highlights include:
   :class:`~pymongo.read_preferences.SecondaryPreferred`,
   :class:`~pymongo.read_preferences.Nearest` to support disabling
   (or explicitly enabling) hedged reads in MongoDB 4.4+.
+- Fixed a bug in change streams that could cause PyMongo to miss some change
+  documents when resuming a stream that was started without a resume token and
+  whose first batch did not contain any change documents.
+
+Deprecations:
+
 - Deprecated the ``oplog_replay`` parameter to
   :meth:`pymongo.collection.Collection.find`. Starting in MongoDB 4.4, the
   server optimizes queries against the oplog collection without requiring
@@ -53,9 +59,15 @@ Highlights include:
 - Deprecated :meth:`pymongo.collection.Collection.reindex`. Use
   :meth:`~pymongo.database.Database.command` to run the ``reIndex`` command
   instead.
-- Fixed a bug in change streams that could cause PyMongo to miss some change
-  documents when resuming a stream that was started without a resume token and
-  whose first batch did not contain any change documents.
+- Deprecated :meth:`pymongo.mongo_client.MongoClient.fsync`. Use
+  :meth:`~pymongo.database.Database.command` to run the ``fsync`` command
+  instead.
+- Deprecated :meth:`pymongo.mongo_client.MongoClient.unlock`. Use
+  :meth:`~pymongo.database.Database.command` to run the ``fsyncUnlock`` command
+  instead. See the documentation for more information.
+- Deprecated :attr:`pymongo.mongo_client.MongoClient.is_locked`. Use
+  :meth:`~pymongo.database.Database.command` to run the ``currentOp`` command
+  instead. See the documentation for more information.
 
 Unavoidable breaking changes:
 

--- a/test/test_monitoring.py
+++ b/test/test_monitoring.py
@@ -37,6 +37,7 @@ from test import (client_context,
                   unittest)
 from test.utils import (EventListener,
                         get_pool,
+                        ignore_deprecations,
                         rs_or_single_client,
                         single_client,
                         wait_until)
@@ -1336,12 +1337,13 @@ class TestCommandMonitoring(PyMongoTestCase):
         self.assertTrue('ok' in succeeded.reply)
 
         if not client_context.is_mongos:
-            self.client.fsync(lock=True)
-            self.listener.results.clear()
-            self.client.unlock()
-            # Wait for async unlock...
-            wait_until(
-                lambda: not self.client.is_locked, "unlock the database")
+            with ignore_deprecations():
+                self.client.fsync(lock=True)
+                self.listener.results.clear()
+                self.client.unlock()
+                # Wait for async unlock...
+                wait_until(
+                    lambda: not self.client.is_locked, "unlock the database")
             started = results['started'][0]
             succeeded = results['succeeded'][0]
             self.assertEqual(0, len(results['failed']))

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -227,6 +227,7 @@ class TestSession(IntegrationTest):
         client.close()
         self.assertEqual(len(listener.results['started']), 0)
 
+    @ignore_deprecations  # fsync and unlock
     def test_client(self):
         client = self.client
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYTHON-2165