### PR TITLE
PYTHON-2482 Test Versioned API with a server started with acceptAPIVersion2

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1989,18 +1989,25 @@ axes:
           test_pyopenssl: true
         batchtime: 10080  # 7 days
 
-  - id: requireApiVersion
-    display_name: "requireApiVersion"
+  - id: versionedApi
+    display_name: "versionedApi"
     values:
+      # Test against a cluster with requireApiVersion=1.
       - id: "requireApiVersion1"
         display_name: "requireApiVersion1"
-        tags: [ "requireApiVersion_tag" ]
+        tags: [ "versionedApi_tag" ]
         variables:
           # REQUIRE_API_VERSION is set to make drivers-evergreen-tools
           # start a cluster with the requireApiVersion parameter.
           REQUIRE_API_VERSION: "1"
           # MONGODB_API_VERSION is the apiVersion to use in the test suite.
           MONGODB_API_VERSION: "1"
+      # Test against a cluster acceptAPIVersion2 but without requireApiVersion=0.
+      - id: "acceptAPIVersion2"
+        display_name: "acceptAPIVersion2"
+        tags: [ "versionedApi_tag" ]
+        variables:
+          ORCHESTRATION_FILE: "versioned-api-testing.json"
 
 buildvariants:
 - matrix_name: "tests-all"
@@ -2533,8 +2540,9 @@ buildvariants:
     platform: ubuntu-16.04
     python-version: ["3.6", "3.9"]
     auth: "auth"
-    requireApiVersion: "*"
-  display_name: "requireApiVersion ${python-version}"
+    versionedApi: "*"
+  display_name: "Versioned API ${versionedApi} ${python-version}"
+  batchtime: 10080  # 7 days
   tasks:
     # Versioned API was introduced in MongoDB 4.7
     - "test-latest-standalone"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2002,7 +2002,9 @@ axes:
           REQUIRE_API_VERSION: "1"
           # MONGODB_API_VERSION is the apiVersion to use in the test suite.
           MONGODB_API_VERSION: "1"
-      # Test against a cluster acceptAPIVersion2 but without requireApiVersion=0.
+      # Test against a cluster with acceptAPIVersion2 but without
+      # requireApiVersion, and don't automatically add apiVersion to
+      # clients created in the test suite.
       - id: "acceptAPIVersion2"
         display_name: "acceptAPIVersion2"
         tags: [ "versionedApi_tag" ]

--- a/test/versioned-api/crud-api-version-1-strict.json
+++ b/test/versioned-api/crud-api-version-1-strict.json
@@ -141,6 +141,7 @@
     },
     {
       "description": "aggregate on database appends declared API version",
+      "skipReason": "DRIVERS-1505 $listLocalSessions is not supported in API version 1",
       "operations": [
         {
           "name": "aggregate",

--- a/test/versioned-api/test-commands-deprecation-errors.json
+++ b/test/versioned-api/test-commands-deprecation-errors.json
@@ -6,7 +6,8 @@
       "minServerVersion": "4.7",
       "serverParameters": {
         "enableTestCommands": true,
-        "acceptAPIVersion2": true
+        "acceptAPIVersion2": true,
+        "requireApiVersion": false
       }
     }
   ],

--- a/test/versioned-api/transaction-handling.json
+++ b/test/versioned-api/transaction-handling.json
@@ -227,6 +227,162 @@
           ]
         }
       ]
+    },
+    {
+      "description": "Committing a transaction twice does not append server API options",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session",
+            "document": {
+              "_id": 6,
+              "x": 66
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 6
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session",
+            "document": {
+              "_id": 7,
+              "x": 77
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 7
+              }
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 6,
+                      "x": 66
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "startTransaction": true,
+                  "apiVersion": "1",
+                  "apiStrict": {
+                    "$$unsetOrMatches": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 7,
+                      "x": 77
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }
+


### PR DESCRIPTION
This change:
- adds testing against a server started with acceptAPIVersion2.
- skips the failing $listLocalSessions test related to DRIVERS-1505.
- resyncs the spec test added in DRIVERS-1504.