### PR TITLE
PYTHON-1359: Add Example for RawBSONDocument

### DIFF
--- a/bson/raw_bson.py
+++ b/bson/raw_bson.py
@@ -30,7 +30,7 @@ Example: Moving a document between different databases/collections
   >>> import bson
   >>> from pymongo import MongoClient
   >>> from bson.raw_bson import RawBSONDocument
-  >>> client = MongoClient("localhost", 27017, document_class=bson.)
+  >>> client = MongoClient("localhost", 27017, document_class=RawBSONDocument)
   >>> db = client.db
   >>> result = db.test.insert_many([
   ...  {'a': 1},
@@ -42,8 +42,7 @@ Example: Moving a document between different databases/collections
   >>> for doc in db.test.find():
   ...    print(f"raw document: {doc.raw}")
   ...    print(f"decoded document: {bson.decode(doc.raw)}")
-  ...    result = replica_db.test.insert_one(doc)
-  ...    assert result.acknowledged
+  ...    replica_db.test.insert_one(doc)
   raw document: b'...'
   decoded document: {'_id': ObjectId('...'), 'a': 1}
   raw document: b'...'
@@ -67,8 +66,6 @@ Example: Moving a document between different databases/collections
 For use cases like moving documents across different databases or writing binary
 blobs to disk, using raw BSON documents provides better speed and avoids the
 overhead of decoding or encoding BSON.
-
-.. versionadded:: 3.12
 """
 
 from collections.abc import Mapping as _Mapping

--- a/bson/raw_bson.py
+++ b/bson/raw_bson.py
@@ -32,18 +32,18 @@ Example: Moving a document between different databases/collections
   >>> from bson.raw_bson import RawBSONDocument
   >>> client = MongoClient("localhost", 27017, document_class=bson.)
   >>> db = client.db
-  >>> docs = [
+  >>> result = db.test.insert_many([
   ...  {'a': 1},
   ...  {'b': 1},
   ...  {'c': 1},
-  ...  {'d': 1}]
-  >>> result = db.test.insert_many(docs)
+  ...  {'d': 1}])
   >>> assert result.acknowledged
   >>> replica_db = client.replica_db
   >>> for doc in db.test.find():
   ...    print(f"raw document: {doc.raw}")
   ...    print(f"decoded document: {bson.decode(doc.raw)}")
-  ...    replica_db.test.insert_one(doc)
+  ...    result = replica_db.test.insert_one(doc)
+  ...    assert result.acknowledged
   raw document: b'...'
   decoded document: {'_id': ObjectId('...'), 'a': 1}
   raw document: b'...'
@@ -54,7 +54,7 @@ Example: Moving a document between different databases/collections
   decoded document: {'_id': ObjectId('...'), 'd': 1}
   >>> for doc in replica_db.test.find():
   ...    print(f"raw document: {doc.raw}")
-  ...    print(f"decoded document: {bson.decode(doc.raw)}")  
+  ...    print(f"decoded document: {bson.decode(doc.raw)}")
   raw document: b'...'
   decoded document: {'_id': ObjectId('...'), 'a': 1}
   raw document: b'...'

--- a/bson/raw_bson.py
+++ b/bson/raw_bson.py
@@ -21,7 +21,7 @@ Example: Moving a document between different databases/collections
 
 .. testsetup::
   from pymongo import MongoClient
-  client = MongoClient("localhost", 27017, document_class=RawBSONDocument)
+  client = MongoClient(document_class=RawBSONDocument)
   client.drop_database('db')
   client.drop_database('replica_db')
 
@@ -30,30 +30,17 @@ Example: Moving a document between different databases/collections
   >>> import bson
   >>> from pymongo import MongoClient
   >>> from bson.raw_bson import RawBSONDocument
-  >>> client = MongoClient("localhost", 27017, document_class=RawBSONDocument)
+  >>> client = MongoClient(document_class=RawBSONDocument)
   >>> db = client.db
-  >>> result = db.test.insert_many([
-  ...  {'a': 1},
-  ...  {'b': 1},
-  ...  {'c': 1},
-  ...  {'d': 1}])
-  >>> assert result.acknowledged
+  >>> result = db.test.insert_many([{'a': 1},
+  ...                               {'b': 1},
+  ...                               {'c': 1},
+  ...                               {'d': 1}])
   >>> replica_db = client.replica_db
   >>> for doc in db.test.find():
   ...    print(f"raw document: {doc.raw}")
   ...    print(f"decoded document: {bson.decode(doc.raw)}")
   ...    replica_db.test.insert_one(doc)
-  raw document: b'...'
-  decoded document: {'_id': ObjectId('...'), 'a': 1}
-  raw document: b'...'
-  decoded document: {'_id': ObjectId('...'), 'b': 1}
-  raw document: b'...'
-  decoded document: {'_id': ObjectId('...'), 'c': 1}
-  raw document: b'...'
-  decoded document: {'_id': ObjectId('...'), 'd': 1}
-  >>> for doc in replica_db.test.find():
-  ...    print(f"raw document: {doc.raw}")
-  ...    print(f"decoded document: {bson.decode(doc.raw)}")
   raw document: b'...'
   decoded document: {'_id': ObjectId('...'), 'a': 1}
   raw document: b'...'

--- a/bson/raw_bson.py
+++ b/bson/raw_bson.py
@@ -40,7 +40,7 @@ Example: Moving a document between different databases/collections
   >>> for doc in db.test.find():
   ...    print(f"raw document: {doc.raw}")
   ...    print(f"decoded document: {bson.decode(doc.raw)}")
-  ...    replica_db.test.insert_one(doc)
+  ...    result = replica_db.test.insert_one(doc)
   raw document: b'...'
   decoded document: {'_id': ObjectId('...'), 'a': 1}
   raw document: b'...'


### PR DESCRIPTION
Adds an Example for usage of RawBSONDocuments with the use case of moving documents across different collections