### PR TITLE
PYTHON-2452 Ensure command-responses with RetryableWriteError label are retried on MongoDB 4.4+

### DIFF
--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -115,7 +115,10 @@ def _check_command_response(response, max_wire_version,
                                max_wire_version)
 
     if parse_write_concern_error and 'writeConcernError' in response:
-        _raise_write_concern_error(response['writeConcernError'])
+        _error = response["writeConcernError"]
+        _labels = response.get("errorLabels", [])
+        _error.update({'errorLabels': _labels})
+        _raise_write_concern_error(_error)
 
     if response["ok"]:
         return

--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -117,7 +117,8 @@ def _check_command_response(response, max_wire_version,
     if parse_write_concern_error and 'writeConcernError' in response:
         _error = response["writeConcernError"]
         _labels = response.get("errorLabels", [])
-        _error.update({'errorLabels': _labels})
+        if _labels:
+            _error.update({'errorLabels': _labels})
         _raise_write_concern_error(_error)
 
     if response["ok"]:
@@ -225,9 +226,10 @@ def _check_write_command_response(result):
         _raise_last_write_error(write_errors)
 
     error = result.get("writeConcernError", {})
-    error_labels = result.get("errorLabels", [])
-    error.update({'errorLabels': error_labels})
     if error:
+        error_labels = result.get("errorLabels", [])
+        if error_labels:
+            error.update({'errorLabels': error_labels})
         _raise_write_concern_error(error)
 
 

--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -116,7 +116,7 @@ def _check_command_response(response, max_wire_version,
 
     if parse_write_concern_error and 'writeConcernError' in response:
         _error = response["writeConcernError"]
-        _labels = response.get("errorLabels", [])
+        _labels = response.get("errorLabels")
         if _labels:
             _error.update({'errorLabels': _labels})
         _raise_write_concern_error(_error)
@@ -225,9 +225,9 @@ def _check_write_command_response(result):
     if write_errors:
         _raise_last_write_error(write_errors)
 
-    error = result.get("writeConcernError", {})
+    error = result.get("writeConcernError")
     if error:
-        error_labels = result.get("errorLabels", [])
+        error_labels = result.get("errorLabels")
         if error_labels:
             error.update({'errorLabels': error_labels})
         _raise_write_concern_error(error)

--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -221,7 +221,9 @@ def _check_write_command_response(result):
     if write_errors:
         _raise_last_write_error(write_errors)
 
-    error = result.get("writeConcernError")
+    error = result.get("writeConcernError", {})
+    error_labels = result.get("errorLabels", [])
+    error.update({'errorLabels': error_labels})
     if error:
         _raise_write_concern_error(error)
 

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -466,15 +466,21 @@ class TestRetryableWrites(IgnoreDeprecationsTest):
             'mode': {'times': 2},
             'data': {
                 'failCommands': ['insert'],
+                'closeConnection': False,
                 'writeConcernError': {
                     'code': 91,
-                    'errmsg': 'Replication is being shut down'}}}
+                    'errmsg': 'Replication is being shut down'},
+            }}
 
         with self.fail_point(fail_insert):
             with self.assertRaises(WriteConcernError) as cm:
-                client.testdb.testcoll.insert_one({})
+                client.pymongo_test.testcoll.insert_one({})
             self.assertIn('RetryableWriteError',
                           cm.exception._error_labels)
+
+        self.assertIn(
+            'RetryableWriteError',
+            listener.results['succeeded'][-1].reply['errorLabels'])
 
 
 # TODO: Make this a real integration test where we stepdown the primary.

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -455,6 +455,7 @@ class TestRetryableWrites(IgnoreDeprecationsTest):
         self.assertEqual(coll.find_one(projection={'_id': True}), {'_id': 1})
 
     @client_context.require_version_min(4, 4)
+    @client_context.require_failCommand_fail_point
     def test_retryable_write_error_label_is_propagated(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(
@@ -470,10 +471,10 @@ class TestRetryableWrites(IgnoreDeprecationsTest):
                     'errmsg': 'Replication is being shut down'}}}
 
         with self.fail_point(fail_insert):
-            with self.assertRaises(WriteConcernError) as exc:
+            with self.assertRaises(WriteConcernError) as cm:
                 client.testdb.testcoll.insert_one({})
             self.assertIn('RetryableWriteError',
-                          exc.exception._error_labels)
+                          cm.exception._error_labels)
 
 
 # TODO: Make this a real integration test where we stepdown the primary.

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -480,8 +480,8 @@ class TestWriteConcernError(IntegrationTest):
         with self.fail_point(fail_insert):
             with self.assertRaises(WriteConcernError) as cm:
                 client.pymongo_test.testcoll.insert_one({})
-            self.assertIn('RetryableWriteError',
-                          cm.exception._error_labels)
+            self.assertTrue(cm.exception.has_error_label(
+                'RetryableWriteError'))
 
         if client_context.version >= Version(4, 4):
             # In MongoDB 4.4+ we rely on the server returning the error label.

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -460,7 +460,6 @@ class TestRetryableWrites(IgnoreDeprecationsTest):
 
 class TestWriteConcernError(IntegrationTest):
     @classmethod
-    @client_context.require_version_min(4, 0)
     @client_context.require_replica_set
     @client_context.require_no_mmap
     @client_context.require_failCommand_fail_point
@@ -476,6 +475,7 @@ class TestWriteConcernError(IntegrationTest):
                     'errmsg': 'Replication is being shut down'},
             }}
 
+    @client_context.require_version_min(4, 0)
     def test_RetryableWriteError_error_label(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(
@@ -496,6 +496,7 @@ class TestWriteConcernError(IntegrationTest):
                 'RetryableWriteError',
                 listener.results['succeeded'][-1].reply['errorLabels'])
 
+    @client_context.require_version_min(4, 4)
     def test_RetryableWriteError_error_label_RawBSONDocument(self):
         # using RawBSONDocument should not cause errorLabel parsing to fail
         with self.fail_point(self.fail_insert):

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -458,7 +458,7 @@ class TestRetryableWrites(IgnoreDeprecationsTest):
 
 class TestWriteConcernError(IntegrationTest):
     @client_context.require_version_min(4, 0)
-    @client_context.require_no_standalone
+    @client_context.require_replica_set
     @client_context.require_no_mmap
     @client_context.require_failCommand_fail_point
     def test_RetryableWriteError_error_label(self):

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -471,16 +471,10 @@ class TestWriteConcernError(IntegrationTest):
             'mode': {'times': 2},
             'data': {
                 'failCommands': ['insert'],
-                'closeConnection': False,
                 'writeConcernError': {
                     'code': 91,
                     'errmsg': 'Replication is being shut down'},
             }}
-
-        if client_context.version < Version(4, 2):
-            # SERVER-39292: specifying closeConnection on MongoDB 4.0+,<4.2
-            # causes the failPoint to fire twice so we remove it.
-            fail_insert['data'].pop('closeConnection')
 
         # Ensure collection exists.
         client.pymongo_test.testcoll.insert_one({})

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -500,6 +500,7 @@ class TestWriteConcernError(IntegrationTest):
         # using RawBSONDocument should not cause errorLabel parsing to fail
         with self.fail_point(self.fail_insert):
             with self.client.start_session() as s:
+                s._start_retryable_write()
                 result = self.client.pymongo_test.command(
                     'insert', 'testcoll', documents=[{'_id': 1}],
                     txnNumber=s._server_session.transaction_id, session=s,


### PR DESCRIPTION
This change will be backported to 3.11 and 3.12 branches