### PR TITLE
PYTHON-2334: Fix gevent race condition

### DIFF
--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -1258,20 +1258,14 @@ class Pool:
                 True, self.opts.wait_queue_timeout):
             self._raise_wait_queue_timeout()
 
+        # We've now acquired the semaphore and must release it on error.
+        sock_info = None
+        incremented = False
         try:
             with self.lock:
                 self.active_sockets += 1
-        except Exception:
-            self._socket_semaphore.release()
+                incremented = True
 
-            if self.enabled_for_cmap:
-                self.opts.event_listeners.publish_connection_check_out_failed(
-                    self.address, ConnectionCheckOutFailedReason.CONN_ERROR)
-            raise
-
-        # We've now acquired the semaphore and must release it on error.
-        sock_info = None
-        try:
             while sock_info is None:
                 try:
                     with self.lock:
@@ -1288,8 +1282,10 @@ class Pool:
                 # We checked out a socket but authentication failed.
                 sock_info.close_socket(ConnectionClosedReason.ERROR)
             self._socket_semaphore.release()
-            with self.lock:
-                self.active_sockets -= 1
+
+            if incremented:
+                with self.lock:
+                    self.active_sockets -= 1
 
             if self.enabled_for_cmap:
                 self.opts.event_listeners.publish_connection_check_out_failed(

--- a/pymongo/thread_util.py
+++ b/pymongo/thread_util.py
@@ -40,22 +40,21 @@ class Semaphore:
             raise ValueError("can't specify timeout for non-blocking acquire")
         rc = False
         endtime = None
-        self._cond.acquire()
-        while self._value == 0:
-            if not blocking:
-                break
-            if timeout is not None:
-                if endtime is None:
-                    endtime = _time() + timeout
-                else:
-                    timeout = endtime - _time()
-                    if timeout <= 0:
-                        break
-            self._cond.wait(timeout)
-        else:
-            self._value = self._value - 1
-            rc = True
-        self._cond.release()
+        with self._cond:
+            while self._value == 0:
+                if not blocking:
+                    break
+                if timeout is not None:
+                    if endtime is None:
+                        endtime = _time() + timeout
+                    else:
+                        timeout = endtime - _time()
+                        if timeout <= 0:
+                            break
+                self._cond.wait(timeout)
+            else:
+                self._value = self._value - 1
+                rc = True
         return rc
 
     __enter__ = acquire


### PR DESCRIPTION
Gevent patches the Lock class such that it can raise Timeout exceptions while waiting in .acquire()

When these raise, it can cause the pymongo thread_util.py:Semaphore to exit the acquire() function without releasing self._cond's lock. Changing to `with self._cond` guarantees release even if an exception is raised by gevent.

Also, in pool.py, when waiting for the lock for active sockets, this same condition could occur and cause self._socket_semaphore's lock to be lost.