### PR TITLE
PYTHON-2583 Bump minimum required PyMongoCrypt version to 1.1.0

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -67,6 +67,8 @@ Breaking Changes in 4.0
   :meth:`~pymongo.cursor.Cursor`.
 - The "tls" install extra is no longer necessary or supported and will be
   ignored by pip.
+- PyMongoCrypt 1.1.0 or later is now required for client side field level
+  encryption support.
 
 Notable improvements
 ....................

--- a/setup.py
+++ b/setup.py
@@ -282,7 +282,7 @@ if sys.platform in ('win32', 'darwin'):
     pyopenssl_reqs.append('certifi')
 
 extras_require = {
-    'encryption': ['pymongocrypt<2.0.0'],
+    'encryption': ['pymongocrypt>=1.1.0,<2.0.0'],
     'ocsp': pyopenssl_reqs,
     'snappy': ['python-snappy'],
     'zstd': ['zstandard'],


### PR DESCRIPTION
FYI I will open a separate PR to backport this to the v3.12 branch.