### PR TITLE
PYTHON-2431 Fix MONGODB-AWS auth tests on macOS

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -487,12 +487,15 @@ functions:
   "run aws auth test with assume role credentials":
     - command: shell.exec
       type: test
+      shell: bash
       params:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+          # Get access to createvirtualenv.
+          . .evergreen/utils.sh
           # The aws_e2e_assume_role script requires python3 with boto3.
-          ${python3_binary} -m venv mongovenv
+          createvirtualenv ${python3_binary} mongovenv
           if [ "Windows_NT" = "$OS" ]; then
             . mongovenv/Scripts/activate
           else

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -823,7 +823,7 @@ tasks:
     - name: "release"
       tags: ["release"]
       exec_timeout_secs: 216000  # 60 minutes (manylinux task is slow).
-      git_tag_only: true
+      git_tag_only: false
       commands:
         - command: shell.exec
           type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -496,11 +496,6 @@ functions:
           . .evergreen/utils.sh
           # The aws_e2e_assume_role script requires python3 with boto3.
           createvirtualenv ${python3_binary} mongovenv
-          if [ "Windows_NT" = "$OS" ]; then
-            . mongovenv/Scripts/activate
-          else
-            . mongovenv/bin/activate
-          fi
           pip install boto3
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           mongo aws_e2e_assume_role.js

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -492,7 +492,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           # The aws_e2e_assume_role script requires python3 with boto3.
-          virtualenv -p ${python3_binary} mongovenv
+          ${python3_binary} -m venv mongovenv
           if [ "Windows_NT" = "$OS" ]; then
             . mongovenv/Scripts/activate
           else

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -826,7 +826,7 @@ tasks:
     - name: "release"
       tags: ["release"]
       exec_timeout_secs: 216000  # 60 minutes (manylinux task is slow).
-      git_tag_only: false
+      git_tag_only: true
       commands:
         - command: shell.exec
           type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1568,7 +1568,7 @@ axes:
         variables:
           skip_EC2_auth_test: true
           skip_ECS_auth_test: true
-          python3_binary: python3
+          python3_binary: /Library/Frameworks/Python.framework/Versions/3.8/bin/python3
           libmongocrypt_url: https://s3.amazonaws.com/mciuploads/libmongocrypt/macos/master/latest/libmongocrypt.tar.gz
       - id: rhel62
         display_name: "RHEL 6.2 (x86_64)"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -487,15 +487,17 @@ functions:
   "run aws auth test with assume role credentials":
     - command: shell.exec
       type: test
-      shell: bash
       params:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          # Get access to createvirtualenv.
-          . .evergreen/utils.sh
           # The aws_e2e_assume_role script requires python3 with boto3.
-          createvirtualenv ${python3_binary} mongovenv
+          virtualenv -p ${python3_binary} mongovenv
+          if [ "Windows_NT" = "$OS" ]; then
+            . mongovenv/Scripts/activate
+          else
+            . mongovenv/bin/activate
+          fi
           pip install boto3
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           mongo aws_e2e_assume_role.js

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -51,18 +51,6 @@ authtest () {
     $PYTHON --version
 
     createvirtualenv $PYTHON venvaws
-    if [ "Windows_NT" = "$OS" ]; then
-      . venvaws/Scripts/activate
-    else
-      . venvaws/bin/activate
-    fi
-
-    # Added to fix Windows Python 3.5 pip install error:
-    # TypeError: stat: can't specify None for path argument
-    if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
-        $PYTHON -m pip install -U setuptools
-    fi
-
     pip install '.[aws]'
     python test/auth_aws/test_auth_aws.py
     deactivate

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -3,6 +3,9 @@
 set -o xtrace
 set -o errexit  # Exit the script with error if any of the commands fail
 
+# Get access to createvirtualenv.
+. .evergreen/utils.sh
+
 ############################################
 #            Main Program                  #
 ############################################
@@ -39,8 +42,6 @@ fi
 # show test output
 set -x
 
-VIRTUALENV=$(command -v virtualenv)
-
 authtest () {
     if [ "Windows_NT" = "$OS" ]; then
       PYTHON=$(cygpath -m $PYTHON)
@@ -49,7 +50,7 @@ authtest () {
     echo "Running MONGODB-AWS authentication tests with $PYTHON"
     $PYTHON --version
 
-    $VIRTUALENV -p $PYTHON --system-site-packages --never-download venvaws
+    createvirtualenv $PYTHON venvaws
     if [ "Windows_NT" = "$OS" ]; then
       . venvaws/Scripts/activate
     else

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -39,7 +39,12 @@ fi
 # show test output
 set -x
 
-VIRTUALENV=$(command -v virtualenv)
+# Workaround macOS python 3.9 incompatibility with system virtualenv.
+if [ $(uname -s) = "Darwin" ]; then
+    VIRTUALENV="/Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m virtualenv"
+else
+    VIRTUALENV=$(command -v virtualenv)
+fi
 
 authtest () {
     if [ "Windows_NT" = "$OS" ]; then

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -3,9 +3,6 @@
 set -o xtrace
 set -o errexit  # Exit the script with error if any of the commands fail
 
-# Get access to createvirtualenv.
-. .evergreen/utils.sh
-
 ############################################
 #            Main Program                  #
 ############################################
@@ -42,6 +39,8 @@ fi
 # show test output
 set -x
 
+VIRTUALENV=$(command -v virtualenv)
+
 authtest () {
     if [ "Windows_NT" = "$OS" ]; then
       PYTHON=$(cygpath -m $PYTHON)
@@ -50,7 +49,12 @@ authtest () {
     echo "Running MONGODB-AWS authentication tests with $PYTHON"
     $PYTHON --version
 
-    createvirtualenv $PYTHON venvaws
+    $VIRTUALENV -p $PYTHON --system-site-packages --never-download venvaws
+    if [ "Windows_NT" = "$OS" ]; then
+      . venvaws/Scripts/activate
+    else
+      . venvaws/bin/activate
+    fi
     pip install '.[aws]'
     python test/auth_aws/test_auth_aws.py
     deactivate

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -56,6 +56,13 @@ authtest () {
     else
       . venvaws/bin/activate
     fi
+
+    # Added to fix Windows Python 3.5 pip install error:
+    # TypeError: stat: can't specify None for path argument
+    if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
+        $PYTHON -m pip install -U setuptools
+    fi
+
     pip install '.[aws]'
     python test/auth_aws/test_auth_aws.py
     deactivate

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -8,14 +8,16 @@ createvirtualenv () {
     PYTHON=$1
     VENVPATH=$2
     if $PYTHON -m virtualenv --version; then
-        VIRTUALENV="$PYTHON -m virtualenv"
+        VIRTUALENV="$PYTHON -m virtualenv --never-download"
+    elif $PYTHON -m venv -h >/dev/null; then
+        VIRTUALENV="$PYTHON -m venv"
     elif command -v virtualenv; then
-        VIRTUALENV="$(command -v virtualenv) -p $PYTHON"
+        VIRTUALENV="$(command -v virtualenv) -p $PYTHON --never-download"
     else
         echo "Cannot test without virtualenv"
         exit 1
     fi
-    $VIRTUALENV --system-site-packages --never-download $VENVPATH
+    $VIRTUALENV --system-site-packages $VENVPATH
     if [ "Windows_NT" = "$OS" ]; then
         . $VENVPATH/Scripts/activate
     else

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -9,7 +9,8 @@ createvirtualenv () {
     VENVPATH=$2
     if $PYTHON -m virtualenv --version; then
         VIRTUALENV="$PYTHON -m virtualenv --never-download"
-    elif $PYTHON -m venv -h >/dev/null; then
+    elif [ $(uname -s) = "Darwin" ] && $PYTHON -m venv -h >/dev/null; then
+        # Only use venv on macOS, venv fails on Windows and some Linux distros.
         VIRTUALENV="$PYTHON -m venv"
     elif command -v virtualenv; then
         VIRTUALENV="$(command -v virtualenv) -p $PYTHON --never-download"

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -8,21 +8,16 @@ createvirtualenv () {
     PYTHON=$1
     VENVPATH=$2
     if $PYTHON -m virtualenv --version; then
-        VIRTUALENV="$PYTHON -m virtualenv --never-download"
-    elif [[ $(uname -s) == "Darwin" || "Windows_NT" == "$OS" ]] && $PYTHON -m venv -h >/dev/null; then
-        # Only use venv on macOS or Windows, venv fails on some Linux distros.
-        VIRTUALENV="$PYTHON -m venv"
+        VIRTUALENV="$PYTHON -m virtualenv"
     elif command -v virtualenv; then
-        VIRTUALENV="$(command -v virtualenv) -p $PYTHON --never-download"
+        VIRTUALENV="$(command -v virtualenv) -p $PYTHON"
     else
         echo "Cannot test without virtualenv"
         exit 1
     fi
-    $VIRTUALENV --system-site-packages $VENVPATH
+    $VIRTUALENV --system-site-packages --never-download $VENVPATH
     if [ "Windows_NT" = "$OS" ]; then
-        # Workaround https://bugs.python.org/issue32451:
-        # mongovenv/Scripts/activate: line 3: $'\r': command not found
-        . $VENVPATH/Scripts/activate || (dos2unix $VENVPATH/Scripts/activate && . $VENVPATH/Scripts/activate)
+        . $VENVPATH/Scripts/activate
     else
         . $VENVPATH/bin/activate
     fi

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -9,8 +9,8 @@ createvirtualenv () {
     VENVPATH=$2
     if $PYTHON -m virtualenv --version; then
         VIRTUALENV="$PYTHON -m virtualenv --never-download"
-    elif [ $(uname -s) = "Darwin" ] && $PYTHON -m venv -h >/dev/null; then
-        # Only use venv on macOS, venv fails on Windows and some Linux distros.
+    elif [[ $(uname -s) == "Darwin" || "Windows_NT" == "$OS" ]] && $PYTHON -m venv -h >/dev/null; then
+        # Only use venv on macOS or Windows, venv fails on some Linux distros.
         VIRTUALENV="$PYTHON -m venv"
     elif command -v virtualenv; then
         VIRTUALENV="$(command -v virtualenv) -p $PYTHON --never-download"
@@ -20,7 +20,9 @@ createvirtualenv () {
     fi
     $VIRTUALENV --system-site-packages $VENVPATH
     if [ "Windows_NT" = "$OS" ]; then
-        . $VENVPATH/Scripts/activate
+        # Workaround https://bugs.python.org/issue32451:
+        # mongovenv/Scripts/activate: line 3: $'\r': command not found
+        . $VENVPATH/Scripts/activate || (dos2unix $VENVPATH/Scripts/activate && . $VENVPATH/Scripts/activate)
     else
         . $VENVPATH/bin/activate
     fi


### PR DESCRIPTION
Tested here: https://evergreen.mongodb.com/version/5fb843b761837d105a7a3fa2

This change fixes this error:
```
[2020/11/12 23:45:52.296] Running command 'shell.exec' in "run aws auth test with assume role credentials" (step 4.1 of 8)
[2020/11/12 23:45:52.512] /usr/local/lib/python2.7/site-packages/virtualenv.py:1047: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
[2020/11/12 23:45:52.512]   import imp
[2020/11/12 23:45:52.559] Using base prefix '/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9'
[2020/11/12 23:45:52.559] New python executable in /data/mci/d1de1a1943ca42ab82064dbabed0a5c2/src/mongovenv/bin/python3.9
[2020/11/12 23:45:52.559] Also creating executable in /data/mci/d1de1a1943ca42ab82064dbabed0a5c2/src/mongovenv/bin/python
[2020/11/12 23:45:52.559] ERROR: The executable /data/mci/d1de1a1943ca42ab82064dbabed0a5c2/src/mongovenv/bin/python3.9 is not functioning
[2020/11/12 23:45:52.559] ERROR: It thinks sys.prefix is '/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9' (should be '/data/mci/d1de1a1943ca42ab82064dbabed0a5c2/src/mongovenv')
[2020/11/12 23:45:52.559] ERROR: virtualenv is not compatible with this system or executable
[2020/11/12 23:45:52.569] Running virtualenv with interpreter /usr/local/bin/python3
[2020/11/12 23:45:52.569] Command failed: command encountered problem: error waiting on process '39b22b81-ce96-418a-bcd8-2ab60de7cec9': exit status 100
```

My initial attempt to workaround this error was to always use `venv` if it existed however that proved to be a bad idea as venv doesn't work everywhere (see https://jira.mongodb.org/browse/PYTHON-2437). Instead, we only attempt to use venv on macOS.