### PR TITLE
Revert "PYTHON-2362 Use dnspython<2.0 to avoid timeouts (#484)"

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -201,12 +201,6 @@ if [ -n "$COVERAGE" -a $PYTHON_IMPL = "CPython" ]; then
     fi
 fi
 
-if $PYTHON -c 'import dns'; then
-  # Trying with/without --user to avoid:
-  # ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
-  $PYTHON -m pip install --upgrade --user 'dnspython<2.0.0' || $PYTHON -m pip install --upgrade 'dnspython<2.0.0'
-fi
-
 $PYTHON setup.py clean
 if [ -z "$GREEN_FRAMEWORK" ]; then
     if [ -z "$C_EXTENSIONS" -a $PYTHON_IMPL = "CPython" ]; then


### PR DESCRIPTION
This reverts commit c54974067772f268a9a9dc6dbba0a490e6b8e842.

This should no longer be needed now that our toolchain installs dnspython<2.0.