### PR TITLE
PYTHON-2360 Ensure ConnectionCreatedEvents are emitted before ConnectionReadyEvents

### DIFF
--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -1150,7 +1150,6 @@ class Pool:
                 break
             try:
                 sock_info = self.connect(all_credentials)
-                sock_info.check_auth(all_credentials)
                 with self.lock:
                     # Close connection and return if the pool was reset during
                     # socket creation or while acquiring the pool lock.
@@ -1193,6 +1192,12 @@ class Pool:
         if self.handshake:
             sock_info.ismaster(all_credentials)
             self.is_writable = sock_info.is_writable
+
+        try:
+            sock_info.check_auth(all_credentials)
+        except Exception:
+            sock_info.close_socket(ConnectionClosedReason.ERROR)
+            raise
 
         return sock_info
 

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -1150,6 +1150,7 @@ class Pool:
                 break
             try:
                 sock_info = self.connect(all_credentials)
+                sock_info.check_auth(all_credentials)
                 with self.lock:
                     # Close connection and return if the pool was reset during
                     # socket creation or while acquiring the pool lock.

--- a/test/cmap/connection-must-have-id.json
+++ b/test/cmap/connection-must-have-id.json
@@ -12,26 +12,32 @@
   ],
   "events": [
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/connection-must-order-ids.json
+++ b/test/cmap/connection-must-order-ids.json
@@ -12,26 +12,32 @@
   ],
   "events": [
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 2
+      "connectionId": 2,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 2
+      "connectionId": 2,
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/pool-checkin-destroy-closed.json
+++ b/test/cmap/pool-checkin-destroy-closed.json
@@ -18,7 +18,8 @@
   "events": [
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionPoolClosed",
@@ -26,12 +27,14 @@
     },
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionClosed",
       "connectionId": 1,
-      "reason": "poolClosed"
+      "reason": "poolClosed",
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/pool-checkin-destroy-stale.json
+++ b/test/cmap/pool-checkin-destroy-stale.json
@@ -18,7 +18,8 @@
   "events": [
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionPoolCleared",
@@ -26,12 +27,14 @@
     },
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionClosed",
       "connectionId": 1,
-      "reason": "stale"
+      "reason": "stale",
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/pool-checkin-make-available.json
+++ b/test/cmap/pool-checkin-make-available.json
@@ -18,15 +18,18 @@
   "events": [
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/pool-checkin.json
+++ b/test/cmap/pool-checkin.json
@@ -15,7 +15,8 @@
   "events": [
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/pool-checkout-connection.json
+++ b/test/cmap/pool-checkout-connection.json
@@ -9,16 +9,26 @@
   ],
   "events": [
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     }
   ],
   "ignore": [
-    "ConnectionPoolCreated",
-    "ConnectionCreated",
-    "ConnectionReady"
+    "ConnectionPoolCreated"
   ]
 }

--- a/test/cmap/pool-checkout-multiple.json
+++ b/test/cmap/pool-checkout-multiple.json
@@ -43,15 +43,18 @@
   "events": [
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/pool-checkout-no-idle.json
+++ b/test/cmap/pool-checkout-no-idle.json
@@ -30,20 +30,24 @@
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionClosed",
       "connectionId": 1,
-      "reason": "idle"
+      "reason": "idle",
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 2
+      "connectionId": 2,
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/pool-checkout-no-stale.json
+++ b/test/cmap/pool-checkout-no-stale.json
@@ -26,11 +26,13 @@
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 1
+      "connectionId": 1,
+      "address": 42
     },
     {
       "type": "ConnectionPoolCleared",
@@ -39,11 +41,13 @@
     {
       "type": "ConnectionClosed",
       "connectionId": 1,
-      "reason": "stale"
+      "reason": "stale",
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 2
+      "connectionId": 2,
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/pool-close-destroy-conns.json
+++ b/test/cmap/pool-close-destroy-conns.json
@@ -24,12 +24,14 @@
   "events": [
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 2
+      "connectionId": 2,
+      "address": 42
     },
     {
       "type": "ConnectionClosed",
       "connectionId": 2,
-      "reason": "poolClosed"
+      "reason": "poolClosed",
+      "address": 42
     },
     {
       "type": "ConnectionPoolClosed",

--- a/test/cmap/pool-create-max-size.json
+++ b/test/cmap/pool-create-max-size.json
@@ -53,59 +53,74 @@
       "options": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/pool-create-min-size.json
+++ b/test/cmap/pool-create-min-size.json
@@ -12,6 +12,11 @@
       "count": 3
     },
     {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 3
+    },
+    {
       "name": "checkOut"
     }
   ],
@@ -23,19 +28,23 @@
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     }
   ],
   "ignore": [

--- a/test/cmap/wait-queue-timeout.json
+++ b/test/cmap/wait-queue-timeout.json
@@ -39,22 +39,27 @@
   },
   "events": [
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
     },
     {
       "type": "ConnectionCheckOutFailed",
-      "reason": "timeout"
+      "reason": "timeout",
+      "address": 42
     },
     {
       "type": "ConnectionCheckedIn",
-      "connectionId": 42
+      "connectionId": 42,
+      "address": 42
     }
   ],
   "ignore": [


### PR DESCRIPTION
This uncovered a minor oversight in our minPoolSize connection creation logic. We did create the connection but we did not ensure that the connection was authenticated. Connections created in the background (for minPoolSize) are now authenticated. This is a minor performance improvement (lower latency on first connection use).