### PR TITLE
PYTHON-1974 Remove manylinux containers only needed for 3.4

### DIFF
--- a/.evergreen/build-manylinux.sh
+++ b/.evergreen/build-manylinux.sh
@@ -2,10 +2,7 @@
 
 docker version
 
-# 2020-03-20-2fda31c Was the last release to include Python 3.4.
-images=(quay.io/pypa/manylinux1_x86_64:2020-03-20-2fda31c \
-        quay.io/pypa/manylinux1_i686:2020-03-20-2fda31c \
-        quay.io/pypa/manylinux1_x86_64 \
+images=(quay.io/pypa/manylinux1_x86_64 \
         quay.io/pypa/manylinux1_i686 \
         quay.io/pypa/manylinux2014_x86_64 \
         quay.io/pypa/manylinux2014_i686 \


### PR DESCRIPTION
Minor cleanup I noticed while doing the 3.11.3 release.