### PR TITLE
PYTHON-2455 Update release checklist to include step to file docs ticket outlining compatibility changes/lack thereof

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -103,6 +103,6 @@ Doing a Release
 15. Announce the release on:
     https://developer.mongodb.com/community/forums/c/community/release-notes/
 
-16. File a ticket for DOCS highlighting changes in server version and Python
+16. File a ticket for DOCSP highlighting changes in server version and Python
     version compatibility or the lack thereof, for example:
-    https://jira.mongodb.org/browse/DOCS-12644
+    https://jira.mongodb.org/browse/DOCSP-13536


### PR DESCRIPTION
Very small PR to adjust Shane's change to the release checklist - instead of the DOCS project, the docs team would prefer we file to DOCSP (private by default). My fault for a non-specific Jira ticket!