### PR TITLE
PYTHON-2433 Fix Python 3 ServerDescription/Exception memory leak

### DIFF
--- a/pymongo/server_description.py
+++ b/pymongo/server_description.py
@@ -15,7 +15,6 @@
 """Represent one server the driver is connected to."""
 
 from bson import EPOCH_NAIVE
-from bson.py3compat import PY3
 from pymongo.server_type import SERVER_TYPE
 from pymongo.ismaster import IsMaster
 from pymongo.monotonic import time as _time
@@ -70,11 +69,6 @@ class ServerDescription(object):
         self._me = ismaster.me
         self._last_update_time = _time()
         self._error = error
-        # PYTHON-2433 Clear error traceback info.
-        if error and PY3:
-            error.__traceback__ = None
-            error.__context__ = None
-            error.__cause__ = None
         self._topology_version = ismaster.topology_version
         if error:
             if hasattr(error, 'details') and isinstance(error.details, dict):

--- a/pymongo/server_description.py
+++ b/pymongo/server_description.py
@@ -15,6 +15,7 @@
 """Represent one server the driver is connected to."""
 
 from bson import EPOCH_NAIVE
+from bson.py3compat import PY3
 from pymongo.server_type import SERVER_TYPE
 from pymongo.ismaster import IsMaster
 from pymongo.monotonic import time as _time
@@ -69,6 +70,11 @@ class ServerDescription(object):
         self._me = ismaster.me
         self._last_update_time = _time()
         self._error = error
+        # PYTHON-2433 Clear error traceback info.
+        if error and PY3:
+            error.__traceback__ = None
+            error.__context__ = None
+            error.__cause__ = None
         self._topology_version = ismaster.topology_version
         if error:
             if hasattr(error, 'details') and isinstance(error.details, dict):


### PR DESCRIPTION
When the SDAM monitor check fails, a ServerDescription is created from
the exception. This exception is kept alive via the
ServerDescription.error field. Unfortunately, the exception's traceback
contains a reference to the previous ServerDescription. Altogether this
means that each consecutively failing check leaks memory by building an
ever growing chain of ServerDescription -> Exception -> Traceback ->
Frame -> ServerDescription -> ... objects.

This change breaks the chain and prevents the memory leak by clearing
the Exception's __traceback__, __context__, and __cause__ fields.