### PR TITLE
PYTHON-2390 Retryable read attempts should use the same implicit session

### DIFF
--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1440,8 +1440,8 @@ class MongoClient(common.BaseObject):
                     retrying = True
                 last_error = exc
 
-    def _retryable_read(self, func, read_pref, session, address=None,
-                        retryable=True, exhaust=False):
+    def _retryable_read_with_session(self, func, read_pref, session,
+                                     address, retryable, exhaust):
         """Execute an operation with at most one consecutive retries
 
         Returns func()'s return value on success. On error retries the same
@@ -1496,6 +1496,13 @@ class MongoClient(common.BaseObject):
         """Internal retryable write helper."""
         with self._tmp_session(session) as s:
             return self._retry_with_session(retryable, func, s, None)
+
+    def _retryable_read(self, func, read_pref, session,
+                        address=None, retryable=True, exhaust=False):
+        """Internal retryable read helper."""
+        with self._tmp_session(session) as s:
+            return self._retryable_read_with_session(
+                func, read_pref, s, address, retryable, exhaust)
 
     def _handle_getlasterror(self, address, error_msg):
         """Clear our pool for a server, mark it Unknown, and check it soon."""

--- a/test/retryable_reads_custom/aggregate.json
+++ b/test/retryable_reads_custom/aggregate.json
@@ -1,0 +1,125 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              }
+            ],
+            "batchSize": 2
+          },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": 42,
+              "collection": "coll"
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/retryable_reads_custom/changeStreams-db.coll.watch.json
+++ b/test/retryable_reads_custom/changeStreams-db.coll.watch.json
@@ -1,0 +1,81 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    }
+  ],
+  "tests": [
+     {
+      "description": "db.coll.watch succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "cursor": {},
+              "pipeline": [
+                {
+                  "$changeStream": {}
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "cursor": {},
+              "pipeline": [
+                {
+                  "$changeStream": {}
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/retryable_reads_custom/count.json
+++ b/test/retryable_reads_custom/count.json
@@ -1,0 +1,78 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "Count succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "count"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "count": "coll"
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "count": "coll"
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/retryable_reads_custom/countDocuments.json
+++ b/test/retryable_reads_custom/countDocuments.json
@@ -1,0 +1,104 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "CountDocuments succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$match": {}
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$match": {}
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/retryable_reads_custom/distinct.json
+++ b/test/retryable_reads_custom/distinct.json
@@ -1,0 +1,102 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "tests": [
+    {
+      "description": "Distinct succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "distinct"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            }
+          },
+          "result": [
+            22,
+            33
+          ]
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "distinct": "coll",
+              "key": "x",
+              "query": {
+                "_id": {
+                  "$gt": 1
+                }
+              }
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "distinct": "coll",
+              "key": "x",
+              "query": {
+                "_id": {
+                  "$gt": 1
+                }
+              }
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/retryable_reads_custom/estimatedDocumentCount.json
+++ b/test/retryable_reads_custom/estimatedDocumentCount.json
@@ -1,0 +1,75 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "EstimatedDocumentCount succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "count"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "count": "coll"
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "count": "coll"
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/retryable_reads_custom/find.json
+++ b/test/retryable_reads_custom/find.json
@@ -1,0 +1,124 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    },
+    {
+      "_id": 4,
+      "x": 44
+    },
+    {
+      "_id": 5,
+      "x": 55
+    }
+  ],
+  "tests": [
+    {
+      "description": "Find succeeds on second attempt with explicit clientOptions",
+      "clientOptions": {
+        "retryReads": true
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "find"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
+          },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "coll",
+              "filter": {},
+              "sort": {
+                "_id": 1
+              },
+              "limit": 4
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "coll",
+              "filter": {},
+              "sort": {
+                "_id": 1
+              },
+              "limit": 4
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/retryable_reads_custom/listCollections.json
+++ b/test/retryable_reads_custom/listCollections.json
@@ -1,0 +1,63 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [],
+  "tests": [
+    {
+      "description": "ListCollections succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "listCollections"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/retryable_reads_custom/listDatabases.json
+++ b/test/retryable_reads_custom/listDatabases.json
@@ -1,0 +1,63 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [],
+  "tests": [
+    {
+      "description": "ListDatabases succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "listDatabases"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listDatabases": 1
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "listDatabases": 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/retryable_reads_custom/listIndexes.json
+++ b/test/retryable_reads_custom/listIndexes.json
@@ -1,0 +1,65 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [],
+  "tests": [
+    {
+      "description": "ListIndexes succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "listIndexes"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listIndexes": "coll"
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "listIndexes": "coll"
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -28,8 +28,10 @@ from test.utils_spec_runner import SpecRunner
 
 
 # Location of JSON test specifications.
-_TEST_PATH = os.path.join(
+TEST_PATH = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'retryable_reads')
+TEST_PATH_CUSTOM = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), 'retryable_reads_custom')
 
 
 class TestClientOptions(PyMongoTestCase):
@@ -53,7 +55,6 @@ class TestClientOptions(PyMongoTestCase):
 class TestSpec(SpecRunner):
 
     @classmethod
-    @client_context.require_version_min(4, 0)
     # TODO: remove this once PYTHON-1948 is done.
     @client_context.require_no_mmap
     def setUpClass(cls):
@@ -98,6 +99,10 @@ class TestSpec(SpecRunner):
             super(TestSpec, self).setup_scenario(scenario_def)
 
 
+class TestSpecCustom(SpecRunner):
+    pass
+
+
 def create_test(scenario_def, test, name):
     @client_context.require_test_commands
     def run_scenario(self):
@@ -106,8 +111,8 @@ def create_test(scenario_def, test, name):
     return run_scenario
 
 
-test_creator = TestCreator(create_test, TestSpec, _TEST_PATH)
-test_creator.create_tests()
+TestCreator(create_test, TestSpec, TEST_PATH).create_tests()
+TestCreator(create_test, TestSpecCustom, TEST_PATH_CUSTOM).create_tests()
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -1349,38 +1349,6 @@ class TestSpec(SpecRunner):
     TEST_PATH = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), 'sessions')
 
-    def last_two_command_events(self):
-        """Return the last two command started events."""
-        started_events = self.listener.results['started'][-2:]
-        self.assertEqual(2, len(started_events))
-        return started_events
-
-    def assert_same_lsid_on_last_two_commands(self):
-        """Run the assertSameLsidOnLastTwoCommands test operation."""
-        event1, event2 = self.last_two_command_events()
-        self.assertEqual(event1.command['lsid'], event2.command['lsid'])
-
-    def assert_different_lsid_on_last_two_commands(self):
-        """Run the assertDifferentLsidOnLastTwoCommands test operation."""
-        event1, event2 = self.last_two_command_events()
-        self.assertNotEqual(event1.command['lsid'], event2.command['lsid'])
-
-    def assert_session_dirty(self, session):
-        """Run the assertSessionDirty test operation.
-
-        Assert that the given session is dirty.
-        """
-        self.assertIsNotNone(session._server_session)
-        self.assertTrue(session._server_session.dirty)
-
-    def assert_session_not_dirty(self, session):
-        """Run the assertSessionNotDirty test operation.
-
-        Assert that the given session is not dirty.
-        """
-        self.assertIsNotNone(session._server_session)
-        self.assertFalse(session._server_session.dirty)
-
 
 def create_test(scenario_def, test, name):
     @client_context.require_test_commands

--- a/test/utils_spec_runner.py
+++ b/test/utils_spec_runner.py
@@ -172,6 +172,38 @@ class SpecRunner(IntegrationTest):
         coll = self.client[database][collection]
         self.assertNotIn(index, [doc['name'] for doc in coll.list_indexes()])
 
+    def last_two_command_events(self):
+        """Return the last two command started events."""
+        started_events = self.listener.results['started'][-2:]
+        self.assertEqual(2, len(started_events))
+        return started_events
+
+    def assert_same_lsid_on_last_two_commands(self):
+        """Run the assertSameLsidOnLastTwoCommands test operation."""
+        event1, event2 = self.last_two_command_events()
+        self.assertEqual(event1.command['lsid'], event2.command['lsid'])
+
+    def assert_different_lsid_on_last_two_commands(self):
+        """Run the assertDifferentLsidOnLastTwoCommands test operation."""
+        event1, event2 = self.last_two_command_events()
+        self.assertNotEqual(event1.command['lsid'], event2.command['lsid'])
+
+    def assert_session_dirty(self, session):
+        """Run the assertSessionDirty test operation.
+
+        Assert that the given session is dirty.
+        """
+        self.assertIsNotNone(session._server_session)
+        self.assertTrue(session._server_session.dirty)
+
+    def assert_session_not_dirty(self, session):
+        """Run the assertSessionNotDirty test operation.
+
+        Assert that the given session is not dirty.
+        """
+        self.assertIsNotNone(session._server_session)
+        self.assertFalse(session._server_session.dirty)
+
     def assertErrorLabelsContain(self, exc, expected_labels):
         labels = [l for l in expected_labels if exc.has_error_label(l)]
         self.assertEqual(labels, expected_labels)


### PR DESCRIPTION
My testing approach uses the `assertSameLsidOnLastTwoCommands` spec test operation from the session spec test to assert that both attempts use the same implicit session. For now I added these tests to the `retryable_reads_custom` directory but I'm also planning to make push these changes upstream into the spec repo.