### PR TITLE
PYTHON-2596 Include host in error message when connection is closed

### DIFF
--- a/pymongo/network.py
+++ b/pymongo/network.py
@@ -26,8 +26,7 @@ from bson import _decode_all_selective
 from pymongo import helpers, message
 from pymongo.common import MAX_MESSAGE_SIZE
 from pymongo.compression_support import decompress, _NO_COMPRESSION
-from pymongo.errors import (AutoReconnect,
-                            NotMasterError,
+from pymongo.errors import (NotMasterError,
                             OperationFailure,
                             ProtocolError,
                             _OperationCancelled)
@@ -261,7 +260,7 @@ def _receive_data_on_socket(sock_info, length, deadline):
                 continue
             raise
         if chunk_length == 0:
-            raise AutoReconnect("connection closed")
+            raise OSError("connection closed")
 
         bytes_read += chunk_length
 

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -236,16 +236,9 @@ def _raise_connection_failure(address, error, msg_prefix=None):
     if msg_prefix:
         msg = msg_prefix + msg
     if isinstance(error, socket.timeout):
-        raise NetworkTimeout(msg)
-    elif isinstance(error, _SSLError) and 'timed out' in str(error):
-        # CPython 2.7 and PyPy 2.x do not distinguish network
-        # timeouts from other SSLErrors (https://bugs.python.org/issue10272).
-        # Luckily, we can work around this limitation because the phrase
-        # 'timed out' appears in all the timeout related SSLErrors raised
-        # on the above platforms.
-        raise NetworkTimeout(msg)
+        raise NetworkTimeout(msg) from error
     else:
-        raise AutoReconnect(msg)
+        raise AutoReconnect(msg) from error
 
 
 def _cond_wait(condition, deadline):


### PR DESCRIPTION
Before this change:
```python
  File "/Users/shane/git/mongo-python-driver/test/test_client.py", line 1579, in test_network_error_message
    client.pymongo_test.test.find_one({})
  File "/Users/shane/git/mongo-python-driver/pymongo/collection.py", line 1261, in find_one
    for result in cursor.limit(-1):
  File "/Users/shane/git/mongo-python-driver/pymongo/cursor.py", line 1199, in next
    if len(self.__data) or self._refresh():
  File "/Users/shane/git/mongo-python-driver/pymongo/cursor.py", line 1120, in _refresh
    self.__send_message(q)
  File "/Users/shane/git/mongo-python-driver/pymongo/cursor.py", line 995, in __send_message
    response = client._run_operation_with_response(
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1271, in _run_operation_with_response
    return self._retryable_read(
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1374, in _retryable_read
    return func(session, server, sock_info, slave_ok)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1263, in _cmd
    return server.run_operation_with_response(
  File "/Users/shane/git/mongo-python-driver/pymongo/server.py", line 117, in run_operation_with_response
    reply = sock_info.receive_message(request_id)
  File "/Users/shane/git/mongo-python-driver/pymongo/pool.py", line 717, in receive_message
    self._raise_connection_failure(error)
  File "/Users/shane/git/mongo-python-driver/pymongo/pool.py", line 715, in receive_message
    return receive_message(self, request_id, self.max_message_size)
  File "/Users/shane/git/mongo-python-driver/pymongo/network.py", line 193, in receive_message
    _receive_data_on_socket(sock_info, 16, deadline))
  File "/Users/shane/git/mongo-python-driver/pymongo/network.py", line 264, in _receive_data_on_socket
    raise AutoReconnect("connection closed")
pymongo.errors.AutoReconnect: connection closed
```

After this change:
```python
Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/pymongo/pool.py", line 708, in receive_message
    return receive_message(self, request_id, self.max_message_size)
  File "/Users/shane/git/mongo-python-driver/pymongo/network.py", line 192, in receive_message
    _receive_data_on_socket(sock_info, 16, deadline))
  File "/Users/shane/git/mongo-python-driver/pymongo/network.py", line 263, in _receive_data_on_socket
    raise OSError("connection closed")
OSError: connection closed

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/Users/shane/git/mongo-python-driver/test/__init__.py", line 496, in wrap
    return f(*args, **kwargs)
  File "/Users/shane/git/mongo-python-driver/test/test_client.py", line 1579, in test_network_error_message
    client.pymongo_test.test.find_one({})
  File "/Users/shane/git/mongo-python-driver/pymongo/collection.py", line 1261, in find_one
    for result in cursor.limit(-1):
  File "/Users/shane/git/mongo-python-driver/pymongo/cursor.py", line 1199, in next
    if len(self.__data) or self._refresh():
  File "/Users/shane/git/mongo-python-driver/pymongo/cursor.py", line 1120, in _refresh
    self.__send_message(q)
  File "/Users/shane/git/mongo-python-driver/pymongo/cursor.py", line 995, in __send_message
    response = client._run_operation_with_response(
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1271, in _run_operation_with_response
    return self._retryable_read(
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1374, in _retryable_read
    return func(session, server, sock_info, slave_ok)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1263, in _cmd
    return server.run_operation_with_response(
  File "/Users/shane/git/mongo-python-driver/pymongo/server.py", line 117, in run_operation_with_response
    reply = sock_info.receive_message(request_id)
  File "/Users/shane/git/mongo-python-driver/pymongo/pool.py", line 710, in receive_message
    self._raise_connection_failure(error)
  File "/Users/shane/git/mongo-python-driver/pymongo/pool.py", line 871, in _raise_connection_failure
    _raise_connection_failure(self.address, error)
  File "/Users/shane/git/mongo-python-driver/pymongo/pool.py", line 241, in _raise_connection_failure
    raise AutoReconnect(msg) from error
pymongo.errors.AutoReconnect: localhost:27017: connection closed
```

This change also removes the python 2 compat code for ssl timeouts added in PYTHON-1157.