### PR TITLE
PYTHON-2443 Fix TypeError when pyOpenSSL socket has timeout of None (with regression test)

### DIFF
--- a/pymongo/socket_checker.py
+++ b/pymongo/socket_checker.py
@@ -41,7 +41,7 @@ class SocketChecker(object):
             self._poller = None
 
     def select(self, sock, read=False, write=False, timeout=0):
-        """Select for reads or writes with a timeout in seconds.
+        """Select for reads or writes with a timeout in seconds (or None).
 
         Returns True if the socket is readable/writable, False on timeout.
         """
@@ -57,7 +57,8 @@ class SocketChecker(object):
                     try:
                         # poll() timeout is in milliseconds. select()
                         # timeout is in seconds.
-                        res = self._poller.poll(timeout * 1000)
+                        timeout_ = None if timeout is None else timeout * 1000
+                        res = self._poller.poll(timeout_)
                         # poll returns a possibly-empty list containing
                         # (fd, event) 2-tuples for the descriptors that have
                         # events or errors to report. Return True if the list

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -21,7 +21,10 @@ import sys
 import threading
 import time
 
-from pymongo import MongoClient
+from bson.son import SON
+from bson.codec_options import DEFAULT_CODEC_OPTIONS
+
+from pymongo import MongoClient, message
 from pymongo.errors import (AutoReconnect,
                             ConnectionFailure,
                             DuplicateKeyError,
@@ -256,6 +259,37 @@ class TestPooling(_TestPoolingBase):
         s.connect((client_context.host, client_context.port))
         socket_checker = SocketChecker()
         self.assertFalse(socket_checker.socket_closed(s))
+        s.close()
+        self.assertTrue(socket_checker.socket_closed(s))
+
+    def test_socket_checker(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((client_context.host, client_context.port))
+        socket_checker = SocketChecker()
+        # Socket has nothing to read.
+        self.assertFalse(socket_checker.select(s, read=True))
+        self.assertFalse(socket_checker.select(s, read=True, timeout=0))
+        self.assertFalse(socket_checker.select(s, read=True, timeout=.05))
+        # Socket is writable.
+        self.assertTrue(socket_checker.select(s, write=True, timeout=None))
+        self.assertTrue(socket_checker.select(s, write=True))
+        self.assertTrue(socket_checker.select(s, write=True, timeout=0))
+        self.assertTrue(socket_checker.select(s, write=True, timeout=.05))
+        # Make the socket readable
+        _, msg, _, _ = message._op_msg(
+            0, SON([('ping', 1)]), 'admin', None, True, False,
+            DEFAULT_CODEC_OPTIONS)
+        s.sendall(msg)
+        # Block until the socket is readable.
+        self.assertTrue(socket_checker.select(s, read=True, timeout=None))
+        self.assertTrue(socket_checker.select(s, read=True))
+        self.assertTrue(socket_checker.select(s, read=True, timeout=0))
+        self.assertTrue(socket_checker.select(s, read=True, timeout=.05))
+        # Socket is still writable.
+        self.assertTrue(socket_checker.select(s, write=True, timeout=None))
+        self.assertTrue(socket_checker.select(s, write=True))
+        self.assertTrue(socket_checker.select(s, write=True, timeout=0))
+        self.assertTrue(socket_checker.select(s, write=True, timeout=.05))
         s.close()
         self.assertTrue(socket_checker.socket_closed(s))
 

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -276,8 +276,8 @@ class TestPooling(_TestPoolingBase):
         self.assertTrue(socket_checker.select(s, write=True, timeout=0))
         self.assertTrue(socket_checker.select(s, write=True, timeout=.05))
         # Make the socket readable
-        _, msg, _, _ = message._op_msg(
-            0, SON([('ping', 1)]), 'admin', None, True, False,
+        _, msg, _ = message.query(
+            0, 'admin.$cmd', 0, -1, SON([('isMaster', 1)]), None,
             DEFAULT_CODEC_OPTIONS)
         s.sendall(msg)
         # Block until the socket is readable.


### PR DESCRIPTION
This PR uses https://github.com/mongodb/mongo-python-driver/pull/526 as a base and then adds a regression test.