### PR TITLE
fix check_keys param - just ignore it

### DIFF
--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -1213,7 +1213,7 @@ class BSON(bytes):
         .. versionchanged:: 3.0
            Replaced `uuid_subtype` option with `codec_options`.
         """
-        return cls(encode(document, check_keys, codec_options))
+        return cls(encode(document, False, codec_options))
 
     def decode(self, codec_options=DEFAULT_CODEC_OPTIONS):
         """Decode this BSON data.


### PR DESCRIPTION
Since BSON library is a general purpose library and so must follow BSON spec and the spec permits such keys, we cannot have this flag in BSON library.

Actually, everyone who need to store Kubernets YAML file in MongoDB will have problem. Once they have label / attribute like "app.kubernetes.io/managed-by: helm", they will encounter this issue as well.

If MongoDB guys has some needs to verify keys, they has to do it in pymongo code and not in BSON library.
