### PR TITLE
PYTHON-2403 Add macOS Python 3.9 release automation

### DIFF
--- a/.evergreen/build-mac.sh
+++ b/.evergreen/build-mac.sh
@@ -8,7 +8,7 @@ rm -rf validdist
 mkdir -p validdist
 mv dist/* validdist || true
 
-for VERSION in 2.7 3.4 3.5 3.6 3.7 3.8; do
+for VERSION in 2.7 3.4 3.5 3.6 3.7 3.8 3.9; do
     if [[ $VERSION == "2.7" ]]; then
         PYTHON=/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python
         rm -rf build


### PR DESCRIPTION
Patch: https://evergreen.mongodb.com/version/5fa5ac2f0305b945939ab269