### PR TITLE
PYTHON-2382 Destroy codec options struct in _cbson._element_to_dict

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2713,6 +2713,7 @@ static PyObject* _cbson_element_to_dict(PyObject* self, PyObject* args) {
         return NULL;
     }
 
+    destroy_codec_options(&options);
     return result_tuple;
 }
 


### PR DESCRIPTION
Tested using a slightly modified version of the user-provided repro script:

```
import gc
from typing import Any
from pymongo import MongoClient
from bson.codec_options import CodecOptions
from bson.codec_options import TypeCodec, TypeRegistry


# %% Define method to analyse the memory
def memory_report(prefix):
    gc.collect()
    rr = {}

    for obj in gc.get_objects():

        tt = type(obj)
        if ('bson.codec_options.CodecOptions' in str(tt)):
            refs = gc.get_referrers(obj)
            print(tt)
            print(len(refs))
            # if len(refs) == 1:
            #     objgraph.show_refs([obj], filename='refs.png')
            rr[tt] = rr.get(tt, 0) + 1

    print(prefix + ' memory report:')
    for key in rr:
        nn = rr[key]
        print(f' {key}: {nn}')


# %% Create codec

class MyClass:
    pass


class MyCodec(TypeCodec):  # type: ignore

    @property
    def python_type(self) -> Any:
        return MyClass

    def transform_python(self, value: Any) -> Any:
        # print(f'transform_python: {value}')
        return value

    @property
    def bson_type(self) -> Any:
        return int

    def transform_bson(self, value: Any) -> Any:
        # print(f'transform_bson: {value}')
        return value * 2


codec = MyCodec()
type_registry = TypeRegistry([codec])
codec_options = CodecOptions(type_registry=type_registry)

client = MongoClient(replicaset='repl0')
database = client['my_database']
collection = database['my_collection'].with_options(codec_options)
collection.drop()

memory_report('before ')
for ii in range(10):
    collection.insert_one({'a': 2})
    cursor = collection.find({})
    for data in cursor:
        assert data['a'] == 4
memory_report('after ')
```