### PR TITLE
Added the mincePy ODM library to documented tools

### DIFF
--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -49,7 +49,7 @@ Humongolus
    examples are also available at GitHub.
    
 MincePy
-   `MincePy <https://https://mincepy.readthedocs.io/en/latest/>`_ is an 
+   `MincePy <https://mincepy.readthedocs.io/en/latest/>`_ is an 
    object-document mapper (ODM) designed to make any Python object storable 
    and queryable in a MongoDB database. It is designed with machine learning 
    and big-data computational and experimental science applications in mind 

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -47,6 +47,15 @@ Humongolus
    possible. The code is available for download
    `at GitHub <https://github.com/entone/Humongolus>`_. Tutorials and usage
    examples are also available at GitHub.
+   
+MincePy
+   `MincePy <https://https://mincepy.readthedocs.io/en/latest/>`_ is an 
+   object-document mapper (ODM) designed to make any Python object storable 
+   and queryable in a MongoDB database. It is designed with machine learning 
+   and big-data computational and experimental science applications in mind 
+   but is entirely general and can be useful to anyone looking to organise, 
+   share, or process large amounts data with as little change to their current 
+   workflow as possible.
 
 Ming
   `Ming <http://merciless.sourceforge.net/>`_ (the Merciless) is a
@@ -71,7 +80,7 @@ MotorEngine
   It implements the same modeling APIs to be data-portable, meaning that a
   model defined in MongoEngine can be read in MotorEngine. The source is
   `available on GitHub <http://github.com/heynemann/motorengine>`_.
-
+  
 uMongo
   `uMongo <https://umongo.readthedocs.io/>`_ is a Python MongoDB ODM.
   Its inception comes from two needs: the lack of async ODM and the


### PR DESCRIPTION
MincePy is an ODM built on top of pymongo using the data-mapper pattern.

Be great if you guys would be willing to include this in the list as I think it offers something quite different from most (if not all) of the other ODMs in that it doesn't require that users subclass from a common model class, which means that any arbitrary Python object can be made storable.  This is invaluable in situations when you don't own (i.e. they're not in your codebase) the types you want to save.