### PR TITLE
PYTHON-2375 Remove macos system python workaround for missing wheel package

### DIFF
--- a/.evergreen/build-mac.sh
+++ b/.evergreen/build-mac.sh
@@ -18,18 +18,7 @@ for VERSION in 2.7 3.4 3.5 3.6 3.7 3.8; do
     fi
     rm -rf build
 
-    # Install wheel if not already there.
-    if ! $PYTHON -m wheel version; then
-        createvirtualenv $PYTHON releasevenv
-        WHEELPYTHON=python
-        pip install --upgrade wheel
-    else
-        WHEELPYTHON=$PYTHON
-    fi
-
-    $WHEELPYTHON setup.py bdist_wheel
-    deactivate || true
-    rm -rf releasevenv
+    $PYTHON setup.py bdist_wheel
 
     # Test that each wheel is installable.
     for release in dist/*; do


### PR DESCRIPTION
Tested here: https://evergreen.mongodb.com/version/5f6e5959d6d80a45fc929848