### PR TITLE
PYTHON-2033 Unified Test Format

### DIFF
--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -224,7 +224,6 @@ def _check_write_command_response(result):
     write_errors = result.get("writeErrors")
     if write_errors:
         _raise_last_write_error(write_errors)
-
     error = result.get("writeConcernError")
     if error:
         error_labels = result.get("errorLabels")

--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -224,6 +224,7 @@ def _check_write_command_response(result):
     write_errors = result.get("writeErrors")
     if write_errors:
         _raise_last_write_error(write_errors)
+
     error = result.get("writeConcernError")
     if error:
         error_labels = result.get("errorLabels")

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -607,6 +607,7 @@ class ClientContext(object):
                              func=func)
 
     def is_topology_type(self, topologies):
+        # TODO: add support for 'sharded-replicaset' topology type.
         if 'single' in topologies and not (self.is_mongos or self.is_rs):
             return True
         if 'replicaset' in topologies and self.is_rs:

--- a/test/test_unified_format.py
+++ b/test/test_unified_format.py
@@ -32,8 +32,7 @@ globals().update(generate_test_classes(
     module=__name__,
     class_name_prefix='UnifiedTestFormat',
     expected_failures=[
-        'Client side error in command starting transaction',            # PYTHON-1894
-        'InsertOne fails after multiple retryable writeConcernErrors'   # PYTHON-2452
+        'Client side error in command starting transaction',    # PYTHON-1894
     ]))
 
 

--- a/test/test_unified_format.py
+++ b/test/test_unified_format.py
@@ -26,6 +26,7 @@ _TEST_PATH = os.path.join(
 
 globals().update(generate_test_classes(
     os.path.join(_TEST_PATH, 'valid-pass'),
+    module=__name__,
     name_prefix='unified_test_format'))
 
 

--- a/test/test_unified_format.py
+++ b/test/test_unified_format.py
@@ -26,10 +26,26 @@ from test.unified_format import generate_test_classes, MatchEvaluatorUtil
 _TEST_PATH = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'unified-test-format')
 
+
 globals().update(generate_test_classes(
     os.path.join(_TEST_PATH, 'valid-pass'),
     module=__name__,
-    class_name_prefix='UnifiedTestFormat'))
+    class_name_prefix='UnifiedTestFormat',
+    expected_failures=[
+        'Client side error in command starting transaction',            # PYTHON-1894
+        'InsertOne fails after multiple retryable writeConcernErrors'   # PYTHON-2452
+    ]))
+
+
+globals().update(generate_test_classes(
+    os.path.join(_TEST_PATH, 'valid-fail'),
+    module=__name__,
+    class_name_prefix='UnifiedTestFormat',
+    expected_failures=[
+        'foo',
+        'FindOneAndReplace returnDocument invalid enum value',
+        'FindOneAndUpdate returnDocument invalid enum value'
+    ]))
 
 
 class TestMatchEvaluatorUtil(unittest.TestCase):

--- a/test/test_unified_format.py
+++ b/test/test_unified_format.py
@@ -36,15 +36,11 @@ globals().update(generate_test_classes(
     ]))
 
 
-globals().update(generate_test_classes(
-    os.path.join(_TEST_PATH, 'valid-fail'),
-    module=__name__,
-    class_name_prefix='UnifiedTestFormat',
-    expected_failures=[
-        'foo',
-        'FindOneAndReplace returnDocument invalid enum value',
-        'FindOneAndUpdate returnDocument invalid enum value'
-    ]))
+# Uncomment to run the valid-fail tests
+# globals().update(generate_test_classes(
+#     os.path.join(_TEST_PATH, 'valid-fail'),
+#     module=__name__,
+#     class_name_prefix='UnifiedTestFormat'))
 
 
 class TestMatchEvaluatorUtil(unittest.TestCase):

--- a/test/test_unified_format.py
+++ b/test/test_unified_format.py
@@ -17,7 +17,7 @@ import sys
 
 sys.path[0:0] = [""]
 
-from bson import ObjectId, Timestamp
+from bson import ObjectId
 
 from test import unittest
 from test.unified_format import generate_test_classes, MatchEvaluatorUtil
@@ -36,11 +36,14 @@ globals().update(generate_test_classes(
     ]))
 
 
-# Uncomment to run the valid-fail tests
-# globals().update(generate_test_classes(
-#     os.path.join(_TEST_PATH, 'valid-fail'),
-#     module=__name__,
-#     class_name_prefix='UnifiedTestFormat'))
+globals().update(generate_test_classes(
+    os.path.join(_TEST_PATH, 'valid-fail'),
+    module=__name__,
+    class_name_prefix='UnifiedTestFormat',
+    bypass_test_generation_errors=True,
+    expected_failures=[
+        '.*',       # All tests expected to fail
+    ]))
 
 
 class TestMatchEvaluatorUtil(unittest.TestCase):

--- a/test/test_unified_format.py
+++ b/test/test_unified_format.py
@@ -27,7 +27,7 @@ _TEST_PATH = os.path.join(
 globals().update(generate_test_classes(
     os.path.join(_TEST_PATH, 'valid-pass'),
     module=__name__,
-    name_prefix='unified_test_format'))
+    class_name_prefix='UnifiedTestFormat'))
 
 
 if __name__ == "__main__":

--- a/test/test_unified_format.py
+++ b/test/test_unified_format.py
@@ -1,0 +1,33 @@
+# Copyright 2020-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+sys.path[0:0] = [""]
+
+from test import unittest
+from test.unified_format import generate_test_classes
+
+
+_TEST_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), 'unified-test-format')
+
+globals().update(generate_test_classes(
+    os.path.join(_TEST_PATH, 'valid-pass'),
+    name_prefix='unified_test_format'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unified-test-format/example-insertOne.json
+++ b/test/unified-test-format/example-insertOne.json
@@ -1,0 +1,100 @@
+{
+  "description": "example-insertOne",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "2.6"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "insertOne",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "insertedId": {
+              "$$unsetOrMatches": 2
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "test",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionData-additionalProperties.json
+++ b/test/unified-test-format/invalid/collectionData-additionalProperties.json
@@ -1,0 +1,40 @@
+{
+  "description": "collectionData-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": "foo",
+      "documents": [],
+      "foo": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionData-collectionName-required.json
+++ b/test/unified-test-format/invalid/collectionData-collectionName-required.json
@@ -1,0 +1,38 @@
+{
+  "description": "collectionData-collectionName-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "foo",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionData-collectionName-type.json
+++ b/test/unified-test-format/invalid/collectionData-collectionName-type.json
@@ -1,0 +1,39 @@
+{
+  "description": "collectionData-collectionName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": 0,
+      "databaseName": "foo",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionData-databaseName-required.json
+++ b/test/unified-test-format/invalid/collectionData-databaseName-required.json
@@ -1,0 +1,38 @@
+{
+  "description": "collectionData-databaseName-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionData-databaseName-type.json
+++ b/test/unified-test-format/invalid/collectionData-databaseName-type.json
@@ -1,0 +1,39 @@
+{
+  "description": "collectionData-databaseName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": 0,
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionData-documents-items.json
+++ b/test/unified-test-format/invalid/collectionData-documents-items.json
@@ -1,0 +1,41 @@
+{
+  "description": "collectionData-documents-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": "foo",
+      "documents": [
+        0
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionData-documents-required.json
+++ b/test/unified-test-format/invalid/collectionData-documents-required.json
@@ -1,0 +1,38 @@
+{
+  "description": "collectionData-documents-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": "foo"
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionData-documents-type.json
+++ b/test/unified-test-format/invalid/collectionData-documents-type.json
@@ -1,0 +1,39 @@
+{
+  "description": "collectionData-documents-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": "foo",
+      "documents": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionOrDatabaseOptions-additionalProperties.json
+++ b/test/unified-test-format/invalid/collectionOrDatabaseOptions-additionalProperties.json
@@ -1,0 +1,27 @@
+{
+  "description": "collectionOrDatabaseOptions-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": {
+          "foo": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionOrDatabaseOptions-readConcern-type.json
+++ b/test/unified-test-format/invalid/collectionOrDatabaseOptions-readConcern-type.json
@@ -1,0 +1,27 @@
+{
+  "description": "collectionOrDatabaseOptions-readConcern-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": {
+          "readConcern": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionOrDatabaseOptions-readPreference-type.json
+++ b/test/unified-test-format/invalid/collectionOrDatabaseOptions-readPreference-type.json
@@ -1,0 +1,27 @@
+{
+  "description": "collectionOrDatabaseOptions-readPreference-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": {
+          "readPreference": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/collectionOrDatabaseOptions-writeConcern-type.json
+++ b/test/unified-test-format/invalid/collectionOrDatabaseOptions-writeConcern-type.json
@@ -1,0 +1,27 @@
+{
+  "description": "collectionOrDatabaseOptions-writeConcern-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": {
+          "writeConcern": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/createEntities-items.json
+++ b/test/unified-test-format/invalid/createEntities-items.json
@@ -1,0 +1,13 @@
+{
+  "description": "createEntities-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    0
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/createEntities-minItems.json
+++ b/test/unified-test-format/invalid/createEntities-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "createEntities-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/createEntities-type.json
+++ b/test/unified-test-format/invalid/createEntities-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "createEntities-type",
+  "schemaVersion": "1.0",
+  "createEntities": 0,
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/description-required.json
+++ b/test/unified-test-format/invalid/description-required.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-additionalProperties.json
+++ b/test/unified-test-format/invalid/entity-additionalProperties.json
@@ -1,0 +1,15 @@
+{
+  "description": "entity-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "foo": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-bucket-additionalProperties.json
+++ b/test/unified-test-format/invalid/entity-bucket-additionalProperties.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-bucket-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-bucket-bucketOptions-type.json
+++ b/test/unified-test-format/invalid/entity-bucket-bucketOptions-type.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-bucket-bucketOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0",
+        "bucketOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-bucket-database-required.json
+++ b/test/unified-test-format/invalid/entity-bucket-database-required.json
@@ -1,0 +1,29 @@
+{
+  "description": "entity-bucket-database-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-bucket-database-type.json
+++ b/test/unified-test-format/invalid/entity-bucket-database-type.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-bucket-database-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-bucket-id-required.json
+++ b/test/unified-test-format/invalid/entity-bucket-id-required.json
@@ -1,0 +1,29 @@
+{
+  "description": "entity-bucket-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "database": "database0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-bucket-id-type.json
+++ b/test/unified-test-format/invalid/entity-bucket-id-type.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-bucket-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": 0,
+        "database": "database0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-additionalProperties.json
+++ b/test/unified-test-format/invalid/entity-client-additionalProperties.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-id-required.json
+++ b/test/unified-test-format/invalid/entity-client-id-required.json
@@ -1,0 +1,15 @@
+{
+  "description": "entity-client-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {}
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-id-type.json
+++ b/test/unified-test-format/invalid/entity-client-id-type.json
@@ -1,0 +1,17 @@
+{
+  "description": "entity-client-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-items.json
+++ b/test/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-items.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-ignoreCommandMonitoringEvents-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "ignoreCommandMonitoringEvents": [
+          0
+        ]
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-minItems.json
+++ b/test/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-minItems.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-ignoreCommandMonitoringEvents-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "ignoreCommandMonitoringEvents": []
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-type.json
+++ b/test/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-ignoreCommandMonitoringEvents-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "ignoreCommandMonitoringEvents": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-observeEvents-enum.json
+++ b/test/unified-test-format/invalid/entity-client-observeEvents-enum.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-observeEvents-enum",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "foo"
+        ]
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-observeEvents-items.json
+++ b/test/unified-test-format/invalid/entity-client-observeEvents-items.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-observeEvents-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          0
+        ]
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-observeEvents-minItems.json
+++ b/test/unified-test-format/invalid/entity-client-observeEvents-minItems.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-observeEvents-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": []
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-observeEvents-type.json
+++ b/test/unified-test-format/invalid/entity-client-observeEvents-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-observeEvents-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-uriOptions-type.json
+++ b/test/unified-test-format/invalid/entity-client-uriOptions-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-uriOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "uriOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-client-useMultipleMongoses-type.json
+++ b/test/unified-test-format/invalid/entity-client-useMultipleMongoses-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-useMultipleMongoses-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-collection-additionalProperties.json
+++ b/test/unified-test-format/invalid/entity-collection-additionalProperties.json
@@ -1,0 +1,32 @@
+{
+  "description": "entity-collection-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-collection-collectionName-required.json
+++ b/test/unified-test-format/invalid/entity-collection-collectionName-required.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-collection-collectionName-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-collection-collectionName-type.json
+++ b/test/unified-test-format/invalid/entity-collection-collectionName-type.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-collection-collectionName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-collection-collectionOptions-type.json
+++ b/test/unified-test-format/invalid/entity-collection-collectionOptions-type.json
@@ -1,0 +1,32 @@
+{
+  "description": "entity-collection-collectionOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "collectionOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-collection-database-required.json
+++ b/test/unified-test-format/invalid/entity-collection-database-required.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-collection-database-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-collection-database-type.json
+++ b/test/unified-test-format/invalid/entity-collection-database-type.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-collection-database-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": 0,
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-collection-id-required.json
+++ b/test/unified-test-format/invalid/entity-collection-id-required.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-collection-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "database": "database0",
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-collection-id-type.json
+++ b/test/unified-test-format/invalid/entity-collection-id-type.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-collection-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": 0,
+        "database": "database0",
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-database-additionalProperties.json
+++ b/test/unified-test-format/invalid/entity-database-additionalProperties.json
@@ -1,0 +1,25 @@
+{
+  "description": "entity-database-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-database-client-required.json
+++ b/test/unified-test-format/invalid/entity-database-client-required.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-database-client-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-database-client-type.json
+++ b/test/unified-test-format/invalid/entity-database-client-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-database-client-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": 0,
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-database-databaseName-required.json
+++ b/test/unified-test-format/invalid/entity-database-databaseName-required.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-database-databaseName-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-database-databaseName-type.json
+++ b/test/unified-test-format/invalid/entity-database-databaseName-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-database-databaseName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-database-databaseOptions-type.json
+++ b/test/unified-test-format/invalid/entity-database-databaseOptions-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "entity-database-databaseOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-database-id-required.json
+++ b/test/unified-test-format/invalid/entity-database-id-required.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-database-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-database-id-type.json
+++ b/test/unified-test-format/invalid/entity-database-id-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-database-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": 0,
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-maxProperties.json
+++ b/test/unified-test-format/invalid/entity-maxProperties.json
@@ -1,0 +1,22 @@
+{
+  "description": "entity-maxProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      },
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-minProperties.json
+++ b/test/unified-test-format/invalid/entity-minProperties.json
@@ -1,0 +1,13 @@
+{
+  "description": "entity-minProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {}
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-session-additionalProperties.json
+++ b/test/unified-test-format/invalid/entity-session-additionalProperties.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-session-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-session-client-required.json
+++ b/test/unified-test-format/invalid/entity-session-client-required.json
@@ -1,0 +1,22 @@
+{
+  "description": "entity-session-client-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-session-client-type.json
+++ b/test/unified-test-format/invalid/entity-session-client-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-session-client-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-session-id-required.json
+++ b/test/unified-test-format/invalid/entity-session-id-required.json
@@ -1,0 +1,22 @@
+{
+  "description": "entity-session-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-session-id-type.json
+++ b/test/unified-test-format/invalid/entity-session-id-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-session-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": 0,
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-session-sessionOptions-type.json
+++ b/test/unified-test-format/invalid/entity-session-sessionOptions-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-session-sessionOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0",
+        "sessionOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-stream-additionalProperties.json
+++ b/test/unified-test-format/invalid/entity-stream-additionalProperties.json
@@ -1,0 +1,19 @@
+{
+  "description": "entity-stream-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": "stream0",
+        "hexBytes": "FF",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-stream-hexBytes-pattern.json
+++ b/test/unified-test-format/invalid/entity-stream-hexBytes-pattern.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-stream-hexBytes-pattern",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": "stream0",
+        "hexBytes": "FFF"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-stream-hexBytes-required.json
+++ b/test/unified-test-format/invalid/entity-stream-hexBytes-required.json
@@ -1,0 +1,17 @@
+{
+  "description": "entity-stream-hexBytes-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": "stream0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-stream-hexBytes-type.json
+++ b/test/unified-test-format/invalid/entity-stream-hexBytes-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-stream-hexBytes-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": "stream0",
+        "hexBytes": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-stream-id-required.json
+++ b/test/unified-test-format/invalid/entity-stream-id-required.json
@@ -1,0 +1,17 @@
+{
+  "description": "entity-stream-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "hexBytes": "FF"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/entity-stream-id-type.json
+++ b/test/unified-test-format/invalid/entity-stream-id-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-stream-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": 0,
+        "hexBytes": "FF"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-additionalProperties.json
+++ b/test/unified-test-format/invalid/expectedError-additionalProperties.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "foo": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorCode-type.json
+++ b/test/unified-test-format/invalid/expectedError-errorCode-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorCode-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorCode": "foo"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorCodeName-type.json
+++ b/test/unified-test-format/invalid/expectedError-errorCodeName-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorCodeName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorCodeName": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorContains-type.json
+++ b/test/unified-test-format/invalid/expectedError-errorContains-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorContains-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorContains": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorLabelsContain-items.json
+++ b/test/unified-test-format/invalid/expectedError-errorLabelsContain-items.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedError-errorLabelsContain-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsContain": [
+              0
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorLabelsContain-minItems.json
+++ b/test/unified-test-format/invalid/expectedError-errorLabelsContain-minItems.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorLabelsContain-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsContain": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorLabelsContain-type.json
+++ b/test/unified-test-format/invalid/expectedError-errorLabelsContain-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorLabelsContain-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsContain": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorLabelsOmit-items.json
+++ b/test/unified-test-format/invalid/expectedError-errorLabelsOmit-items.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedError-errorLabelsOmit-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsOmit": [
+              0
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorLabelsOmit-minItems.json
+++ b/test/unified-test-format/invalid/expectedError-errorLabelsOmit-minItems.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorLabelsOmit-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsOmit": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorLabelsOmit-type.json
+++ b/test/unified-test-format/invalid/expectedError-errorLabelsOmit-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorLabelsOmit-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsOmit": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-isClientError-type.json
+++ b/test/unified-test-format/invalid/expectedError-isClientError-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-isClientError-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isClientError": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-isError-const.json
+++ b/test/unified-test-format/invalid/expectedError-isError-const.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-isError-const",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isError": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-isError-type.json
+++ b/test/unified-test-format/invalid/expectedError-isError-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-isError-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isError": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-minProperties.json
+++ b/test/unified-test-format/invalid/expectedError-minProperties.json
@@ -1,0 +1,23 @@
+{
+  "description": "expectedError-minProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {}
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-additionalProperties.json
+++ b/test/unified-test-format/invalid/expectedEvent-additionalProperties.json
@@ -1,0 +1,32 @@
+{
+  "description": "expectedEvent-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "foo": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-commandFailedEvent-commandName-type.json
+++ b/test/unified-test-format/invalid/expectedEvent-commandFailedEvent-commandName-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandFailedEvent-commandName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandFailedEvent": {
+                    "commandName": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-commandStartedEvent-additionalProperties.json
+++ b/test/unified-test-format/invalid/expectedEvent-commandStartedEvent-additionalProperties.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandStartedEvent-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {
+                    "foo": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-commandStartedEvent-command-type.json
+++ b/test/unified-test-format/invalid/expectedEvent-commandStartedEvent-command-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandStartedEvent-command-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {
+                    "command": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-commandStartedEvent-commandName-type.json
+++ b/test/unified-test-format/invalid/expectedEvent-commandStartedEvent-commandName-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandStartedEvent-commandName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {
+                    "commandName": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-commandStartedEvent-databaseName-type.json
+++ b/test/unified-test-format/invalid/expectedEvent-commandStartedEvent-databaseName-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandStartedEvent-databaseName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {
+                    "databaseName": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-commandSucceededEvent-commandName-type.json
+++ b/test/unified-test-format/invalid/expectedEvent-commandSucceededEvent-commandName-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandSucceededEvent-commandName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandSucceededEvent": {
+                    "commandName": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-commandSucceededEvent-reply-type.json
+++ b/test/unified-test-format/invalid/expectedEvent-commandSucceededEvent-reply-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandSucceededEvent-reply-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandSucceededEvent": {
+                    "reply": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-maxProperties.json
+++ b/test/unified-test-format/invalid/expectedEvent-maxProperties.json
@@ -1,0 +1,33 @@
+{
+  "description": "expectedEvent-maxProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {},
+                  "commandSucceededEvent": {}
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEvent-minProperties.json
+++ b/test/unified-test-format/invalid/expectedEvent-minProperties.json
@@ -1,0 +1,30 @@
+{
+  "description": "expectedEvent-minProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEventsForClient-additionalProperties.json
+++ b/test/unified-test-format/invalid/expectedEventsForClient-additionalProperties.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedEventsForClient-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [],
+              "foo": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEventsForClient-client-required.json
+++ b/test/unified-test-format/invalid/expectedEventsForClient-client-required.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedEventsForClient-client-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "events": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEventsForClient-client-type.json
+++ b/test/unified-test-format/invalid/expectedEventsForClient-client-type.json
@@ -1,0 +1,28 @@
+{
+  "description": "expectedEventsForClient-client-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": 0,
+              "events": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEventsForClient-events-items.json
+++ b/test/unified-test-format/invalid/expectedEventsForClient-events-items.json
@@ -1,0 +1,30 @@
+{
+  "description": "expectedEventsForClient-events-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                0
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEventsForClient-events-required.json
+++ b/test/unified-test-format/invalid/expectedEventsForClient-events-required.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedEventsForClient-events-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedEventsForClient-events-type.json
+++ b/test/unified-test-format/invalid/expectedEventsForClient-events-type.json
@@ -1,0 +1,28 @@
+{
+  "description": "expectedEventsForClient-events-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/initialData-items.json
+++ b/test/unified-test-format/invalid/initialData-items.json
@@ -1,0 +1,13 @@
+{
+  "description": "initialData-items",
+  "schemaVersion": "1.0",
+  "initialData": [
+    0
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/initialData-minItems.json
+++ b/test/unified-test-format/invalid/initialData-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "initialData-minItems",
+  "schemaVersion": "1.0",
+  "initialData": [],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/initialData-type.json
+++ b/test/unified-test-format/invalid/initialData-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "initialData-type",
+  "schemaVersion": "1.0",
+  "initialData": 0,
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-additionalProperties.json
+++ b/test/unified-test-format/invalid/operation-additionalProperties.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "foo": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-arguments-type.json
+++ b/test/unified-test-format/invalid/operation-arguments-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-arguments-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "arguments": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-expectError-conflicts_with_expectResult.json
+++ b/test/unified-test-format/invalid/operation-expectError-conflicts_with_expectResult.json
@@ -1,0 +1,26 @@
+{
+  "description": "operation-expectError-conflicts_with_expectResult",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isError": true
+          },
+          "expectResult": {}
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-expectError-conflicts_with_saveResultAsEntity.json
+++ b/test/unified-test-format/invalid/operation-expectError-conflicts_with_saveResultAsEntity.json
@@ -1,0 +1,26 @@
+{
+  "description": "operation-expectError-conflicts_with_saveResultAsEntity",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isError": true
+          },
+          "saveResultAsEntity": "foo"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-expectError-type.json
+++ b/test/unified-test-format/invalid/operation-expectError-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-expectError-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-expectEvents-type.json
+++ b/test/unified-test-format/invalid/operation-expectEvents-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-expectEvents-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-name-required.json
+++ b/test/unified-test-format/invalid/operation-name-required.json
@@ -1,0 +1,21 @@
+{
+  "description": "operation-name-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "object": "client0"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-name-type.json
+++ b/test/unified-test-format/invalid/operation-name-type.json
@@ -1,0 +1,22 @@
+{
+  "description": "operation-name-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": 0,
+          "object": "client0"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-object-required.json
+++ b/test/unified-test-format/invalid/operation-object-required.json
@@ -1,0 +1,21 @@
+{
+  "description": "operation-object-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-object-type.json
+++ b/test/unified-test-format/invalid/operation-object-type.json
@@ -1,0 +1,22 @@
+{
+  "description": "operation-object-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/operation-saveResultAsEntity-type.json
+++ b/test/unified-test-format/invalid/operation-saveResultAsEntity-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-saveResultAsEntity-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "saveResultAsEntity": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-additionalProperties.json
+++ b/test/unified-test-format/invalid/runOnRequirement-additionalProperties.json
@@ -1,0 +1,16 @@
+{
+  "description": "runOnRequirement-additionalProperties",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "foo": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-maxServerVersion-pattern.json
+++ b/test/unified-test-format/invalid/runOnRequirement-maxServerVersion-pattern.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-maxServerVersion-pattern",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": "1.2.3.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-maxServerVersion-type.json
+++ b/test/unified-test-format/invalid/runOnRequirement-maxServerVersion-type.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-maxServerVersion-type",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-minProperties.json
+++ b/test/unified-test-format/invalid/runOnRequirement-minProperties.json
@@ -1,0 +1,13 @@
+{
+  "description": "runOnRequirement-minProperties",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {}
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-minServerVersion-pattern.json
+++ b/test/unified-test-format/invalid/runOnRequirement-minServerVersion-pattern.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-minServerVersion-pattern",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "1.2.3.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-minServerVersion-type.json
+++ b/test/unified-test-format/invalid/runOnRequirement-minServerVersion-type.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-minServerVersion-type",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-topologies-enum.json
+++ b/test/unified-test-format/invalid/runOnRequirement-topologies-enum.json
@@ -1,0 +1,17 @@
+{
+  "description": "runOnRequirement-topologies-enum",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "foo"
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-topologies-items.json
+++ b/test/unified-test-format/invalid/runOnRequirement-topologies-items.json
@@ -1,0 +1,17 @@
+{
+  "description": "runOnRequirement-topologies-items",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        0
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-topologies-minItems.json
+++ b/test/unified-test-format/invalid/runOnRequirement-topologies-minItems.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-topologies-minItems",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirement-topologies-type.json
+++ b/test/unified-test-format/invalid/runOnRequirement-topologies-type.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-topologies-type",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirements-items.json
+++ b/test/unified-test-format/invalid/runOnRequirements-items.json
@@ -1,0 +1,13 @@
+{
+  "description": "runOnRequirements-items",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    0
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirements-minItems.json
+++ b/test/unified-test-format/invalid/runOnRequirements-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "runOnRequirements-minItems",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/runOnRequirements-type.json
+++ b/test/unified-test-format/invalid/runOnRequirements-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "runOnRequirements-type",
+  "schemaVersion": "1.0",
+  "runOnRequirements": 0,
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/schemaVersion-pattern.json
+++ b/test/unified-test-format/invalid/schemaVersion-pattern.json
@@ -1,0 +1,10 @@
+{
+  "description": "schemaVersion-pattern",
+  "schemaVersion": "1.2.3.4",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/schemaVersion-required.json
+++ b/test/unified-test-format/invalid/schemaVersion-required.json
@@ -1,0 +1,9 @@
+{
+  "description": "schemaVersion-required",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/schemaVersion-type.json
+++ b/test/unified-test-format/invalid/schemaVersion-type.json
@@ -1,0 +1,10 @@
+{
+  "description": "schemaVersion-type",
+  "schemaVersion": 0,
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-additionalProperties.json
+++ b/test/unified-test-format/invalid/test-additionalProperties.json
@@ -1,0 +1,11 @@
+{
+  "description": "test-additionalProperties",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "foo": 0
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-description-required.json
+++ b/test/unified-test-format/invalid/test-description-required.json
@@ -1,0 +1,9 @@
+{
+  "description": "test-description-required",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "operation": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-description-type.json
+++ b/test/unified-test-format/invalid/test-description-type.json
@@ -1,0 +1,10 @@
+{
+  "description": "test-description-type",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": 0,
+      "operation": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-expectEvents-items.json
+++ b/test/unified-test-format/invalid/test-expectEvents-items.json
@@ -1,0 +1,13 @@
+{
+  "description": "test-expectEvents-items",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        0
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-expectEvents-type.json
+++ b/test/unified-test-format/invalid/test-expectEvents-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "test-expectEvents-type",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": 0
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-operations-items.json
+++ b/test/unified-test-format/invalid/test-operations-items.json
@@ -1,0 +1,12 @@
+{
+  "description": "test-operations-items",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        0
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-operations-required.json
+++ b/test/unified-test-format/invalid/test-operations-required.json
@@ -1,0 +1,9 @@
+{
+  "description": "test-operations-required",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo"
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-operations-type.json
+++ b/test/unified-test-format/invalid/test-operations-type.json
@@ -1,0 +1,10 @@
+{
+  "description": "test-operations-type",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": 0
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-outcome-items.json
+++ b/test/unified-test-format/invalid/test-outcome-items.json
@@ -1,0 +1,13 @@
+{
+  "description": "test-outcome-items",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "outcome": [
+        0
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-outcome-minItems.json
+++ b/test/unified-test-format/invalid/test-outcome-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "test-outcome-minItems",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "outcome": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-outcome-type.json
+++ b/test/unified-test-format/invalid/test-outcome-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "test-outcome-type",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "outcome": 0
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-runOnRequirements-items.json
+++ b/test/unified-test-format/invalid/test-runOnRequirements-items.json
@@ -1,0 +1,13 @@
+{
+  "description": "test-runOnRequirements-items",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "runOnRequirements": [
+        0
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-runOnRequirements-minItems.json
+++ b/test/unified-test-format/invalid/test-runOnRequirements-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "test-runOnRequirements-minItems",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "runOnRequirements": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-runOnRequirements-type.json
+++ b/test/unified-test-format/invalid/test-runOnRequirements-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "test-runOnRequirements-type",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "runOnRequirements": 0
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/test-skipReason-type.json
+++ b/test/unified-test-format/invalid/test-skipReason-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "test-skipReason-type",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "skipReason": 0
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/tests-items.json
+++ b/test/unified-test-format/invalid/tests-items.json
@@ -1,0 +1,7 @@
+{
+  "description": "tests-items",
+  "schemaVersion": "1.0",
+  "tests": [
+    0
+  ]
+}

--- a/test/unified-test-format/invalid/tests-minItems.json
+++ b/test/unified-test-format/invalid/tests-minItems.json
@@ -1,0 +1,5 @@
+{
+  "description": "tests-minItems",
+  "schemaVersion": "1.0",
+  "tests": []
+}

--- a/test/unified-test-format/invalid/tests-required.json
+++ b/test/unified-test-format/invalid/tests-required.json
@@ -1,0 +1,4 @@
+{
+  "description": "tests-required",
+  "schemaVersion": "1.0"
+}

--- a/test/unified-test-format/invalid/tests-type.json
+++ b/test/unified-test-format/invalid/tests-type.json
@@ -1,0 +1,5 @@
+{
+  "description": "tests-type",
+  "schemaVersion": "1.0",
+  "tests": 0
+}

--- a/test/unified-test-format/valid-fail/entity-bucket-database-undefined.json
+++ b/test/unified-test-format/valid-fail/entity-bucket-database-undefined.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-bucket-database-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/valid-fail/entity-collection-database-undefined.json
+++ b/test/unified-test-format/valid-fail/entity-collection-database-undefined.json
@@ -1,0 +1,19 @@
+{
+  "description": "entity-collection-database-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "foo",
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/valid-fail/entity-database-client-undefined.json
+++ b/test/unified-test-format/valid-fail/entity-database-client-undefined.json
@@ -1,0 +1,19 @@
+{
+  "description": "entity-database-client-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "database": {
+        "id": "database0",
+        "client": "foo",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/valid-fail/entity-session-client-undefined.json
+++ b/test/unified-test-format/valid-fail/entity-session-client-undefined.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-session-client-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "session": {
+        "id": "session0",
+        "client": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/valid-fail/returnDocument-enum-invalid.json
+++ b/test/unified-test-format/valid-fail/returnDocument-enum-invalid.json
@@ -1,0 +1,66 @@
+{
+  "description": "returnDocument-enum-invalid",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndReplace returnDocument invalid enum value",
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "x": 111
+            },
+            "returnDocument": "invalid"
+          }
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate returnDocument invalid enum value",
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "invalid"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-fail/schemaVersion-unsupported.json
+++ b/test/unified-test-format/valid-fail/schemaVersion-unsupported.json
@@ -1,0 +1,10 @@
+{
+  "description": "schemaVersion-unsupported",
+  "schemaVersion": "0.1",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-change-streams.json
+++ b/test/unified-test-format/valid-pass/poc-change-streams.json
@@ -1,0 +1,414 @@
+{
+  "description": "poc-change-streams",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "getMore",
+          "killCursors"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database2",
+        "client": "client1",
+        "databaseName": "change-stream-tests-2"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection2",
+        "database": "database1",
+        "collectionName": "test2"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection3",
+        "database": "database2",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests",
+      "documents": []
+    },
+    {
+      "collectionName": "test2",
+      "databaseName": "change-stream-tests",
+      "documents": []
+    },
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests-2",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster.",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.8.0",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "client0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection2",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection3",
+          "arguments": {
+            "document": {
+              "y": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "z": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test2"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests-2",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "y": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "z": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "allChangesForCluster": true,
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test consecutive resume",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "batchSize": 1,
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "x": 3
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 3
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "change-stream-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        },
+                        "resumeAfter": {
+                          "$$exists": true
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "change-stream-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        },
+                        "resumeAfter": {
+                          "$$exists": true
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "change-stream-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-command-monitoring.json
+++ b/test/unified-test-format/valid-pass/poc-command-monitoring.json
@@ -1,0 +1,222 @@
+{
+  "description": "poc-command-monitoring",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "command-monitoring-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "command-monitoring-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        },
+        {
+          "_id": 5,
+          "x": 55
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "A successful find event with a getmore and the server kills the cursor",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.1",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gte": 1
+              }
+            },
+            "sort": {
+              "_id": 1
+            },
+            "batchSize": 3,
+            "limit": 4
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": {
+                      "$gte": 1
+                    }
+                  },
+                  "sort": {
+                    "_id": 1
+                  },
+                  "batchSize": 3,
+                  "limit": 4
+                },
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "cursor": {
+                    "id": {
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
+                    },
+                    "ns": "command-monitoring-tests.test",
+                    "firstBatch": [
+                      {
+                        "_id": 1,
+                        "x": 11
+                      },
+                      {
+                        "_id": 2,
+                        "x": 22
+                      },
+                      {
+                        "_id": 3,
+                        "x": 33
+                      }
+                    ]
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "test",
+                  "batchSize": 1
+                },
+                "commandName": "getMore",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "cursor": {
+                    "id": 0,
+                    "ns": "command-monitoring-tests.test",
+                    "nextBatch": [
+                      {
+                        "_id": 4,
+                        "x": 44
+                      }
+                    ]
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A failed find event",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "$or": true
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-crud.json
+++ b/test/unified-test-format/valid-pass/poc-crud.json
@@ -1,0 +1,446 @@
+{
+  "description": "poc-crud",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client0",
+        "databaseName": "admin"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection2",
+        "database": "database0",
+        "collectionName": "coll2",
+        "collectionOptions": {
+          "readConcern": {
+            "level": "majority"
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    },
+    {
+      "collectionName": "coll2",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    },
+    {
+      "collectionName": "aggregate_out",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite with mixed ordered operations",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 3,
+                    "x": 33
+                  }
+                }
+              },
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  }
+                }
+              },
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 4,
+                    "x": 44
+                  }
+                }
+              },
+              {
+                "deleteMany": {
+                  "filter": {
+                    "x": {
+                      "$nin": [
+                        24,
+                        34
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 4
+                  },
+                  "replacement": {
+                    "_id": 4,
+                    "x": 44
+                  },
+                  "upsert": true
+                }
+              }
+            ],
+            "ordered": true
+          },
+          "expectResult": {
+            "deletedCount": 2,
+            "insertedCount": 2,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 3,
+                "3": 4
+              }
+            },
+            "matchedCount": 3,
+            "modifiedCount": 3,
+            "upsertedCount": 1,
+            "upsertedIds": {
+              "5": 4
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 34
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertMany continue-on-error behavior with unordered (duplicate key in requests)",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection1",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 2,
+                "x": 22
+              },
+              {
+                "_id": 2,
+                "x": 22
+              },
+              {
+                "_id": 3,
+                "x": 33
+              }
+            ],
+            "ordered": false
+          },
+          "expectError": {
+            "expectResult": {
+              "deletedCount": 0,
+              "insertedCount": 2,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {}
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ReplaceOne prohibits atomic modifiers",
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection1",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "$set": {
+                "x": 22
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "readConcern majority with out stage",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.1.0",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection2",
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "aggregate_out"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll2",
+                  "pipeline": [
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$out": "aggregate_out"
+                    }
+                  ],
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "aggregate_out",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $listLocalSessions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "database1",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "dummy": "dummy field"
+                }
+              },
+              {
+                "$project": {
+                  "_id": 0,
+                  "dummy": 1
+                }
+              }
+            ]
+          },
+          "expectResult": [
+            {
+              "dummy": "dummy field"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-gridfs.json
+++ b/test/unified-test-format/valid-pass/poc-gridfs.json
@@ -1,0 +1,301 @@
+{
+  "description": "poc-gridfs",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "gridfs-tests"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_files_collection",
+        "database": "database0",
+        "collectionName": "fs.files"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_chunks_collection",
+        "database": "database0",
+        "collectionName": "fs.chunks"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "fs.files",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "length": 10,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "md5": "57d83cd477bfb1ccd975ab33d827a92b",
+          "filename": "length-10",
+          "contentType": "application/octet-stream",
+          "aliases": [],
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "collectionName": "fs.chunks",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "ESIzRA==",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000006"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "n": 1,
+          "data": {
+            "$binary": {
+              "base64": "VWZ3iA==",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000007"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "n": 2,
+          "data": {
+            "$binary": {
+              "base64": "mao=",
+              "subType": "00"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Delete when length is 10",
+      "operations": [
+        {
+          "name": "delete",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000005"
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "fs.files",
+          "databaseName": "gridfs-tests",
+          "documents": []
+        },
+        {
+          "collectionName": "fs.chunks",
+          "databaseName": "gridfs-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Download when there are three chunks",
+      "operations": [
+        {
+          "name": "download",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000005"
+            }
+          },
+          "expectResult": {
+            "$$matchesHexBytes": "112233445566778899aa"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Download when files entry does not exist",
+      "operations": [
+        {
+          "name": "download",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000000"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "Download when an intermediate chunk is missing",
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "bucket0_chunks_collection",
+          "arguments": {
+            "filter": {
+              "files_id": {
+                "$oid": "000000000000000000000005"
+              },
+              "n": 1
+            }
+          },
+          "expectResult": {
+            "deletedCount": 1
+          }
+        },
+        {
+          "name": "download",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000005"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "Upload when length is 5",
+      "operations": [
+        {
+          "name": "upload",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "filename",
+            "source": {
+              "$$hexBytes": "1122334455"
+            },
+            "chunkSizeBytes": 4
+          },
+          "expectResult": {
+            "$$type": "objectId"
+          },
+          "saveResultAsEntity": "oid0"
+        },
+        {
+          "name": "find",
+          "object": "bucket0_files_collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "uploadDate": -1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": {
+                "$$matchesEntity": "oid0"
+              },
+              "length": 5,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$$type": "date"
+              },
+              "md5": {
+                "$$unsetOrMatches": "283d4fea5dded59cf837d3047328f5af"
+              },
+              "filename": "filename"
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "bucket0_chunks_collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": {
+                  "$oid": "000000000000000000000007"
+                }
+              }
+            },
+            "sort": {
+              "n": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "files_id": {
+                "$$matchesEntity": "oid0"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "ESIzRA==",
+                  "subType": "00"
+                }
+              }
+            },
+            {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "files_id": {
+                "$$matchesEntity": "oid0"
+              },
+              "n": 1,
+              "data": {
+                "$binary": {
+                  "base64": "VQ==",
+                  "subType": "00"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-retryable-reads.json
+++ b/test/unified-test-format/valid-pass/poc-retryable-reads.json
@@ -1,0 +1,433 @@
+{
+  "description": "poc-retryable-reads",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "uriOptions": {
+          "retryReads": false
+        },
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-reads-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "retryable-reads-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "retryable-reads-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate succeeds after InterruptedAtShutdown",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "aggregate"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              }
+            ]
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find succeeds on second attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 2
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "sort": {
+                    "_id": 1
+                  },
+                  "limit": 2
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "sort": {
+                    "_id": 1
+                  },
+                  "limit": 2
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find fails on first attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection1",
+          "arguments": {
+            "filter": {}
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client1",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {}
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find fails on second attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {}
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {}
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {}
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ListDatabases succeeds on second attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "listDatabases"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "listDatabases",
+          "object": "client0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listDatabases": 1
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listDatabases": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-retryable-writes.json
+++ b/test/unified-test-format/valid-pass/poc-retryable-writes.json
@@ -1,0 +1,483 @@
+{
+  "description": "poc-retryable-writes",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "uriOptions": {
+          "retryWrites": false
+        },
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-writes-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "retryable-writes-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "retryable-writes-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndUpdate is committed on first attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "onPrimaryTransactionalWrite",
+              "mode": {
+                "times": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate is not committed on first attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "onPrimaryTransactionalWrite",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failBeforeCommitExceptionCode": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate is never committed",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "onPrimaryTransactionalWrite",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failBeforeCommitExceptionCode": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertMany succeeds after PrimarySteppedDown",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 189,
+                "errorLabels": [
+                  "RetryableWriteError"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3,
+                "x": 33
+              },
+              {
+                "_id": 4,
+                "x": 44
+              }
+            ],
+            "ordered": true
+          },
+          "expectResult": {
+            "insertedCount": {
+              "$$unsetOrMatches": 2
+            },
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 3,
+                "1": 4
+              }
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertOne fails after connection failure when retryWrites option is false",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client1",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertOne fails after multiple retryable writeConcernErrors",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-sessions.json
+++ b/test/unified-test-format/valid-pass/poc-sessions.json
@@ -1,0 +1,466 @@
+{
+  "description": "poc-sessions",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "session-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "session-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Server supports explicit sessions",
+      "operations": [
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server supports implicit sessions",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Dirty explicit session is discarded",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.8",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 2
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-transactions-convenient-api.json
+++ b/test/unified-test-format/valid-pass/poc-transactions-convenient-api.json
@@ -1,0 +1,505 @@
+{
+  "description": "poc-transactions-convenient-api",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        },
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session1",
+        "client": "client1"
+      }
+    },
+    {
+      "session": {
+        "id": "session2",
+        "client": "client0",
+        "sessionOptions": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "majority"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "withTransaction and no transaction options set",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection0",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "withTransaction inherits transaction options from client",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session1",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection1",
+                "arguments": {
+                  "session": "session1",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client1",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session1"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session1"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "w": 1
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "withTransaction inherits transaction options from defaultTransactionOptions",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session2",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection0",
+                "arguments": {
+                  "session": "session2",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session2"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "level": "majority"
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session2"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "w": 1
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "withTransaction explicit transaction options",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection0",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ],
+            "readConcern": {
+              "level": "majority"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "level": "majority"
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "w": 1
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.json
+++ b/test/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.json
@@ -1,0 +1,409 @@
+{
+  "description": "poc-transactions-mongos-pin-auto",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "remain pinned after non-transient Interrupted error on insertOne",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ],
+            "errorCodeName": "Interrupted"
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 4
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "recoveryToken": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "unpin after transient error within a transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 4
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "abortTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "recoveryToken": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "abortTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/poc-transactions.json
+++ b/test/unified-test-format/valid-pass/poc-transactions.json
@@ -1,0 +1,322 @@
+{
+  "description": "poc-transactions",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Client side error in command starting transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": {
+                ".": "."
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "assertSessionTransactionState",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "state": "starting"
+          }
+        }
+      ]
+    },
+    {
+      "description": "explicitly create collection using create command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.3.4",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "session": "session0",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test",
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "drop",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "create",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create index on a non-existing collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.3.4",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "name": "x_1",
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test",
+            "indexName": "x_1"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test",
+            "indexName": "x_1"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test",
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "drop",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "test",
+                  "indexes": [
+                    {
+                      "name": "x_1",
+                      "key": {
+                        "x": 1
+                      }
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "createIndexes",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -24,7 +24,6 @@ import types
 
 from bson import json_util
 
-from pymongo.mongo_client import MongoClient
 from pymongo.write_concern import WriteConcern
 
 from test import client_context, unittest, IntegrationTest
@@ -239,13 +238,13 @@ class UnifiedSpecTestMeta(type):
         for test_spec in cls.TEST_SPEC['tests']:
             description = test_spec['description']
             test_name = 'test_%s' % (
-                description.replace(' ', '_').replace('.', '_').lower(),)
+                description.replace(' ', '_').replace('.', '_'),)
             test_method = create_test(copy.deepcopy(test_spec))
             test_method.__name__ = test_name
             setattr(cls, test_name, test_method)
 
 
-def generate_test_classes(test_path, name_prefix=''):
+def generate_test_classes(test_path, module=__name__, name_prefix=''):
     """Method for generating test classes. Returns a dictionary where keys are
     the names of test classes and values are the test class objects."""
     test_klasses = {}
@@ -281,6 +280,6 @@ def generate_test_classes(test_path, name_prefix=''):
             test_klasses[class_name] = type(
                 class_name,
                 (UnifiedSpecTestMixin, test_base_class_factory(scenario_def),),
-                {})
+                {'__module__': module})
 
     return test_klasses

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -548,7 +548,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         # process file-level runOnRequirements
         run_on_spec = cls.TEST_SPEC.get('runOnRequirements', [])
         if not cls.should_run_on(run_on_spec):
-            raise unittest.SkipTest('runOnRequirements not satisfied')
+            raise unittest.SkipTest(
+                '%s runOnRequirements not satisfied' % (cls.__name__,))
 
     @classmethod
     def tearDownClass(cls):
@@ -985,6 +986,7 @@ def generate_test_classes(test_path, module=__name__, class_name_prefix='',
                     print('Ignoring test file %s with '
                           'unsupported schemaVersion %s' %
                           (fpath, schema_version))
+                    continue
                 test_klasses[class_name] = type(
                     class_name,
                     (mixin_class, test_base_class_factory(scenario_def),),

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -545,10 +545,14 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
                 '%s runOnRequirements not satisfied' % (cls.__name__,))
 
         # add any special-casing for skipping tests here
-        if (cls.TEST_SPEC['description'] == 'poc-retryable-writes'
-                and client_context.storage_engine == 'mmapv1'):
-            raise unittest.skipTest(
-                "MMAPv1 does not support retryWrites=True")
+        if client_context.storage_engine == 'mmapv1':
+            if cls.TEST_SPEC['description'].find('retryable-writes') != -1:
+                raise unittest.SkipTest(
+                    "MMAPv1 does not support retryWrites=True")
+            if cls.TEST_SPEC['description'].find('change-streams') != -1:
+                raise unittest.SkipTest(
+                    "MMAPv1 does not support change streams")
+
 
     @classmethod
     def tearDownClass(cls):

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -37,21 +37,19 @@ from pymongo import ASCENDING, MongoClient
 from pymongo.client_session import ClientSession, TransactionOptions, _TxnState
 from pymongo.change_stream import ChangeStream
 from pymongo.collection import Collection
-from pymongo.cursor import Cursor
 from pymongo.database import Database
 from pymongo.errors import BulkWriteError, InvalidOperation, PyMongoError
 from pymongo.monitoring import (
     CommandFailedEvent, CommandListener, CommandStartedEvent,
-    CommandSucceededEvent)
+    CommandSucceededEvent, _SENSITIVE_COMMANDS)
 from pymongo.read_concern import ReadConcern
 from pymongo.read_preferences import ReadPreference
-from pymongo.results import BulkWriteResult, InsertManyResult, InsertOneResult
+from pymongo.results import BulkWriteResult
 from pymongo.write_concern import WriteConcern
 
 from test import client_context, unittest, IntegrationTest
 from test.utils import (
-    camel_to_snake, rs_or_single_client, single_client,
-    snake_to_camel, ScenarioDict)
+    camel_to_snake, rs_or_single_client, single_client, snake_to_camel)
 
 from test.version import Version
 from test.utils import (
@@ -136,7 +134,7 @@ def parse_bulk_write_error_result(error):
 class EventListenerUtil(CommandListener):
     def __init__(self, observe_events, ignore_commands):
         self._event_types = set(observe_events)
-        self._ignore_commands = set(ignore_commands)
+        self._ignore_commands = _SENSITIVE_COMMANDS | set(ignore_commands)
         self._ignore_commands.add('configureFailPoint')
         self.results = []
 

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -604,7 +604,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
 
         if expect_result:
             if isinstance(exception, BulkWriteError):
-                result = SpecTestUtil.parse_bulk_write_error_result(
+                result = parse_bulk_write_error_result(
                     exception)
                 self.match_evaluator.match_result(expect_result, result)
             else:
@@ -650,7 +650,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
     def _collectionOperation_bulkWrite(self, target, *args, **kwargs):
         self.__raise_if_unsupported('bulkWrite', target, Collection)
         write_result = target.bulk_write(*args, **kwargs)
-        return SpecTestUtil.parse_bulk_write_result(write_result)
+        return parse_bulk_write_result(write_result)
 
     def _collectionOperation_find(self, target, *args, **kwargs):
         self.__raise_if_unsupported('find', target, Collection)

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -743,6 +743,9 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             self.entity_map[save_as_entity] = result
 
     def __set_fail_point(self, client, command_args):
+        if not client_context.test_commands_enabled:
+            self.skipTest('Test commands must be enabled')
+
         cmd_on = SON([('configureFailPoint', 'failCommand')])
         cmd_on.update(command_args)
         client.admin.command(cmd_on)

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -526,9 +526,12 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
                 coll_name, write_concern=WriteConcern(w="majority"))
             coll.drop()
 
-            # documents MAY be an empty list
-            if len(documents):
+            if len(documents) > 0:
                 coll.insert_many(documents)
+            else:
+                # ensure collection exists
+                result = coll.insert_one({})
+                coll.delete_one({'_id': result.inserted_id})
 
     @classmethod
     def setUpClass(cls):

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -25,10 +25,10 @@ import sys
 import traceback
 import types
 
-from bson import json_util, SON, Int64
+from bson import json_util, Code, Decimal128, DBRef, SON, Int64, MaxKey, MinKey
 from bson.binary import Binary
 from bson.objectid import ObjectId
-from bson.py3compat import abc, integer_types, iteritems, text_type
+from bson.py3compat import abc, integer_types, iteritems, text_type, PY3
 from bson.regex import Regex, RE_TYPE
 
 from gridfs import GridFSBucket
@@ -286,6 +286,16 @@ class EntityMapUtil(object):
             return self._session_lsids[session_name]
 
 
+if not PY3:
+    binary_types = (Binary,)
+    long_types = (Int64, long)
+    unicode_types = (unicode,)
+else:
+    binary_types = (Binary, bytes)
+    long_types = (Int64,)
+    unicode_types = (str,)
+
+
 BSON_TYPE_ALIAS_MAP = {
     # https://docs.mongodb.com/manual/reference/operator/query/type/
     # https://pymongo.readthedocs.io/en/stable/api/bson/index.html
@@ -293,15 +303,22 @@ BSON_TYPE_ALIAS_MAP = {
     'string': (text_type,),
     'object': (abc.Mapping,),
     'array': (abc.MutableSequence,),
-    'binData': (Binary, bytes),
+    'binData': binary_types,
+    'undefined': (type(None),),
     'objectId': (ObjectId,),
     'bool': (bool,),
     'date': (datetime.datetime,),
     'null': (type(None),),
     'regex': (Regex, RE_TYPE),
+    'dbPointer': (DBRef,),
+    'javascript': (*unicode_types, Code),
+    'symbol': unicode_types,
+    'javascriptWithScope': (*unicode_types, Code),
     'int': (int,),
-    'long': (Int64,)
-    # TODO: add all supported types
+    'long': (Int64,),
+    'decimal': (Decimal128,),
+    'maxKey': (MaxKey,),
+    'minKey': (MinKey,),
 }
 
 

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -549,13 +549,6 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             if cls.TEST_SPEC['description'].find('retryable-writes') != -1:
                 raise unittest.SkipTest(
                     "MMAPv1 does not support retryWrites=True")
-            if cls.TEST_SPEC['description'].find('change-streams') != -1:
-                raise unittest.SkipTest(
-                    "MMAPv1 does not support change streams")
-            if cls.TEST_SPEC['description'].find(
-                    'transactions-convenient-api') != -1:
-                raise unittest.SkipTest(
-                    "MMAPv1 does not support document-level locking")
 
     @classmethod
     def tearDownClass(cls):
@@ -643,6 +636,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
                       'of type %s' % (opname, type(target)))
 
     def __entityOperation_createChangeStream(self, target, *args, **kwargs):
+        if client_context.storage_engine == 'mmapv1':
+            self.skipTest("MMAPv1 does not support change streams")
         self.__raise_if_unsupported(
             'createChangeStream', target, MongoClient, Database, Collection)
         return target.watch(*args, **kwargs)
@@ -702,8 +697,16 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         return {'insertedId': result.inserted_id}
 
     def _sessionOperation_withTransaction(self, target, *args, **kwargs):
+        if client_context.storage_engine == 'mmapv1':
+            self.skipTest('MMAPv1 does not support document-level locking')
         self.__raise_if_unsupported('withTransaction', target, ClientSession)
         return target.with_transaction(*args, **kwargs)
+
+    def _sessionOperation_startTransaction(self, target, *args, **kwargs):
+        if client_context.storage_engine == 'mmapv1':
+            self.skipTest('MMAPv1 does not support document-level locking')
+        self.__raise_if_unsupported('startTransaction', target, ClientSession)
+        return target.start_transaction(*args, **kwargs)
 
     def _changeStreamOperation_iterateUntilDocumentOrError(self, target,
                                                            *args, **kwargs):

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1,0 +1,286 @@
+# Copyright 2020-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified test format runner.
+
+https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst
+"""
+
+import copy
+import os
+import sys
+import types
+
+from bson import json_util
+
+from pymongo.mongo_client import MongoClient
+from pymongo.write_concern import WriteConcern
+
+from test import client_context, unittest, IntegrationTest
+from test.utils import (
+    camel_to_snake, camel_to_snake_args, rs_or_single_client,
+    snake_to_camel, ScenarioDict)
+
+from test.version import Version
+
+
+JSON_OPTS = json_util.JSONOptions(tz_aware=False)
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass.
+
+    Vendored from six: https://github.com/benjaminp/six/blob/master/six.py
+    """
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            if sys.version_info[:2] >= (3, 7):
+                # This version introduced PEP 560 that requires a bit
+                # of extra care (we mimic what is done by __build_class__).
+                resolved_bases = types.resolve_bases(bases)
+                if resolved_bases is not bases:
+                    d['__orig_bases__'] = bases
+            else:
+                resolved_bases = bases
+            return meta(name, resolved_bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def is_run_on_requirement_satisfied(requirement):
+    topology_satisfied = True
+    req_topologies = requirement.get('topologies')
+    if req_topologies:
+        topology_satisfied = client_context.is_topology_type(
+            req_topologies)
+
+    min_version_satisfied = True
+    req_min_server_version = requirement.get('minServerVersion')
+    if req_min_server_version:
+        min_version_satisfied = Version.from_string(
+            req_min_server_version) <= client_context.version
+
+    max_version_satisfied = True
+    req_max_server_version = requirement.get('maxServerVersion')
+    if req_max_server_version:
+        max_version_satisfied = Version.from_string(
+            req_max_server_version) >= client_context.version
+
+    return (topology_satisfied and min_version_satisfied and
+            max_version_satisfied)
+
+
+class UnifiedSpecTestMixin(IntegrationTest):
+    """Mixin class to run test cases from test specification files.
+
+    Assumes that tests conform to the `unified test format
+    <https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst>`_.
+
+    Specification of the test suite being currently run is available as
+    a class attribute ``TEST_SPEC``.
+    """
+    SCHEMA_VERSION = '1.0'
+
+    @staticmethod
+    def should_run_on(run_on_spec):
+        if not run_on_spec:
+            # Always run these tests.
+            return True
+
+        for req in run_on_spec:
+            if is_run_on_requirement_satisfied(req):
+                return True
+        return False
+
+    @staticmethod
+    def insert_initial_data(client, collection_data):
+        coll_name = collection_data['collectionName']
+        db_name = collection_data['databaseName']
+        documents = collection_data['documents']
+
+        coll = client.get_database(db_name).get_collection(
+            coll_name, write_concern=WriteConcern(w="majority"))
+        coll.drop()
+
+        # documents MAY be an empty list
+        if documents:
+            coll.insert_many(documents)
+
+    @classmethod
+    def setUpClass(cls):
+        # The super call takes care of creating the internal client.
+        super(UnifiedSpecTestMixin, cls).setUpClass()
+
+        # process schemaVersion
+        version = cls.TEST_SPEC['schemaVersion']
+        version_tuple = tuple(version.split('.', 2)[:2])
+        max_version_tuple = tuple(cls.SCHEMA_VERSION.split('.', 2)[:2])
+        if not version_tuple <= max_version_tuple:
+            raise unittest.SkipTest(
+                'expected schemaVersion %s or lower, got %s' % (
+                    cls.SCHEMA_VERSION, version))
+
+        # process file-level runOnRequirements
+        run_on_spec = cls.TEST_SPEC.get('runOnRequirements', [])
+        if not cls.should_run_on(run_on_spec):
+            raise unittest.SkipTest('runOnRequirements not satisfied')
+
+    @classmethod
+    def tearDownClass(cls):
+        super(UnifiedSpecTestMixin, cls).tearDownClass()
+        cls.client.close()
+
+    def create_entity(self, entity_spec):
+        if len(entity_spec) != 1:
+            raise ValueError("Entity spec MUST contain exactly one top-level key.")
+
+        for entity_type, spec in entity_spec.items():
+            pass
+
+        if entity_type == 'client':
+            # TODO
+            # Add logic to respect the following fields
+            # - uriOptions
+            # - useMultipleMongoses
+            # - observeEvents
+            # - ignoreCommandMonitoringEvents
+            client = rs_or_single_client()
+            self.entity_map[spec['id']] = client
+            self.addCleanup(client.close)
+            return
+        elif entity_type == 'database':
+            # TODO
+            # Add logic to respect the following fields
+            # - databaseOptions
+            client = self.entity_map[spec['client']]
+            self.entity_map[spec['id']] = client.get_database(spec['databaseName'])
+            return
+        elif entity_type == 'collection':
+            # TODO
+            # Add logic to respect the following fields
+            # - collectionOptions
+            database = self.entity_map[spec['database']]
+            self.entity_map[spec['id']] = database.get_collection(spec['collectionName'])
+            return
+        # elif ...
+            # TODO
+            # Implement the following entity types:
+            # - session
+            # - bucket
+        else:
+            raise ValueError("Unknown entity type %s" % (entity_type,))
+
+    def setUp(self):
+        super(UnifiedSpecTestMixin, self).setUp()
+
+        # process createEntities
+        self.entity_map = {}
+        entity_spec = self.TEST_SPEC.get('createEntities', [])
+        for spec in entity_spec:
+            self.create_entity(spec)
+
+        # process initialData
+        initial_data = self.TEST_SPEC.get('initialData', [])
+        for data in initial_data:
+            self.insert_initial_data(self.client, data)
+
+        # initialize internals
+        self.test_assets = {}
+
+    def run_scenario(self, spec):
+        # process test-level runOnRequirements
+        run_on_spec = spec.get('runOnRequirements', [])
+        if not self.should_run_on(run_on_spec):
+            raise unittest.SkipTest('runOnRequirements not satisfied')
+
+        # process skipReason
+        skip_reason = spec.get('skipReason', None)
+        if skip_reason is not None:
+            raise unittest.SkipTest('%s' % (skip_reason,))
+
+        # process operations
+        # TODO: process operations
+
+        # process expectedEvents
+        # TODO: process expectedEvents
+
+        # process outcome
+        # TODO: process outcome
+
+
+class UnifiedSpecTestMeta(type):
+    """Metaclass for generating test classes."""
+    def __init__(cls, *args, **kwargs):
+        super(UnifiedSpecTestMeta, cls).__init__(*args, **kwargs)
+
+        def create_test(spec):
+            def test_case(self):
+                self.run_scenario(spec)
+            return test_case
+
+        for test_spec in cls.TEST_SPEC['tests']:
+            description = test_spec['description']
+            test_name = 'test_%s' % (
+                description.replace(' ', '_').replace('.', '_').lower(),)
+            test_method = create_test(copy.deepcopy(test_spec))
+            test_method.__name__ = test_name
+            setattr(cls, test_name, test_method)
+
+
+def generate_test_classes(test_path, name_prefix=''):
+    """Method for generating test classes. Returns a dictionary where keys are
+    the names of test classes and values are the test class objects."""
+    test_klasses = {}
+    if name_prefix:
+        name_prefix = name_prefix + '_'
+
+    def test_base_class_factory(test_spec):
+        """Utility that creates the base class to use for test generation.
+        This is needed to ensure that cls.TEST_SPEC is appropriately set when
+        the metaclass __init__ is invoked."""
+        class SpecTestBase(with_metaclass(UnifiedSpecTestMeta)):
+            TEST_SPEC = test_spec
+        return SpecTestBase
+
+    for dirpath, _, filenames in os.walk(test_path):
+        dirname = os.path.split(dirpath)[-1]
+
+        for filename in filenames:
+            with open(os.path.join(dirpath, filename)) as scenario_stream:
+                # Use tz_aware=False to match how CodecOptions decodes
+                # dates.
+                opts = json_util.JSONOptions(tz_aware=False)
+                scenario_def = ScenarioDict(
+                    json_util.loads(scenario_stream.read(),
+                                    json_options=opts))
+
+            test_type = os.path.splitext(filename)[0]
+            snake_class_name = 'Test_%s_%s' % (
+                name_prefix + dirname.replace('-', '_'),
+                test_type.replace('-', '_').replace('.', '_'))
+            class_name = snake_to_camel(snake_class_name)
+
+            test_klasses[class_name] = type(
+                class_name,
+                (UnifiedSpecTestMixin, test_base_class_factory(scenario_def),),
+                {})
+
+    return test_klasses

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -286,11 +286,11 @@ class EntityMapUtil(object):
 if not PY3:
     binary_types = (Binary,)
     long_types = (Int64, long)
-    unicode_types = (unicode,)
+    unicode_type = unicode
 else:
     binary_types = (Binary, bytes)
     long_types = (Int64,)
-    unicode_types = (str,)
+    unicode_type = str
 
 
 BSON_TYPE_ALIAS_MAP = {
@@ -308,9 +308,9 @@ BSON_TYPE_ALIAS_MAP = {
     'null': (type(None),),
     'regex': (Regex, RE_TYPE),
     'dbPointer': (DBRef,),
-    'javascript': (*unicode_types, Code),
-    'symbol': unicode_types,
-    'javascriptWithScope': (*unicode_types, Code),
+    'javascript': (unicode_type, Code),
+    'symbol': (unicode_type,),
+    'javascriptWithScope': (unicode_type, Code),
     'int': (int,),
     'long': (Int64,),
     'decimal': (Decimal128,),
@@ -928,7 +928,7 @@ class UnifiedSpecTestMeta(type):
             test_name = 'test_%s' % (description.strip('. ').
                                      replace(' ', '_').replace('.', '_'),)
             test_method = create_test(copy.deepcopy(test_spec))
-            test_method.__name__ = test_name
+            test_method.__name__ = str(test_name)
 
             for fail_pattern in cls.EXPECTED_FAILURES:
                 if re.search(fail_pattern, description):

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -201,8 +201,43 @@ class UnifiedSpecTestMixin(IntegrationTest):
         for data in initial_data:
             self.insert_initial_data(self.client, data)
 
-        # initialize internals
-        self.test_assets = {}
+        # PyMongo internals
+        #self.test_assets = {}
+
+    def run_entity_operation(self, entity_name, spec):
+        target = self.entity_map[entity_name]
+        opname = camel_to_snake(spec['name'])
+        opargs = spec.get('arguments')
+        expect_error = spec.get('expectError')
+        if expect_error:
+            # TODO: process expectedError object
+            # See L420-446 of utils_spec_runner.py
+            pass
+        else:
+            # Operation expected to succeed
+            arguments = {}
+            if opargs:
+                if 'session' in arguments:
+                    # TODO: resolve session to entity
+                    pass
+                if 'readConcern' in arguments:
+                    from pymongo.read_concern import ReadConcern
+                    arguments['read_concern'] = ReadConcern(
+                        **opargs.pop('readConcern'))
+                if 'readPreference' in arguments:
+                    from pymongo.read_preferences import ReadPreference
+                    pass
+
+    def run_special_operation(self, spec):
+        pass
+
+    def run_operations(self, spec):
+        for op in spec:
+            target = op['object']
+            if target != 'testRunner':
+                self.run_entity_operation(target, op)
+            else:
+                self.run_special_operation(op)
 
     def run_scenario(self, spec):
         # process test-level runOnRequirements
@@ -216,7 +251,7 @@ class UnifiedSpecTestMixin(IntegrationTest):
             raise unittest.SkipTest('%s' % (skip_reason,))
 
         # process operations
-        # TODO: process operations
+        self.run_operations(spec['operations'])
 
         # process expectedEvents
         # TODO: process expectedEvents

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -560,8 +560,6 @@ class UnifiedSpecTestMixin(IntegrationTest):
         error_labels_contain = spec.get('errorLabelsContain')
         error_labels_omit = spec.get('errorLabelsOmit')
         expect_result = spec.get('expectResult')
-        # TODO: process expectedError object
-        # See L420-446 of utils_spec_runner.py
 
         if is_error:
             # already satisfied because exception was raised

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -198,7 +198,7 @@ class EntityMapUtil(object):
                 self._listeners[spec['id']] = listener
                 kwargs['event_listeners'] = [listener]
             if client_context.is_mongos and spec.get('useMultipleMongoses'):
-                kwargs['host'] = client_context.mongos_seeds()
+                kwargs['h'] = client_context.mongos_seeds()
             kwargs.update(spec.get('uriOptions', {}))
             client = rs_or_single_client(**kwargs)
             self[spec['id']] = client
@@ -882,14 +882,6 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
                                      actual_documents)
 
     def run_scenario(self, spec):
-        # process createEntities
-        self.entity_map = EntityMapUtil(self)
-        self.entity_map.create_entities_from_spec(
-            self.TEST_SPEC.get('createEntities', []))
-
-        # process initialData
-        self.insert_initial_data(self.TEST_SPEC.get('initialData', []))
-
         # process test-level runOnRequirements
         run_on_spec = spec.get('runOnRequirements', [])
         if not self.should_run_on(run_on_spec):
@@ -899,6 +891,14 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         skip_reason = spec.get('skipReason', None)
         if skip_reason is not None:
             raise unittest.SkipTest('%s' % (skip_reason,))
+
+        # process createEntities
+        self.entity_map = EntityMapUtil(self)
+        self.entity_map.create_entities_from_spec(
+            self.TEST_SPEC.get('createEntities', []))
+
+        # process initialData
+        self.insert_initial_data(self.TEST_SPEC.get('initialData', []))
 
         # process operations
         self.run_operations(spec['operations'])

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -544,6 +544,12 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             raise unittest.SkipTest(
                 '%s runOnRequirements not satisfied' % (cls.__name__,))
 
+        # add any special-casing for skipping tests here
+        if (cls.TEST_SPEC['description'] == 'poc-retryable-writes'
+                and client_context.storage_engine == 'mmapv1'):
+            raise unittest.skipTest(
+                "MMAPv1 does not support retryWrites=True")
+
     @classmethod
     def tearDownClass(cls):
         super(UnifiedSpecTestMixinV1, cls).tearDownClass()

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -244,12 +244,10 @@ class UnifiedSpecTestMeta(type):
             setattr(cls, test_name, test_method)
 
 
-def generate_test_classes(test_path, module=__name__, name_prefix=''):
+def generate_test_classes(test_path, module=__name__, class_name_prefix=''):
     """Method for generating test classes. Returns a dictionary where keys are
     the names of test classes and values are the test class objects."""
     test_klasses = {}
-    if name_prefix:
-        name_prefix = name_prefix + '_'
 
     def test_base_class_factory(test_spec):
         """Utility that creates the base class to use for test generation.
@@ -272,8 +270,8 @@ def generate_test_classes(test_path, module=__name__, name_prefix=''):
                                     json_options=opts))
 
             test_type = os.path.splitext(filename)[0]
-            snake_class_name = 'Test_%s_%s' % (
-                name_prefix + dirname.replace('-', '_'),
+            snake_class_name = 'Test%s_%s_%s' % (
+                class_name_prefix, dirname.replace('-', '_'),
                 test_type.replace('-', '_').replace('.', '_'))
             class_name = snake_to_camel(snake_class_name)
 

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -135,11 +135,11 @@ class EventListenerUtil(CommandListener):
     def __init__(self, observe_events, ignore_commands):
         self._event_types = set(observe_events)
         self._ignore_commands = _SENSITIVE_COMMANDS | set(ignore_commands)
-        self._ignore_commands.add('configureFailPoint')
+        self._ignore_commands.add('configurefailpoint')
         self.results = []
 
     def _observe_event(self, event):
-        if event.command_name not in self._ignore_commands:
+        if event.command_name.lower() not in self._ignore_commands:
             self.results.append(event)
 
     def started(self, event):
@@ -193,6 +193,7 @@ class EntityMapUtil(object):
             observe_events = spec.get('observeEvents', [])
             ignore_commands = spec.get('ignoreCommandMonitoringEvents', [])
             if len(observe_events) or len(ignore_commands):
+                ignore_commands = [cmd.lower() for cmd in ignore_commands]
                 listener = EventListenerUtil(observe_events, ignore_commands)
                 self._listeners[spec['id']] = listener
                 kwargs['event_listeners'] = [listener]

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -340,7 +340,9 @@ class MatchEvaluatorUtil(object):
             actual[key_to_compare], permissible_types)
 
     def _operation_matchesEntity(self, spec, actual, key_to_compare):
-        raise NotImplementedError
+        expected_entity = self._test_class.entity_map[spec]
+        self._test_class.assertIsInstance(expected_entity, abc.Mapping)
+        self._test_class.assertEqual(expected_entity, actual[key_to_compare])
 
     def _operation_matchesHexBytes(self, spec, actual, key_to_compare):
         raise NotImplementedError
@@ -564,13 +566,19 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             self.assertNotIsInstance(exception, PyMongoError)
 
         if error_contains:
-            raise NotImplementedError
+            if isinstance(exception, BulkWriteError):
+                errmsg = str(exception.details).lower()
+            else:
+                errmsg = str(exception).lower()
+            self.assertIn(error_contains.lower(), errmsg)
 
         if error_code:
-            raise NotImplementedError
+            self.assertEqual(
+                error_code, exception.details.get('code'))
 
         if error_code_name:
-            raise NotImplementedError
+            self.assertEqual(
+                error_code_name, exception.details.get('codeName'))
 
         if error_labels_contain:
             labels = [err_label for err_label in error_labels_contain

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -546,7 +546,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
 
         # add any special-casing for skipping tests here
         if client_context.storage_engine == 'mmapv1':
-            if cls.TEST_SPEC['description'].find('retryable-writes') != -1:
+            if 'retryable-writes' in cls.TEST_SPEC['description']:
                 raise unittest.SkipTest(
                     "MMAPv1 does not support retryWrites=True")
 
@@ -573,8 +573,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
     def maybe_skip_test(self, spec):
         # add any special-casing for skipping tests here
         if client_context.storage_engine == 'mmapv1':
-            if spec['description'].find(
-                    'Dirty explicit session is discarded') != -1:
+            if 'Dirty explicit session is discarded' in spec['description']:
                 raise unittest.SkipTest(
                     "MMAPv1 does not support retryWrites=True")
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -563,6 +563,11 @@ def camel_to_snake_args(arguments):
     return arguments
 
 
+def snake_to_camel(snake):
+    # Regex to convert snake_case to lowerCamelCase.
+    return re.sub(r'_([a-z])', lambda m: m.group(1).upper(), snake)
+
+
 def parse_collection_options(opts):
     if 'readPreference' in opts:
         opts['read_preference'] = parse_read_preference(

--- a/test/utils.py
+++ b/test/utils.py
@@ -958,6 +958,10 @@ def assertion_context(msg):
         py3compat.reraise(type(exc), msg, sys.exc_info()[2])
 
 
+class SpecParserUtil(object):
+    pass
+
+
 def parse_spec_options(opts):
     if 'readPreference' in opts:
         opts['read_preference'] = parse_read_preference(

--- a/test/utils.py
+++ b/test/utils.py
@@ -1053,7 +1053,12 @@ def prepare_spec_arguments(spec, arguments, opname, entity_map,
             # camelCase maxTimeMS. See PYTHON-1855.
             arguments['maxTimeMS'] = arguments.pop('max_time_ms')
         elif opname == 'with_transaction' and arg_name == 'callback':
-            callback_ops = arguments[arg_name]['operations']
+            if 'operations' in arguments[arg_name]:
+                # CRUD v2 format
+                callback_ops = arguments[arg_name]['operations']
+            else:
+                # Unified test format
+                callback_ops = arguments[arg_name]
             arguments['callback'] = lambda _: with_txn_callback(
                 copy.deepcopy(callback_ops))
         elif opname == 'drop_collection' and arg_name == 'collection':

--- a/test/utils.py
+++ b/test/utils.py
@@ -959,10 +959,6 @@ def assertion_context(msg):
         py3compat.reraise(type(exc), msg, sys.exc_info()[2])
 
 
-class SpecParserUtil(object):
-    pass
-
-
 def parse_spec_options(opts):
     if 'readPreference' in opts:
         opts['read_preference'] = parse_read_preference(

--- a/test/utils.py
+++ b/test/utils.py
@@ -995,7 +995,7 @@ def parse_spec_options(opts):
                     hint = args.pop('hint')
                     if not isinstance(hint, string_type):
                         hint = list(iteritems(hint))
-                args['hint'] = hint
+                    args['hint'] = hint
                 req['arguments'] = args
             else:
                 # Unified test format

--- a/test/utils.py
+++ b/test/utils.py
@@ -991,7 +991,7 @@ def parse_spec_options(opts):
     if 'requests' in opts:
         reqs = opts.pop('requests')
         for req in reqs:
-            args = req.pop('arguments')
+            args = req.pop('arguments', {})
             if 'hint' in args:
                 hint = args.pop('hint')
                 if not isinstance(hint, string_type):
@@ -1025,9 +1025,16 @@ def prepare_spec_arguments(spec, arguments, opname, entity_map,
             # Parse each request into a bulk write model.
             requests = []
             for request in arguments["requests"]:
-                bulk_model = camel_to_upper_camel(request["name"])
-                bulk_class = getattr(operations, bulk_model)
-                bulk_arguments = camel_to_snake_args(request["arguments"])
+                if 'name' in request:
+                    # CRUD v2 format
+                    bulk_model = camel_to_upper_camel(request["name"])
+                    bulk_class = getattr(operations, bulk_model)
+                    bulk_arguments = camel_to_snake_args(request["arguments"])
+                else:
+                    # Unified test format
+                    bulk_model, spec = next(iteritems(request))
+                    bulk_class = getattr(operations, camel_to_upper_camel(bulk_model))
+                    bulk_arguments = camel_to_snake_args(spec)
                 requests.append(bulk_class(**dict(bulk_arguments)))
             arguments["requests"] = requests
         elif arg_name == "session":

--- a/test/utils.py
+++ b/test/utils.py
@@ -17,6 +17,7 @@
 
 import collections
 import contextlib
+import copy
 import functools
 import os
 import re
@@ -31,10 +32,11 @@ from functools import partial
 
 from bson import json_util, py3compat
 from bson.objectid import ObjectId
+from bson.py3compat import iteritems, string_type
 from bson.son import SON
 
 from pymongo import (MongoClient,
-                     monitoring, read_preferences)
+                     monitoring, operations, read_preferences)
 from pymongo.errors import ConfigurationError, OperationFailure
 from pymongo.monitoring import _SENSITIVE_COMMANDS, ConnectionPoolListener
 from pymongo.pool import (_CancellationContext,
@@ -954,3 +956,102 @@ def assertion_context(msg):
     except AssertionError as exc:
         msg = '%s (%s)' % (exc, msg)
         py3compat.reraise(type(exc), msg, sys.exc_info()[2])
+
+
+def parse_spec_options(opts):
+    if 'readPreference' in opts:
+        opts['read_preference'] = parse_read_preference(
+            opts.pop('readPreference'))
+
+    if 'writeConcern' in opts:
+        opts['write_concern'] = WriteConcern(
+            **dict(opts.pop('writeConcern')))
+
+    if 'readConcern' in opts:
+        opts['read_concern'] = ReadConcern(
+            **dict(opts.pop('readConcern')))
+
+    if 'maxTimeMS' in opts:
+        opts['max_time_ms'] = opts.pop('maxTimeMS')
+
+    if 'maxCommitTimeMS' in opts:
+        opts['max_commit_time_ms'] = opts.pop('maxCommitTimeMS')
+
+    if 'hint' in opts:
+        hint = opts.pop('hint')
+        if not isinstance(hint, string_type):
+            hint = list(iteritems(hint))
+        opts['hint'] = hint
+
+    # Properly format 'hint' arguments for the Bulk API tests.
+    if 'requests' in opts:
+        reqs = opts.pop('requests')
+        for req in reqs:
+            args = req.pop('arguments')
+            if 'hint' in args:
+                hint = args.pop('hint')
+                if not isinstance(hint, string_type):
+                    hint = list(iteritems(hint))
+                args['hint'] = hint
+            req['arguments'] = args
+        opts['requests'] = reqs
+
+    return dict(opts)
+
+
+def prepare_spec_arguments(spec, arguments, opname, entity_map,
+                           with_txn_callback):
+    for arg_name in list(arguments):
+        c2s = camel_to_snake(arg_name)
+        # PyMongo accepts sort as list of tuples.
+        if arg_name == "sort":
+            sort_dict = arguments[arg_name]
+            arguments[arg_name] = list(iteritems(sort_dict))
+        # Named "key" instead not fieldName.
+        if arg_name == "fieldName":
+            arguments["key"] = arguments.pop(arg_name)
+        # Aggregate uses "batchSize", while find uses batch_size.
+        elif ((arg_name == "batchSize" or arg_name == "allowDiskUse") and
+              opname == "aggregate"):
+            continue
+        # Requires boolean returnDocument.
+        elif arg_name == "returnDocument":
+            arguments[c2s] = arguments.pop(arg_name) == "After"
+        elif c2s == "requests":
+            # Parse each request into a bulk write model.
+            requests = []
+            for request in arguments["requests"]:
+                bulk_model = camel_to_upper_camel(request["name"])
+                bulk_class = getattr(operations, bulk_model)
+                bulk_arguments = camel_to_snake_args(request["arguments"])
+                requests.append(bulk_class(**dict(bulk_arguments)))
+            arguments["requests"] = requests
+        elif arg_name == "session":
+            arguments['session'] = entity_map[arguments['session']]
+        elif (opname in ('command', 'run_admin_command') and
+              arg_name == 'command'):
+            # Ensure the first key is the command name.
+            ordered_command = SON([(spec['command_name'], 1)])
+            ordered_command.update(arguments['command'])
+            arguments['command'] = ordered_command
+        elif opname == 'open_download_stream' and arg_name == 'id':
+            arguments['file_id'] = arguments.pop(arg_name)
+        elif opname != 'find' and c2s == 'max_time_ms':
+            # find is the only method that accepts snake_case max_time_ms.
+            # All other methods take kwargs which must use the server's
+            # camelCase maxTimeMS. See PYTHON-1855.
+            arguments['maxTimeMS'] = arguments.pop('max_time_ms')
+        elif opname == 'with_transaction' and arg_name == 'callback':
+            callback_ops = arguments[arg_name]['operations']
+            arguments['callback'] = lambda _: with_txn_callback(
+                copy.deepcopy(callback_ops))
+        elif opname == 'drop_collection' and arg_name == 'collection':
+            arguments['name_or_collection'] = arguments.pop(arg_name)
+        elif opname == 'create_collection' and arg_name == 'collection':
+            arguments['name'] = arguments.pop(arg_name)
+        elif opname == 'create_index' and arg_name == 'keys':
+            arguments['keys'] = list(arguments.pop(arg_name).items())
+        elif opname == 'drop_index' and arg_name == 'name':
+            arguments['index_or_name'] = arguments.pop(arg_name)
+        else:
+            arguments[c2s] = arguments.pop(arg_name)

--- a/test/utils.py
+++ b/test/utils.py
@@ -37,6 +37,7 @@ from bson.son import SON
 
 from pymongo import (MongoClient,
                      monitoring, operations, read_preferences)
+from pymongo.collection import ReturnDocument
 from pymongo.errors import ConfigurationError, OperationFailure
 from pymongo.monitoring import _SENSITIVE_COMMANDS, ConnectionPoolListener
 from pymongo.pool import (_CancellationContext,
@@ -1020,7 +1021,7 @@ def prepare_spec_arguments(spec, arguments, opname, entity_map,
             continue
         # Requires boolean returnDocument.
         elif arg_name == "returnDocument":
-            arguments[c2s] = arguments.pop(arg_name) == "After"
+            arguments[c2s] = getattr(ReturnDocument, arguments.pop(arg_name).upper())
         elif c2s == "requests":
             # Parse each request into a bulk write model.
             requests = []

--- a/test/utils.py
+++ b/test/utils.py
@@ -988,13 +988,23 @@ def parse_spec_options(opts):
     if 'requests' in opts:
         reqs = opts.pop('requests')
         for req in reqs:
-            args = req.pop('arguments', {})
-            if 'hint' in args:
-                hint = args.pop('hint')
-                if not isinstance(hint, string_type):
-                    hint = list(iteritems(hint))
+            if 'name' in req:
+                # CRUD v2 format
+                args = req.pop('arguments', {})
+                if 'hint' in args:
+                    hint = args.pop('hint')
+                    if not isinstance(hint, string_type):
+                        hint = list(iteritems(hint))
                 args['hint'] = hint
-            req['arguments'] = args
+                req['arguments'] = args
+            else:
+                # Unified test format
+                bulk_model, spec = next(iteritems(req))
+                if 'hint' in spec:
+                    hint = spec.pop('hint')
+                    if not isinstance(hint, string_type):
+                        hint = list(iteritems(hint))
+                    spec['hint'] = hint
         opts['requests'] = reqs
 
     return dict(opts)

--- a/test/utils_spec_runner.py
+++ b/test/utils_spec_runner.py
@@ -15,6 +15,7 @@
 """Utilities for testing driver specs."""
 
 import copy
+import functools
 import threading
 
 
@@ -50,7 +51,9 @@ from test.utils import (camel_to_snake,
                         CompareType,
                         CMAPListener,
                         OvertCommandListener,
+                        parse_spec_options,
                         parse_read_preference,
+                        prepare_spec_arguments,
                         rs_client,
                         ServerAndTopologyEventListener,
                         HeartbeatEventListener)
@@ -249,44 +252,7 @@ class SpecRunner(IntegrationTest):
 
     @staticmethod
     def parse_options(opts):
-        if 'readPreference' in opts:
-            opts['read_preference'] = parse_read_preference(
-                opts.pop('readPreference'))
-
-        if 'writeConcern' in opts:
-            opts['write_concern'] = WriteConcern(
-                **dict(opts.pop('writeConcern')))
-
-        if 'readConcern' in opts:
-            opts['read_concern'] = ReadConcern(
-                **dict(opts.pop('readConcern')))
-
-        if 'maxTimeMS' in opts:
-            opts['max_time_ms'] = opts.pop('maxTimeMS')
-
-        if 'maxCommitTimeMS' in opts:
-            opts['max_commit_time_ms'] = opts.pop('maxCommitTimeMS')
-
-        if 'hint' in opts:
-            hint = opts.pop('hint')
-            if not isinstance(hint, string_type):
-                hint = list(iteritems(hint))
-            opts['hint'] = hint
-
-        # Properly format 'hint' arguments for the Bulk API tests.
-        if 'requests' in opts:
-            reqs = opts.pop('requests')
-            for req in reqs:
-                args = req.pop('arguments')
-                if 'hint' in args:
-                    hint = args.pop('hint')
-                    if not isinstance(hint, string_type):
-                        hint = list(iteritems(hint))
-                    args['hint'] = hint
-                req['arguments'] = args
-            opts['requests'] = reqs
-
-        return dict(opts)
+        return parse_spec_options(opts)
 
     def run_operation(self, sessions, collection, operation):
         original_collection = collection
@@ -328,61 +294,11 @@ class SpecRunner(IntegrationTest):
 
         cmd = getattr(obj, name)
 
-        for arg_name in list(arguments):
-            c2s = camel_to_snake(arg_name)
-            # PyMongo accepts sort as list of tuples.
-            if arg_name == "sort":
-                sort_dict = arguments[arg_name]
-                arguments[arg_name] = list(iteritems(sort_dict))
-            # Named "key" instead not fieldName.
-            if arg_name == "fieldName":
-                arguments["key"] = arguments.pop(arg_name)
-            # Aggregate uses "batchSize", while find uses batch_size.
-            elif ((arg_name == "batchSize" or arg_name == "allowDiskUse") and
-                  name == "aggregate"):
-                continue
-            # Requires boolean returnDocument.
-            elif arg_name == "returnDocument":
-                arguments[c2s] = arguments.pop(arg_name) == "After"
-            elif c2s == "requests":
-                # Parse each request into a bulk write model.
-                requests = []
-                for request in arguments["requests"]:
-                    bulk_model = camel_to_upper_camel(request["name"])
-                    bulk_class = getattr(operations, bulk_model)
-                    bulk_arguments = camel_to_snake_args(request["arguments"])
-                    requests.append(bulk_class(**dict(bulk_arguments)))
-                arguments["requests"] = requests
-            elif arg_name == "session":
-                arguments['session'] = sessions[arguments['session']]
-            elif (name in ('command', 'run_admin_command') and
-                  arg_name == 'command'):
-                # Ensure the first key is the command name.
-                ordered_command = SON([(operation['command_name'], 1)])
-                ordered_command.update(arguments['command'])
-                arguments['command'] = ordered_command
-            elif name == 'open_download_stream' and arg_name == 'id':
-                arguments['file_id'] = arguments.pop(arg_name)
-            elif name != 'find' and c2s == 'max_time_ms':
-                # find is the only method that accepts snake_case max_time_ms.
-                # All other methods take kwargs which must use the server's
-                # camelCase maxTimeMS. See PYTHON-1855.
-                arguments['maxTimeMS'] = arguments.pop('max_time_ms')
-            elif name == 'with_transaction' and arg_name == 'callback':
-                callback_ops = arguments[arg_name]['operations']
-                arguments['callback'] = lambda _: self.run_operations(
-                    sessions, original_collection, copy.deepcopy(callback_ops),
-                    in_with_transaction=True)
-            elif name == 'drop_collection' and arg_name == 'collection':
-                arguments['name_or_collection'] = arguments.pop(arg_name)
-            elif name == 'create_collection' and arg_name == 'collection':
-                arguments['name'] = arguments.pop(arg_name)
-            elif name == 'create_index' and arg_name == 'keys':
-                arguments['keys'] = list(arguments.pop(arg_name).items())
-            elif name == 'drop_index' and arg_name == 'name':
-                arguments['index_or_name'] = arguments.pop(arg_name)
-            else:
-                arguments[c2s] = arguments.pop(arg_name)
+        with_txn_callback = functools.partial(
+            self.run_operations, sessions, original_collection,
+            in_with_transaction=True)
+        prepare_spec_arguments(operation, arguments, name, sessions,
+                               with_txn_callback)
 
         if name == 'run_on_thread':
             args = {'sessions': sessions, 'collection': collection}


### PR DESCRIPTION
PYTHON-2033

To Do:

- [x] Implement `$$matchesEntity` operator
- [ ] ~Implement `$$matchesHexBytes` operator~ - this will be implemented along with GridFS since it is not used by any tests other than GridFS.
- [x] Implement support for `expectError.errorContains`
- [x] Implement support for `expectError.errorCode`
- [x] Implement support for `expectError.errorCodeName`
- [x] Implement `targetedFailPoint` operation
- [x] Add support for `uriOptions` and `useMultipleMongoses` to `MongoClient` entity creation
- [x] Add support for all BSON types to `$$type` operator