### PR TITLE
PYTHON-2502 Remove Python 2.7 from release scripts

### DIFF
--- a/.evergreen/build-mac.sh
+++ b/.evergreen/build-mac.sh
@@ -8,14 +8,8 @@ rm -rf validdist
 mkdir -p validdist
 mv dist/* validdist || true
 
-for VERSION in 2.7 3.4 3.5 3.6 3.7 3.8 3.9; do
-    if [[ $VERSION == "2.7" ]]; then
-        PYTHON=/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python
-        rm -rf build
-        $PYTHON setup.py bdist_egg
-    else
-        PYTHON=/Library/Frameworks/Python.framework/Versions/$VERSION/bin/python3
-    fi
+for VERSION in 3.4 3.5 3.6 3.7 3.8 3.9; do
+    PYTHON=/Library/Frameworks/Python.framework/Versions/$VERSION/bin/python3
     rm -rf build
 
     # Install wheel if not already there.

--- a/.evergreen/build-manylinux-internal.sh
+++ b/.evergreen/build-manylinux-internal.sh
@@ -11,7 +11,7 @@ mv dist/* validdist || true
 
 # Compile wheels
 for PYTHON in /opt/python/*/bin/python; do
-    if [[ ! $PYTHON =~ (cp27|cp34|cp35|cp36|cp37|cp38|cp39) ]]; then
+    if [[ ! $PYTHON =~ (cp34|cp35|cp36|cp37|cp38|cp39) ]]; then
         continue
     fi
     # https://github.com/pypa/manylinux/issues/49

--- a/.evergreen/build-manylinux.sh
+++ b/.evergreen/build-manylinux.sh
@@ -22,7 +22,6 @@ ls dist
 
 # Check for any unexpected files.
 unexpected=$(find dist \! \( -iname dist -or \
-                             -iname '*cp27*' -or \
                              -iname '*cp34*' -or \
                              -iname '*cp35*' -or \
                              -iname '*cp36*' -or \

--- a/.evergreen/build-windows.sh
+++ b/.evergreen/build-windows.sh
@@ -8,14 +8,10 @@ rm -rf validdist
 mkdir -p validdist
 mv dist/* validdist || true
 
-for VERSION in 27 34 35 36 37 38 39; do
+for VERSION in 34 35 36 37 38 39; do
     _pythons=(C:/Python/Python${VERSION}/python.exe \
               C:/Python/32/Python${VERSION}/python.exe)
     for PYTHON in "${_pythons[@]}"; do
-        if [[ $VERSION == "2.7" ]]; then
-            rm -rf build
-            $PYTHON setup.py bdist_egg
-        fi
         rm -rf build
         $PYTHON setup.py bdist_wheel
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -856,7 +856,6 @@ tasks:
     - name: "release"
       tags: ["release"]
       exec_timeout_secs: 216000  # 60 minutes (manylinux task is slow).
-      git_tag_only: true
       commands:
         - command: shell.exec
           type: test
@@ -2601,6 +2600,7 @@ buildvariants:
   matrix_spec:
     platform: [ubuntu-20.04, windows-64-vsMulti-small, macos-1014]
   display_name: "Release ${platform}"
+  batchtime: 20160 # 14 days
   tasks:
     - name: "release"
 

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -24,7 +24,17 @@ createvirtualenv () {
     fi
     # Upgrade to the latest versions of pip setuptools wheel so that
     # pip can always download the latest cryptography+cffi wheels.
-    python -m pip install --upgrade pip setuptools wheel
+    PYTHON_VERSION=$(python -c 'import sys;print("%s.%s" % sys.version_info[:2])')
+    if [[ $PYTHON_VERSION == "3.4" ]]; then
+        # pip 19.2 dropped support for Python 3.4.
+        python -m pip install --upgrade 'pip<19.2'
+    if [[ $PYTHON_VERSION == "2.7" || $PYTHON_VERSION == "3.5" ]]; then
+        # pip 21 will drop support for Python 2.7 and 3.5.
+        python -m pip install --upgrade 'pip<21'
+    else
+        python -m pip install --upgrade pip
+    fi
+    python -m pip install --upgrade setuptools wheel
 }
 
 # Usage:

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -28,7 +28,7 @@ createvirtualenv () {
     if [[ $PYTHON_VERSION == "3.4" ]]; then
         # pip 19.2 dropped support for Python 3.4.
         python -m pip install --upgrade 'pip<19.2'
-    if [[ $PYTHON_VERSION == "3.5" ]]; then
+    elif [[ $PYTHON_VERSION == "3.5" ]]; then
         # pip 21 will drop support for 3.5.
         python -m pip install --upgrade 'pip<21'
     else

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -28,8 +28,8 @@ createvirtualenv () {
     if [[ $PYTHON_VERSION == "3.4" ]]; then
         # pip 19.2 dropped support for Python 3.4.
         python -m pip install --upgrade 'pip<19.2'
-    if [[ $PYTHON_VERSION == "2.7" || $PYTHON_VERSION == "3.5" ]]; then
-        # pip 21 will drop support for Python 2.7 and 3.5.
+    if [[ $PYTHON_VERSION == "3.5" ]]; then
+        # pip 21 will drop support for 3.5.
         python -m pip install --upgrade 'pip<21'
     else
         python -m pip install --upgrade pip

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -28,9 +28,9 @@ createvirtualenv () {
 }
 
 # Usage:
-# testinstall /path/to/python /path/to/.whl/or/.egg ["no-virtualenv"]
+# testinstall /path/to/python /path/to/.whl ["no-virtualenv"]
 # * param1: Python binary to test
-# * param2: Path to the wheel or egg file to install
+# * param2: Path to the wheel to install
 # * param3 (optional): If set to a non-empty string, don't create a virtualenv. Used in manylinux containers.
 testinstall () {
     PYTHON=$1
@@ -42,11 +42,7 @@ testinstall () {
         PYTHON=python
     fi
 
-    if [[ $RELEASE == *.egg ]]; then
-        $PYTHON -m easy_install $RELEASE
-    else
-        $PYTHON -m pip install --upgrade $RELEASE
-    fi
+    $PYTHON -m pip install --upgrade $RELEASE
     cd tools
     $PYTHON fail_if_no_c.py
     $PYTHON -m pip uninstall -y pymongo


### PR DESCRIPTION
This change also removes `git_tag_only:true` so that we can test our changes to the release build process without pushing a test-only tag and without manually editing the config. I haven't changed the evg project config so when a tag is pushed we'll have the same behavior as before (the release task will run automatically in a new build).

This change also stops building `.egg` files (https://jira.mongodb.org/browse/PYTHON-1300).