### PR TITLE
PYTHON-2320 Use select instead of poll on Jython

### DIFF
--- a/pymongo/socket_checker.py
+++ b/pymongo/socket_checker.py
@@ -16,8 +16,11 @@
 
 import errno
 import select
+import sys
 
-_HAVE_POLL = hasattr(select, "poll")
+# PYTHON-2320: Jython does not fully support poll on SSL sockets,
+# https://bugs.jython.org/issue2900
+_HAVE_POLL = hasattr(select, "poll") and not sys.platform.startswith('java')
 _SelectError = getattr(select, "error", OSError)
 
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/PYTHON-2320
Jython poll bug: https://bugs.jython.org/issue2900

Calling poll() on a SSLSocket registered with POLLHUP causes the following AttributeError: 'SSLSocket' object has no attribute 'channel':
```
  File "pymongo/socket_checker.py", line 57, in select
    res = self._poller.poll(timeout * 1000)
  File "/usr/local/Cellar/jython/2.7.2/libexec/Lib/_socket.py", line 592, in poll
    result = self._handle_poll(partial(self.queue.poll, timeout_in_ns, TimeUnit.NANOSECONDS))
  File "/usr/local/Cellar/jython/2.7.2/libexec/Lib/_socket.py", line 541, in _event_test
    fd, event = self._event_test(notification)
  File "/usr/local/Cellar/jython/2.7.2/libexec/Lib/_socket.py", line 541, in _event_test
    if mask & POLLHUP and (notification.hangup or not notification.sock.channel):
AttributeError: 'SSLSocket' object has no attribute 'channel'
```