### PR TITLE
PYTHON-2363 Rate limit new connection creations via maxConnecting

### DIFF
--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -89,6 +89,9 @@ MAX_POOL_SIZE = 100
 # Default value for minPoolSize.
 MIN_POOL_SIZE = 0
 
+# The maximum number of concurrent connection creation attempts per pool.
+MAX_CONNECTING = 2
+
 # Default value for maxIdleTimeMS.
 MAX_IDLE_TIME_MS = None
 

--- a/test/cmap/pool-checkout-maxConnecting-is-enforced.json
+++ b/test/cmap/pool-checkout-maxConnecting-is-enforced.json
@@ -1,0 +1,104 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "maxConnecting is enforced",
+  "runOn": [
+    {
+      "minServerVersion": "4.4.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 50
+    },
+    "data": {
+      "failCommands": [
+        "isMaster"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 750
+    }
+  },
+  "poolOptions": {
+    "maxPoolSize": 10,
+    "waitQueueTimeoutMS": 5000
+  },
+  "operations": [
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "wait",
+      "thread": "thread2",
+      "ms": 100
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "wait",
+      "thread": "thread3",
+      "ms": 100
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 3
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCreated",
+      "address": 42,
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42,
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCheckOutStarted",
+    "ConnectionCheckedIn",
+    "ConnectionCheckedOut",
+    "ConnectionClosed",
+    "ConnectionPoolCreated"
+  ]
+}

--- a/test/cmap/pool-checkout-maxConnecting-timeout.json
+++ b/test/cmap/pool-checkout-maxConnecting-timeout.json
@@ -1,0 +1,98 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "waiting on maxConnecting is limited by WaitQueueTimeoutMS",
+  "runOn": [
+    {
+      "minServerVersion": "4.4.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 50
+    },
+    "data": {
+      "failCommands": [
+        "isMaster"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 750
+    }
+  },
+  "poolOptions": {
+    "maxPoolSize": 10,
+    "waitQueueTimeoutMS": 50
+  },
+  "operations": [
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 2
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
+    },
+    {
+      "name": "waitForThread",
+      "target": "thread3"
+    }
+  ],
+  "error": {
+    "type": "WaitQueueTimeoutError",
+    "message": "Timed out while checking out a connection from connection pool"
+  },
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "timeout",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionCheckedIn",
+    "ConnectionCheckedOut",
+    "ConnectionClosed",
+    "ConnectionPoolCreated"
+  ]
+}

--- a/test/cmap/pool-checkout-returned-connection-maxConnecting.json
+++ b/test/cmap/pool-checkout-returned-connection-maxConnecting.json
@@ -1,0 +1,119 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "threads blocked by maxConnecting check out returned connections",
+  "runOn": [
+    {
+      "minServerVersion": "4.4.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 50
+    },
+    "data": {
+      "failCommands": [
+        "isMaster"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 750
+    }
+  },
+  "poolOptions": {
+    "maxPoolSize": 10,
+    "waitQueueTimeoutMS": 5000
+  },
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn0"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 4
+    },
+    {
+      "name": "wait",
+      "ms": 100
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn0"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckedOut",
+      "count": 4
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCreated",
+      "address": 42,
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionClosed",
+    "ConnectionReady",
+    "ConnectionPoolCreated",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -401,7 +401,7 @@ class TestPooling(_TestPoolingBase):
         # hitting maxConnecting. The end result is fewer total connections
         # and better latency.
         if client_context.tls and client_context.auth_enabled:
-            self.assertLessEqual(len(pool.sockets), 20)
+            self.assertLessEqual(len(pool.sockets), 25)
         else:
             self.assertLessEqual(len(pool.sockets), 50)
         # MongoDB 4.4.1 with auth + ssl:

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -379,6 +379,32 @@ class TestPooling(_TestPoolingBase):
         for socket_info in socks:
             socket_info.close_socket(None)
 
+    def test_maxConnecting(self):
+        client = rs_or_single_client()
+        self.addCleanup(client.close)
+        pool = get_pool(client)
+        docs = []
+
+        # Run 50 short running operations
+        def find_one():
+            docs.append(client.test.test.find_one({'$where': delay(0.001)}))
+        threads = [threading.Thread(target=find_one) for _ in range(50)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(10)
+
+        self.assertEqual(len(docs), 50)
+        self.assertLessEqual(len(pool.sockets), 50)
+        # MongoDB 4.4.1 with auth + ssl:
+        # maxConnecting = 2:         6 connections in ~0.231+ seconds
+        # maxConnecting = unbounded: 50 connections in ~0.642+ seconds
+        #
+        # MongoDB 4.4.1 with no-auth no-ssl Python 3.8:
+        # maxConnecting = 2:         15-22 connections in ~0.108+ seconds
+        # maxConnecting = unbounded: 30+ connections in ~0.140+ seconds
+        print(len(pool.sockets))
+
 
 class TestPoolMaxSize(_TestPoolingBase):
     def test_max_pool_size(self):

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -396,6 +396,14 @@ class TestPooling(_TestPoolingBase):
 
         self.assertEqual(len(docs), 50)
         self.assertLessEqual(len(pool.sockets), 50)
+        # TLS and auth make connection establishment more expensive than
+        # the artificially delayed query which leads to more threads
+        # hitting maxConnecting. The end result is fewer total connections
+        # and better latency.
+        if client_context.tls and client_context.auth_enabled:
+            self.assertLessEqual(len(pool.sockets), 20)
+        else:
+            self.assertLessEqual(len(pool.sockets), 50)
         # MongoDB 4.4.1 with auth + ssl:
         # maxConnecting = 2:         6 connections in ~0.231+ seconds
         # maxConnecting = unbounded: 50 connections in ~0.642+ seconds

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -401,7 +401,7 @@ class TestPooling(_TestPoolingBase):
         # hitting maxConnecting. The end result is fewer total connections
         # and better latency.
         if client_context.tls and client_context.auth_enabled:
-            self.assertLessEqual(len(pool.sockets), 25)
+            self.assertLessEqual(len(pool.sockets), 30)
         else:
             self.assertLessEqual(len(pool.sockets), 50)
         # MongoDB 4.4.1 with auth + ssl:

--- a/test/utils_spec_runner.py
+++ b/test/utils_spec_runner.py
@@ -121,11 +121,9 @@ class SpecRunner(IntegrationTest):
         client.admin.command(cmd)
 
     def set_fail_point(self, command_args):
-        cmd = SON([('configureFailPoint', 'failCommand')])
-        cmd.update(command_args)
         clients = self.mongos_clients if self.mongos_clients else [self.client]
         for client in clients:
-            self._set_fail_point(client, cmd)
+            self._set_fail_point(client, command_args)
 
     def targeted_fail_point(self, session, fail_point):
         """Run the targetedFailPoint test operation.


### PR DESCRIPTION
At most 2 connections can be in the pending state per connection pool.
The pending state covers all the work required to setup a new connection
including TCP, TLS, and MongoDB authentication. For example, if two
threads are currently creating connections, a third thread will wait for
either an existing connection to be checked back into the pool or for
one of the two threads to finish creating a connection.

The change reduces the likelihood of connection storms and improves the
driver's ability to reuse existing connections.