### PR TITLE
PYTHON-2331 Fix set_memory_error complier warning

### DIFF
--- a/bson/buffer.c
+++ b/bson/buffer.c
@@ -33,7 +33,7 @@ struct buffer {
 
 /* Set Python's error indicator to MemoryError.
  * Called after allocation failures. */
-static void set_memory_error() {
+static void set_memory_error(void) {
     PyErr_NoMemory();
 }
 


### PR DESCRIPTION
```
bson/buffer.c:36:13: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   36 | static void set_memory_error() {
      |             ^~~~~~~~~~~~~~~~
```

Jira: https://jira.mongodb.org/browse/PYTHON-2331