### PR TITLE
PYTHON-2342 Prefer checking error codes over error messages

### DIFF
--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -120,18 +120,8 @@ def _check_command_response(response, max_wire_version,
     if response["ok"]:
         return
 
-    details = response
-    # Mongos returns the error details in a 'raw' object
-    # for some errors.
-    if "raw" in response:
-        for shard in itervalues(response["raw"]):
-            # Grab the first non-empty raw error from a shard.
-            if shard.get("errmsg") and not shard.get("ok"):
-                details = shard
-                break
-
-    errmsg = details["errmsg"]
-    code = details.get("code")
+    errmsg = response["errmsg"]
+    code = response.get("code")
 
     # For allowable errors, only check for error messages when the code is not
     # included.

--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -120,8 +120,18 @@ def _check_command_response(response, max_wire_version,
     if response["ok"]:
         return
 
-    errmsg = response["errmsg"]
-    code = response.get("code")
+    details = response
+    # Mongos returns the error details in a 'raw' object
+    # for some errors.
+    if "raw" in response:
+        for shard in itervalues(response["raw"]):
+            # Grab the first non-empty raw error from a shard.
+            if shard.get("errmsg") and not shard.get("ok"):
+                details = shard
+                break
+
+    errmsg = details["errmsg"]
+    code = details.get("code")
 
     # For allowable errors, only check for error messages when the code is not
     # included.

--- a/pymongo/network.py
+++ b/pymongo/network.py
@@ -157,8 +157,7 @@ def command(sock_info, dbname, spec, slave_ok, is_mongos,
                 client._process_response(response_doc, session)
             if check:
                 helpers._check_command_response(
-                    response_doc, sock_info.max_wire_version, None,
-                    allowable_errors,
+                    response_doc, sock_info.max_wire_version, allowable_errors,
                     parse_write_concern_error=parse_write_concern_error)
     except Exception as exc:
         if publish:

--- a/pymongo/server.py
+++ b/pymongo/server.py
@@ -131,10 +131,8 @@ class Server(object):
                               user_fields=user_fields)
             if use_cmd:
                 first = docs[0]
-                operation.client._process_response(
-                    first, operation.session)
-                _check_command_response(
-                    first, sock_info.max_wire_version)
+                operation.client._process_response(first, operation.session)
+                _check_command_response(first, sock_info.max_wire_version)
         except Exception as exc:
             if publish:
                 duration = datetime.now() - start

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -969,10 +969,8 @@ class TestDatabase(IntegrationTest):
             'errmsg': 'outer',
             'raw': {'shard0/host0,host1': {'ok': 0, 'errmsg': 'inner'}}}
 
-        with self.assertRaises(OperationFailure) as context:
+        with self.assertRaisesRegex(OperationFailure, 'outer, full error:'):
             helpers._check_command_response(error_document, None)
-
-        self.assertIn('inner', str(context.exception))
 
         # If a shard has no primary and you run a command like dbstats, which
         # cannot be run on a secondary, mongos's response includes empty "raw"
@@ -982,10 +980,8 @@ class TestDatabase(IntegrationTest):
             'errmsg': 'outer',
             'raw': {'shard0/host0,host1': {}}}
 
-        with self.assertRaises(OperationFailure) as context:
+        with self.assertRaisesRegex(OperationFailure, 'outer, full error:'):
             helpers._check_command_response(error_document, None)
-
-        self.assertIn('outer', str(context.exception))
 
         # Raw error has ok: 0 but no errmsg. Not a known case, but test it.
         error_document = {
@@ -993,10 +989,8 @@ class TestDatabase(IntegrationTest):
             'errmsg': 'outer',
             'raw': {'shard0/host0,host1': {'ok': 0}}}
 
-        with self.assertRaises(OperationFailure) as context:
+        with self.assertRaisesRegex(OperationFailure, 'outer, full error:'):
             helpers._check_command_response(error_document, None)
-
-        self.assertIn('outer', str(context.exception))
 
     @client_context.require_test_commands
     @client_context.require_no_mongos

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -969,8 +969,10 @@ class TestDatabase(IntegrationTest):
             'errmsg': 'outer',
             'raw': {'shard0/host0,host1': {'ok': 0, 'errmsg': 'inner'}}}
 
-        with self.assertRaisesRegex(OperationFailure, 'outer, full error:'):
+        with self.assertRaises(OperationFailure) as context:
             helpers._check_command_response(error_document, None)
+
+        self.assertIn('inner', str(context.exception))
 
         # If a shard has no primary and you run a command like dbstats, which
         # cannot be run on a secondary, mongos's response includes empty "raw"
@@ -980,8 +982,10 @@ class TestDatabase(IntegrationTest):
             'errmsg': 'outer',
             'raw': {'shard0/host0,host1': {}}}
 
-        with self.assertRaisesRegex(OperationFailure, 'outer, full error:'):
+        with self.assertRaises(OperationFailure) as context:
             helpers._check_command_response(error_document, None)
+
+        self.assertIn('outer', str(context.exception))
 
         # Raw error has ok: 0 but no errmsg. Not a known case, but test it.
         error_document = {
@@ -989,8 +993,10 @@ class TestDatabase(IntegrationTest):
             'errmsg': 'outer',
             'raw': {'shard0/host0,host1': {'ok': 0}}}
 
-        with self.assertRaisesRegex(OperationFailure, 'outer, full error:'):
+        with self.assertRaises(OperationFailure) as context:
             helpers._check_command_response(error_document, None)
+
+        self.assertIn('outer', str(context.exception))
 
     @client_context.require_test_commands
     @client_context.require_no_mongos


### PR DESCRIPTION
I've performed the following requests in the drivers ticket:

> - Audit the driver for uses of error messages to make decisions
> - For each error message, determine the server's related error code and check that first, falling back to error message matching to avoid breaking changes with old server versions.
>
> For example, the Python driver does an exact match on the error message "ns not found". It should attempt to match error code 26 first, matching the error message as a fallback. The fallback is necessary to avoid a backward breaking change with MongoDB 2.6 and 3.0 which do not return an error code.


I also removed the "db assertion failure" check which was removed by the server in MongoDB 2.5.
