### PR TITLE
PYTHON-2372 Build macOS releases in Evergreen

### DIFF
--- a/.evergreen/build-mac.sh
+++ b/.evergreen/build-mac.sh
@@ -2,11 +2,14 @@
 
 for VERSION in 2.7 3.4 3.5 3.6 3.7 3.8; do
     if [[ $VERSION == "2.7" ]]; then
+        PYTHON=/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python
         rm -rf build
-        python$VERSION setup.py bdist_egg
+        $PYTHON setup.py bdist_egg
+    else
+        PYTHON=/Library/Frameworks/Python.framework/Versions/$VERSION/bin/python3
     fi
     rm -rf build
-    python$VERSION setup.py bdist_wheel
+    $PYTHON setup.py bdist_wheel
 done
 
 ls dist

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -817,7 +817,7 @@ tasks:
 
     - name: "release"
       tags: ["release"]
-      git_tag_only: true
+#      git_tag_only: true
       commands:
         - command: shell.exec
           type: test
@@ -2563,7 +2563,7 @@ buildvariants:
 
 - matrix_name: "Release"
   matrix_spec:
-    platform: [ubuntu-20.04, windows-64-vsMulti-small]
+    platform: [ubuntu-20.04, windows-64-vsMulti-small, macos-1014]
   display_name: "Release ${platform}"
   tasks:
     - name: "release"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -817,7 +817,7 @@ tasks:
 
     - name: "release"
       tags: ["release"]
-#      git_tag_only: true
+      git_tag_only: true
       commands:
         - command: shell.exec
           type: test


### PR DESCRIPTION
Tested here: https://evergreen.mongodb.com/version/5f5c16890305b97395debec5

Here are the new files:
```
[2020/09/12 00:32:00.273] pymongo-3.11.1.dev1-cp27-cp27m-macosx_10_14_intel.whl
[2020/09/12 00:32:00.273] pymongo-3.11.1.dev1-cp34-cp34m-macosx_10_6_intel.whl
[2020/09/12 00:32:00.273] pymongo-3.11.1.dev1-cp35-cp35m-macosx_10_6_intel.whl
[2020/09/12 00:32:00.273] pymongo-3.11.1.dev1-cp36-cp36m-macosx_10_6_intel.whl
[2020/09/12 00:32:00.273] pymongo-3.11.1.dev1-cp37-cp37m-macosx_10_6_intel.whl
[2020/09/12 00:32:00.273] pymongo-3.11.1.dev1-cp38-cp38-macosx_10_9_x86_64.whl
[2020/09/12 00:32:00.273] pymongo-3.11.1.dev1-py2.7-macosx-10.14-intel.egg
```