### PR TITLE
PYTHON-2357 Specify error label in retryable writes test

### DIFF
--- a/test/retryable_writes/insertOne-serverErrors.json
+++ b/test/retryable_writes/insertOne-serverErrors.json
@@ -966,7 +966,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -38,7 +38,6 @@ from pymongo.operations import (InsertOne,
 from pymongo.write_concern import WriteConcern
 
 from test import unittest, client_context, IntegrationTest, SkipTest, client_knobs
-from test.test_crud_v1 import check_result as crud_v1_check_result
 from test.utils import (rs_or_single_client,
                         DeprecationFilter,
                         OvertCommandListener,

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -62,20 +62,15 @@ class TestAllScenarios(SpecRunner):
         return scenario_def.get('collection_name', 'test')
 
     def run_test_ops(self, sessions, collection, test):
+        # Transform retryable writes spec format into transactions.
+        operation = test['operation']
         outcome = test['outcome']
-        should_fail = outcome.get('error')
-        result = None
-        error = None
-        try:
-            result = self.run_operation(
-                sessions, collection, test['operation'])
-        except (ConnectionFailure, OperationFailure) as exc:
-            error = exc
-        if should_fail:
-            self.assertIsNotNone(error, 'should have raised an error')
-        else:
-            self.assertIsNone(error)
-            crud_v1_check_result(self, outcome['result'], result)
+        if 'error' in outcome:
+            operation['error'] = outcome['error']
+        if 'result' in outcome:
+            operation['result'] = outcome['result']
+        test['operations'] = [operation]
+        super(TestAllScenarios, self).run_test_ops(sessions, collection, test)
 
 
 def create_test(scenario_def, test, name):


### PR DESCRIPTION
Two changes:
- PYTHON-2357 Specify error label in retryable writes test (simply resyncs the tests).
- PYTHON-2356 Add errorLabelsContain/errorLabelsOmit support to retryable writes tests (implemented by transforming the retryable write test into the transaction test format).