### PR TITLE
PYTHON-2334 Add regression test for gevent.Timeout compatibility

### DIFF
--- a/pymongo/thread_util.py
+++ b/pymongo/thread_util.py
@@ -60,10 +60,9 @@ class Semaphore:
     __enter__ = acquire
 
     def release(self):
-        self._cond.acquire()
-        self._value = self._value + 1
-        self._cond.notify()
-        self._cond.release()
+        with self._cond:
+            self._value = self._value + 1
+            self._cond.notify()
 
     def __exit__(self, t, v, tb):
         self.release()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1949,7 +1949,7 @@ class TestMongoClientFailover(MockClientTest):
             raise SkipTest("Must be running monkey patched by gevent")
         from gevent import spawn, Timeout
         client = rs_or_single_client(maxPoolSize=1)
-        coll = client.test.test
+        coll = client.pymongo_test.test
         coll.insert_one({})
 
         def contentious_task():


### PR DESCRIPTION
This is a follow on to: https://github.com/mongodb/mongo-python-driver/pull/472

Before the fixes this test would fail like this:
```
======================================================================
ERROR: test_gevent_timeout (test.test_client.TestMongoClientFailover)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/test/test_client.py", line 1975, in test_gevent_timeout
    self.assertIsNone(ct.get())
  File "src/gevent/greenlet.py", line 769, in gevent._gevent_cgreenlet.Greenlet.get
  File "src/gevent/greenlet.py", line 364, in gevent._gevent_cgreenlet.Greenlet._raise_exception
  File "/Users/shane/git/mongo-python-driver/venv3.8/lib/python3.8/site-packages/gevent/_compat.py", line 65, in reraise
    raise value.with_traceback(tb)
  File "src/gevent/greenlet.py", line 854, in gevent._gevent_cgreenlet.Greenlet.run
  File "/Users/shane/git/mongo-python-driver/test/test_client.py", line 1959, in contentious_task
    coll.find_one({'$where': delay(1)})
  File "/Users/shane/git/mongo-python-driver/pymongo/collection.py", line 1319, in find_one
    for result in cursor.limit(-1):
  File "/Users/shane/git/mongo-python-driver/pymongo/cursor.py", line 1207, in next
    if len(self.__data) or self._refresh():
  File "/Users/shane/git/mongo-python-driver/pymongo/cursor.py", line 1124, in _refresh
    self.__send_message(q)
  File "/Users/shane/git/mongo-python-driver/pymongo/cursor.py", line 999, in __send_message
    response = client._run_operation_with_response(
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1368, in _run_operation_with_response
    return self._retryable_read(
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1471, in _retryable_read
    return func(session, server, sock_info, slave_ok)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1312, in _slaveok_for_server
    yield sock_info, slave_ok
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1255, in _get_socket
    yield sock_info
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/Users/shane/git/mongo-python-driver/pymongo/pool.py", line 1238, in get_socket
    self.return_socket(sock_info)
  File "/Users/shane/git/mongo-python-driver/pymongo/pool.py", line 1317, in return_socket
    self._socket_semaphore.release()
  File "/Users/shane/git/mongo-python-driver/pymongo/thread_util.py", line 86, in release
    return Semaphore.release(self)
  File "/Users/shane/git/mongo-python-driver/pymongo/thread_util.py", line 64, in release
    self._cond.acquire()
  File "/Users/shane/git/mongo-python-driver/venv3.8/lib/python3.8/site-packages/gevent/thread.py", line 118, in acquire
    acquired = BoundedSemaphore.acquire(self, blocking, timeout)
  File "src/gevent/_semaphore.py", line 143, in gevent._gevent_c_semaphore.Semaphore.acquire
  File "src/gevent/_semaphore.py", line 178, in gevent._gevent_c_semaphore.Semaphore.acquire
  File "src/gevent/_abstract_linkable.py", line 381, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait
  File "src/gevent/_abstract_linkable.py", line 346, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 352, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 348, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 303, in gevent._gevent_c_abstract_linkable.AbstractLinkable._AbstractLinkable__wait_to_be_notified
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 65, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_gevent_c_greenlet_primitives.pxd", line 35, in gevent._gevent_c_greenlet_primitives._greenlet_switch
gevent.timeout.Timeout: 10 seconds

----------------------------------------------------------------------
Ran 1 test in 10.015s

FAILED (errors=1)
```

After the changes in PYTHON-2334 the test passes.

CC: @TylerWilley 