### PR TITLE
PYTHON-2457 Test that clients wait 500ms between failed heartbeat checks

### DIFF
--- a/test/test_streaming_protocol.py
+++ b/test/test_streaming_protocol.py
@@ -133,6 +133,8 @@ class TestStreamingProtocol(IntegrationTest):
     @client_context.require_version_min(4, 9, -1)
     @client_context.require_failCommand_appName
     def test_monitor_waits_after_server_check_error(self):
+        # This test implements:
+        # https://github.com/mongodb/specifications/blob/6c5b2ac/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst#monitors-sleep-at-least-minheartbeatfreqencyms-between-checks
         fail_ismaster = {
             'mode': {'times': 5},
             'data': {

--- a/test/test_streaming_protocol.py
+++ b/test/test_streaming_protocol.py
@@ -152,6 +152,18 @@ class TestStreamingProtocol(IntegrationTest):
             # Force a connection.
             client.admin.command('ping')
             duration = time.time() - start
+            # Explanation of the expected events:
+            # 0ms: run configureFailPoint
+            # 1ms: create MongoClient
+            # 2ms: failed monitor handshake, 1
+            # 502ms: failed monitor handshake, 2
+            # 1002ms: failed monitor handshake, 3
+            # 1502ms: failed monitor handshake, 4
+            # 2002ms: failed monitor handshake, 5
+            # 2502ms: monitor handshake succeeds
+            # 2503ms: run awaitable isMaster
+            # 2504ms: application handshake succeeds
+            # 2505ms: ping command succeeds
             self.assertGreaterEqual(duration, 2)
             self.assertLessEqual(duration, 3.5)
 


### PR DESCRIPTION
Implements: https://github.com/mongodb/specifications/pull/879/