### PR TITLE
PYTHON-2256 Document that a ClientSession cannot be used for multiple operations concurrently

### DIFF
--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -343,7 +343,7 @@ class ClientSession(object):
     :class:`ClientSession` cannot be used to run multiple operations
     concurrently.
 
-    Should not be called directly by application developers - to create a
+    Should not be initialized directly by application developers - to create a
     :class:`ClientSession`, call
     :meth:`~pymongo.mongo_client.MongoClient.start_session`.
     """
@@ -471,9 +471,9 @@ class ClientSession(object):
         however, ``with_transaction`` will return without taking further
         action.
 
-        This :class:`ClientSession` is **not thread-safe or fork-safe**. The
-        ``callback`` must not attempt to execute multiple operations
-        concurrently.
+        :class:`ClientSession` instances are **not thread-safe or fork-safe**.
+        Consequently, the ``callback`` must not attempt to execute multiple
+        operations concurrently.
 
         When ``callback`` raises an exception, ``with_transaction``
         automatically aborts the current transaction. When ``callback`` or

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -336,7 +336,17 @@ def _within_time_limit(start_time):
 
 
 class ClientSession(object):
-    """A session for ordering sequential operations."""
+    """A session for ordering sequential operations.
+
+    :class:`ClientSession` instances are **not thread-safe or fork-safe**.
+    They can only be used by one thread or process at a time. A single
+    :class:`ClientSession` cannot be used to run multiple operations
+    concurrently.
+
+    Should not be called directly by application developers - to create a
+    :class:`ClientSession`, call
+    :meth:`~pymongo.mongo_client.MongoClient.start_session`.
+    """
     def __init__(self, client, server_session, options, authset, implicit):
         # A MongoClient, a _ServerSession, a SessionOptions, and a set.
         self._client = client
@@ -460,6 +470,10 @@ class ClientSession(object):
         ``callback`` does commit or abort the transaction without error,
         however, ``with_transaction`` will return without taking further
         action.
+
+        This :class:`ClientSession` is **not thread-safe or fork-safe**. The
+        ``callback`` must not attempt to execute multiple operations
+        concurrently.
 
         When ``callback`` raises an exception, ``with_transaction``
         automatically aborts the current transaction. When ``callback`` or

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1779,7 +1779,10 @@ class MongoClient(common.BaseObject):
         deprecated method :meth:`~pymongo.database.Database.authenticate`.
 
         A :class:`~pymongo.client_session.ClientSession` may only be used with
-        the MongoClient that started it.
+        the MongoClient that started it. :class:`ClientSession` instances are
+        **not thread-safe or fork-safe**. They can only be used by one thread
+        or process at a time. A single :class:`ClientSession` cannot be used
+        to run multiple operations concurrently.
 
         :Returns:
           An instance of :class:`~pymongo.client_session.ClientSession`.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYTHON-2256