### PR TITLE
PYTHON-2544 Do not check error messages when an error code is present

### DIFF
--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -39,6 +39,7 @@ _SHUTDOWN_CODES = frozenset([
 # "node is recovering" error codes (of which the "node is shutting down"
 # errors are a subset).
 _NOT_MASTER_CODES = frozenset([
+    10058,  # LegacyNotPrimary <=3.2 "not master" error code
     10107,  # NotMaster
     13435,  # NotMasterNoSlaveOk
     11602,  # InterruptedDueToReplStateChange
@@ -148,8 +149,9 @@ def _check_command_response(response, max_wire_version,
             return
 
     # Server is "not master" or "recovering"
-    if code in _NOT_MASTER_CODES:
-        raise NotMasterError(errmsg, response)
+    if code is not None:
+        if code in _NOT_MASTER_CODES:
+            raise NotMasterError(errmsg, response)
     elif "not master" in errmsg or "node is recovering" in errmsg:
         raise NotMasterError(errmsg, response)
 

--- a/test/discovery_and_monitoring/errors/non-stale-topologyVersion-greater-LegacyNotPrimary.json
+++ b/test/discovery_and_monitoring/errors/non-stale-topologyVersion-greater-LegacyNotPrimary.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Non-stale topologyVersion greater LegacyNotPrimary error",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -51,108 +51,46 @@
       }
     },
     {
-      "description": "Non-stale application network error",
+      "description": "Non-stale topologyVersion greater LegacyNotPrimary error marks server Unknown",
       "applicationErrors": [
         {
           "address": "a:27017",
           "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "network"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            }
+          }
         }
       ],
       "outcome": {
         "servers": {
           "a:27017": {
             "type": "Unknown",
-            "topologyVersion": null,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },
         "topologyType": "ReplicaSetNoPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
-      }
-    },
-    {
-      "description": "Primary A is rediscovered",
-      "responses": [
-        [
-          "a:27017",
-          {
-            "ok": 1,
-            "ismaster": true,
-            "hosts": [
-              "a:27017"
-            ],
-            "setName": "rs",
-            "minWireVersion": 0,
-            "maxWireVersion": 9,
-            "topologyVersion": {
-              "processId": {
-                "$oid": "000000000000000000000001"
-              },
-              "counter": {
-                "$numberLong": "1"
-              }
-            }
-          }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "topologyVersion": {
-              "processId": {
-                "$oid": "000000000000000000000001"
-              },
-              "counter": {
-                "$numberLong": "1"
-              }
-            },
-            "pool": {
-              "generation": 1
-            }
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
-      }
-    },
-    {
-      "description": "Ignore stale timeout error (stale generation)",
-      "applicationErrors": [
-        {
-          "address": "a:27017",
-          "generation": 0,
-          "when": "beforeHandshakeCompletes",
-          "maxWireVersion": 9,
-          "type": "timeout"
-        }
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "topologyVersion": {
-              "processId": {
-                "$oid": "000000000000000000000001"
-              },
-              "counter": {
-                "$numberLong": "1"
-              }
-            },
-            "pool": {
-              "generation": 1
-            }
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
         "setName": "rs"
       }

--- a/test/discovery_and_monitoring/errors/non-stale-topologyVersion-missing-LegacyNotPrimary.json
+++ b/test/discovery_and_monitoring/errors/non-stale-topologyVersion-missing-LegacyNotPrimary.json
@@ -1,0 +1,84 @@
+{
+  "description": "Non-stale topologyVersion missing LegacyNotPrimary error",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Non-stale topologyVersion missing LegacyNotPrimary error marks server Unknown",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 9,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/discovery_and_monitoring/errors/non-stale-topologyVersion-proccessId-changed-LegacyNotPrimary.json
+++ b/test/discovery_and_monitoring/errors/non-stale-topologyVersion-proccessId-changed-LegacyNotPrimary.json
@@ -1,0 +1,99 @@
+{
+  "description": "Non-stale topologyVersion proccessId changed LegacyNotPrimary error",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Non-stale topologyVersion proccessId changed LegacyNotPrimary error marks server Unknown",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 9,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000002"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000002"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/discovery_and_monitoring/errors/post-42-LegacyNotPrimary.json
+++ b/test/discovery_and_monitoring/errors/post-42-LegacyNotPrimary.json
@@ -1,0 +1,69 @@
+{
+  "description": "Post-4.2 LegacyNotPrimary error",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 8
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Post-4.2 LegacyNotPrimary error marks server Unknown",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 8,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/discovery_and_monitoring/errors/pre-42-LegacyNotPrimary.json
+++ b/test/discovery_and_monitoring/errors/pre-42-LegacyNotPrimary.json
@@ -1,0 +1,69 @@
+{
+  "description": "Pre-4.2 LegacyNotPrimary error",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 7
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Pre-4.2 LegacyNotPrimary error marks server Unknown and clears the pool",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 7,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 1
+            }
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/discovery_and_monitoring/errors/prefer-error-code.json
+++ b/test/discovery_and_monitoring/errors/prefer-error-code.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Do not check errmsg when code exists",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -51,54 +51,19 @@
       }
     },
     {
-      "description": "Non-stale application network error",
+      "description": "errmsg \"not master\" gets ignored when error code exists",
       "applicationErrors": [
         {
           "address": "a:27017",
           "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "network"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "not master",
+            "code": 1
+          }
         }
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "Unknown",
-            "topologyVersion": null,
-            "pool": {
-              "generation": 1
-            }
-          }
-        },
-        "topologyType": "ReplicaSetNoPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
-      }
-    },
-    {
-      "description": "Primary A is rediscovered",
-      "responses": [
-        [
-          "a:27017",
-          {
-            "ok": 1,
-            "ismaster": true,
-            "hosts": [
-              "a:27017"
-            ],
-            "setName": "rs",
-            "minWireVersion": 0,
-            "maxWireVersion": 9,
-            "topologyVersion": {
-              "processId": {
-                "$oid": "000000000000000000000001"
-              },
-              "counter": {
-                "$numberLong": "1"
-              }
-            }
-          }
-        ]
       ],
       "outcome": {
         "servers": {
@@ -114,7 +79,7 @@
               }
             },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },
@@ -124,14 +89,18 @@
       }
     },
     {
-      "description": "Ignore stale timeout error (stale generation)",
+      "description": "errmsg \"node is recovering\" gets ignored when error code exists",
       "applicationErrors": [
         {
           "address": "a:27017",
-          "generation": 0,
-          "when": "beforeHandshakeCompletes",
+          "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "timeout"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "node is recovering",
+            "code": 1
+          }
         }
       ],
       "outcome": {
@@ -148,7 +117,7 @@
               }
             },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },

--- a/test/discovery_and_monitoring/errors/stale-generation-afterHandshakeCompletes-LegacyNotPrimary.json
+++ b/test/discovery_and_monitoring/errors/stale-generation-afterHandshakeCompletes-LegacyNotPrimary.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Stale generation LegacyNotPrimary error afterHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,14 +124,27 @@
       }
     },
     {
-      "description": "Ignore stale timeout error (stale generation)",
+      "description": "Ignore stale LegacyNotPrimary error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",
           "generation": 0,
-          "when": "beforeHandshakeCompletes",
+          "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "timeout"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            }
+          }
         }
       ],
       "outcome": {

--- a/test/discovery_and_monitoring/errors/stale-generation-afterHandshakeCompletes-network.json
+++ b/test/discovery_and_monitoring/errors/stale-generation-afterHandshakeCompletes-network.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation NotMasterNoSlaveOk error afterHandshakeCompletes",
+  "description": "Stale generation network error afterHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,7 +124,7 @@
       }
     },
     {
-      "description": "Ignore stale NotMasterNoSlaveOk error (stale generation)",
+      "description": "Ignore stale network error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",

--- a/test/discovery_and_monitoring/errors/stale-generation-afterHandshakeCompletes-timeout.json
+++ b/test/discovery_and_monitoring/errors/stale-generation-afterHandshakeCompletes-timeout.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation NotMasterNoSlaveOk error afterHandshakeCompletes",
+  "description": "Stale generation timeout error afterHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,7 +124,7 @@
       }
     },
     {
-      "description": "Ignore stale NotMasterNoSlaveOk error (stale generation)",
+      "description": "Ignore stale timeout error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",

--- a/test/discovery_and_monitoring/errors/stale-generation-beforeHandshakeCompletes-LegacyNotPrimary.json
+++ b/test/discovery_and_monitoring/errors/stale-generation-beforeHandshakeCompletes-LegacyNotPrimary.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Stale generation LegacyNotPrimary error beforeHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,14 +124,27 @@
       }
     },
     {
-      "description": "Ignore stale timeout error (stale generation)",
+      "description": "Ignore stale LegacyNotPrimary error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",
           "generation": 0,
           "when": "beforeHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "timeout"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            }
+          }
         }
       ],
       "outcome": {

--- a/test/discovery_and_monitoring/errors/stale-generation-beforeHandshakeCompletes-network.json
+++ b/test/discovery_and_monitoring/errors/stale-generation-beforeHandshakeCompletes-network.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation NotMasterNoSlaveOk error beforeHandshakeCompletes",
+  "description": "Stale generation network error beforeHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,7 +124,7 @@
       }
     },
     {
-      "description": "Ignore stale NotMasterNoSlaveOk error (stale generation)",
+      "description": "Ignore stale network error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",

--- a/test/discovery_and_monitoring/errors/stale-topologyVersion-LegacyNotPrimary.json
+++ b/test/discovery_and_monitoring/errors/stale-topologyVersion-LegacyNotPrimary.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Stale topologyVersion LegacyNotPrimary error",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -51,54 +51,27 @@
       }
     },
     {
-      "description": "Non-stale application network error",
+      "description": "Ignore stale LegacyNotPrimary error (topologyVersion less)",
       "applicationErrors": [
         {
           "address": "a:27017",
           "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "network"
-        }
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "Unknown",
-            "topologyVersion": null,
-            "pool": {
-              "generation": 1
-            }
-          }
-        },
-        "topologyType": "ReplicaSetNoPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
-      }
-    },
-    {
-      "description": "Primary A is rediscovered",
-      "responses": [
-        [
-          "a:27017",
-          {
-            "ok": 1,
-            "ismaster": true,
-            "hosts": [
-              "a:27017"
-            ],
-            "setName": "rs",
-            "minWireVersion": 0,
-            "maxWireVersion": 9,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
             "topologyVersion": {
               "processId": {
                 "$oid": "000000000000000000000001"
               },
               "counter": {
-                "$numberLong": "1"
+                "$numberLong": "0"
               }
             }
           }
-        ]
+        }
       ],
       "outcome": {
         "servers": {
@@ -114,7 +87,7 @@
               }
             },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },
@@ -124,14 +97,26 @@
       }
     },
     {
-      "description": "Ignore stale timeout error (stale generation)",
+      "description": "Ignore stale LegacyNotPrimary error (topologyVersion equal)",
       "applicationErrors": [
         {
           "address": "a:27017",
-          "generation": 0,
-          "when": "beforeHandshakeCompletes",
+          "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "timeout"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
         }
       ],
       "outcome": {
@@ -148,7 +133,7 @@
               }
             },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },


### PR DESCRIPTION
Add 10058 as a "not master" error code to account for MongoDB<=3.2 errors.

This change implements: https://github.com/mongodb/specifications/pull/920