### PR TITLE
PYTHON-2294 Resync SDAM spec tests to workaround slow elections Windows and macOS

### DIFF
--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -333,6 +333,16 @@ def validate_timeout_or_zero(option, value):
     return validate_positive_float(option, value) / 1000.0
 
 
+def validate_timeout_or_none_or_zero(option, value):
+    """Validates a timeout specified in milliseconds returning
+    a value in floating point seconds. value=0 and value="0" and treated the
+    same as value=None which means unlimited timeout.
+    """
+    if value is None or value == 0 or value == "0":
+        return None
+    return validate_positive_float(option, value) / 1000.0
+
+
 def validate_max_staleness(option, value):
     """Validates maxStalenessSeconds according to the Max Staleness Spec."""
     if value == -1 or value == "-1":
@@ -593,7 +603,7 @@ URI_OPTIONS_VALIDATOR_MAP = {
     'authmechanismproperties': validate_auth_mechanism_properties,
     'authsource': validate_string,
     'compressors': validate_compressors,
-    'connecttimeoutms': validate_timeout_or_none,
+    'connecttimeoutms': validate_timeout_or_none_or_zero,
     'directconnection': validate_boolean_or_string,
     'heartbeatfrequencyms': validate_timeout_or_none,
     'journal': validate_boolean_or_string,
@@ -608,7 +618,7 @@ URI_OPTIONS_VALIDATOR_MAP = {
     'retryreads': validate_boolean_or_string,
     'retrywrites': validate_boolean_or_string,
     'serverselectiontimeoutms': validate_timeout_or_zero,
-    'sockettimeoutms': validate_timeout_or_none,
+    'sockettimeoutms': validate_timeout_or_none_or_zero,
     'ssl_keyfile': validate_readable,
     'tls': validate_boolean_or_string,
     'tlsallowinvalidcertificates': validate_allow_invalid_certs,

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -335,7 +335,7 @@ def validate_timeout_or_zero(option, value):
 
 def validate_timeout_or_none_or_zero(option, value):
     """Validates a timeout specified in milliseconds returning
-    a value in floating point seconds. value=0 and value="0" and treated the
+    a value in floating point seconds. value=0 and value="0" are treated the
     same as value=None which means unlimited timeout.
     """
     if value is None or value == 0 or value == "0":

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -631,7 +631,7 @@ class MongoClient(common.BaseObject):
                 # Determine connection timeout from kwargs.
                 timeout = keyword_opts.get("connecttimeoutms")
                 if timeout is not None:
-                    timeout = common.validate_timeout_or_none(
+                    timeout = common.validate_timeout_or_none_or_zero(
                         keyword_opts.cased_key("connecttimeoutms"), timeout)
                 res = uri_parser.parse_uri(
                     entity, port, validate=True, warn=True, normalize=False,

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -227,11 +227,13 @@ class MongoClient(common.BaseObject):
           - `socketTimeoutMS`: (integer or None) Controls how long (in
             milliseconds) the driver will wait for a response after sending an
             ordinary (non-monitoring) database operation before concluding that
-            a network error has occurred. Defaults to ``None`` (no timeout).
+            a network error has occurred. ``0`` or ``None`` means no timeout.
+            Defaults to ``None`` (no timeout).
           - `connectTimeoutMS`: (integer or None) Controls how long (in
             milliseconds) the driver will wait during server monitoring when
             connecting a new socket to a server before concluding the server
-            is unavailable. Defaults to ``20000`` (20 seconds).
+            is unavailable. ``0`` or ``None`` means no timeout.
+            Defaults to ``20000`` (20 seconds).
           - `server_selector`: (callable or None) Optional, user-provided
             function that augments server selection rules. The function should
             accept as an argument a list of

--- a/test/discovery_and_monitoring_integration/connectTimeoutMS.json
+++ b/test/discovery_and_monitoring_integration/connectTimeoutMS.json
@@ -1,32 +1,63 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.4",
-      "topology": [
-        "replicaset"
-      ]
+      "minServerVersion": "4.4"
     }
   ],
   "database_name": "sdam-tests",
-  "collection_name": "test-replSetStepDown",
-  "data": [
-    {
-      "_id": 1
-    },
-    {
-      "_id": 2
-    }
-  ],
+  "collection_name": "connectTimeoutMS",
+  "data": [],
   "tests": [
     {
-      "description": "Rediscover quickly after replSetStepDown",
+      "description": "connectTimeoutMS=0",
       "clientOptions": {
-        "appname": "replSetStepDownTest",
-        "heartbeatFrequencyMS": 60000,
-        "serverSelectionTimeoutMS": 5000,
-        "w": "majority"
+        "retryWrites": false,
+        "connectTimeoutMS": 0,
+        "heartbeatFrequencyMS": 500,
+        "appname": "connectTimeoutMS=0"
       },
       "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "isMaster"
+                ],
+                "appName": "connectTimeoutMS=0",
+                "blockConnection": true,
+                "blockTimeMS": 550
+              }
+            }
+          }
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 750
+          }
+        },
         {
           "name": "insertMany",
           "object": "collection",
@@ -42,53 +73,11 @@
           }
         },
         {
-          "name": "recordPrimary",
-          "object": "testRunner"
-        },
-        {
-          "name": "runAdminCommand",
-          "object": "testRunner",
-          "command_name": "replSetFreeze",
-          "arguments": {
-            "command": {
-              "replSetFreeze": 0
-            },
-            "readPreference": {
-              "mode": "Secondary"
-            }
-          }
-        },
-        {
-          "name": "runAdminCommand",
-          "object": "testRunner",
-          "command_name": "replSetStepDown",
-          "arguments": {
-            "command": {
-              "replSetStepDown": 30,
-              "secondaryCatchUpPeriodSecs": 30,
-              "force": false
-            }
-          }
-        },
-        {
-          "name": "waitForPrimaryChange",
+          "name": "assertEventCount",
           "object": "testRunner",
           "arguments": {
-            "timeoutMS": 15000
-          }
-        },
-        {
-          "name": "insertMany",
-          "object": "collection",
-          "arguments": {
-            "documents": [
-              {
-                "_id": 5
-              },
-              {
-                "_id": 6
-              }
-            ]
+            "event": "ServerMarkedUnknownEvent",
+            "count": 0
           }
         },
         {
@@ -104,13 +93,13 @@
         {
           "command_started_event": {
             "command": {
-              "insert": "test-replSetStepDown",
+              "insert": "connectTimeoutMS",
               "documents": [
                 {
-                  "_id": 3
+                  "_id": 1
                 },
                 {
-                  "_id": 4
+                  "_id": 2
                 }
               ]
             },
@@ -121,13 +110,13 @@
         {
           "command_started_event": {
             "command": {
-              "insert": "test-replSetStepDown",
+              "insert": "connectTimeoutMS",
               "documents": [
                 {
-                  "_id": 5
+                  "_id": 3
                 },
                 {
-                  "_id": 6
+                  "_id": 4
                 }
               ]
             },
@@ -150,12 +139,6 @@
             },
             {
               "_id": 4
-            },
-            {
-              "_id": 5
-            },
-            {
-              "_id": 6
             }
           ]
         }

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -134,6 +134,24 @@ class ClientUnitTest(unittest.TestCase):
         self.assertEqual(ReadPreference.PRIMARY, client.read_preference)
         self.assertAlmostEqual(12, client.server_selection_timeout)
 
+    def test_connect_timeout(self):
+        client = MongoClient(connect=False, connectTimeoutMS=None,
+                             socketTimeoutMS=None)
+        pool_opts = client._MongoClient__options.pool_options
+        self.assertEqual(None, pool_opts.socket_timeout)
+        self.assertEqual(None, pool_opts.connect_timeout)
+        client = MongoClient(connect=False, connectTimeoutMS=0,
+                             socketTimeoutMS=0)
+        pool_opts = client._MongoClient__options.pool_options
+        self.assertEqual(None, pool_opts.socket_timeout)
+        self.assertEqual(None, pool_opts.connect_timeout)
+        client = MongoClient(
+            'mongodb://localhost/?connectTimeoutMS=0&socketTimeoutMS=0',
+            connect=False)
+        pool_opts = client._MongoClient__options.pool_options
+        self.assertEqual(None, pool_opts.socket_timeout)
+        self.assertEqual(None, pool_opts.connect_timeout)
+
     def test_types(self):
         self.assertRaises(TypeError, MongoClient, 1)
         self.assertRaises(TypeError, MongoClient, 1.14)
@@ -996,8 +1014,8 @@ class TestClient(IntegrationTest):
         c = connected(rs_or_single_client(socketTimeoutMS=None))
         self.assertEqual(None, get_pool(c).opts.socket_timeout)
 
-        self.assertRaises(ValueError,
-                          rs_or_single_client, socketTimeoutMS=0)
+        c = connected(rs_or_single_client(socketTimeoutMS=0))
+        self.assertEqual(None, get_pool(c).opts.socket_timeout)
 
         self.assertRaises(ValueError,
                           rs_or_single_client, socketTimeoutMS=-1)

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -1249,6 +1249,7 @@ class TestClusterTime(IntegrationTest):
         # Prevent heartbeats from updating $clusterTime between operations.
         client = rs_or_single_client(event_listeners=[listener],
                                      heartbeatFrequencyMS=999999)
+        self.addCleanup(client.close)
         collection = client.pymongo_test.collection
         # Prepare for tests of find() and aggregate().
         collection.insert_many([{} for _ in range(10)])


### PR DESCRIPTION
PYTHON-2296 Test behavior of connectTimeoutMS=0 with streaming protocol
PYTHON-2311 Fix flaky streaming protocol test

Patch: https://evergreen.mongodb.com/version/5f129b4e850e614ba95578e7