### PR TITLE
PYTHON-1690: Fix error message when insert_many is given a single RawBSONDocument instead of a list

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -687,7 +687,7 @@ class Collection(common.BaseObject):
         .. versionadded:: 3.0
         """
         if (not isinstance(documents, abc.Iterable)
-                or isinstance(documents, abc.Mapping) 
+                or isinstance(documents, abc.Mapping)
                 or not documents):
             raise TypeError("documents must be a non-empty list")
         inserted_ids = []

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -686,7 +686,7 @@ class Collection(common.BaseObject):
 
         .. versionadded:: 3.0
         """
-        if not isinstance(documents, abc.Sequence) or not documents:
+        if not isinstance(documents, abc.Iterable) or isinstance(documents, abc.Mapping) or not documents:
             raise TypeError("documents must be a non-empty list")
         inserted_ids = []
         def gen():

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -686,7 +686,7 @@ class Collection(common.BaseObject):
 
         .. versionadded:: 3.0
         """
-        if not isinstance(documents, abc.Iterable) or not documents:
+        if not isinstance(documents, abc.Sequence) or not documents:
             raise TypeError("documents must be a non-empty list")
         inserted_ids = []
         def gen():

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -686,9 +686,9 @@ class Collection(common.BaseObject):
 
         .. versionadded:: 3.0
         """
-        if not isinstance(documents, abc.Iterable) \
-                or isinstance(documents, abc.Mapping) \
-                or not documents:
+        if (not isinstance(documents, abc.Iterable)
+                or isinstance(documents, abc.Mapping) 
+                or not documents):
             raise TypeError("documents must be a non-empty list")
         inserted_ids = []
         def gen():

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -686,7 +686,9 @@ class Collection(common.BaseObject):
 
         .. versionadded:: 3.0
         """
-        if not isinstance(documents, abc.Iterable) or isinstance(documents, abc.Mapping) or not documents:
+        if not isinstance(documents, abc.Iterable) \
+                or isinstance(documents, abc.Mapping) \
+                or not documents:
             raise TypeError("documents must be a non-empty list")
         inserted_ids = []
         def gen():

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -23,6 +23,8 @@ import sys
 from codecs import utf_8_decode
 from collections import defaultdict
 
+import bson
+
 sys.path[0:0] = [""]
 
 from bson import encode
@@ -785,6 +787,26 @@ class TestCollection(IntegrationTest):
         self.assertTrue(isinstance(result, InsertManyResult))
         self.assertFalse(result.acknowledged)
         self.assertEqual(20, db.test.count_documents({}))
+
+    def test_insert_many_invalid(self):
+        db = self.db
+        db.test.drop()
+
+        with self.assertRaisesRegex(
+                TypeError, "documents must be a non-empty list"):
+            db.test.insert_many({})
+
+        with self.assertRaisesRegex(
+                TypeError, "documents must be a non-empty list"):
+            db.test.insert_many([])
+
+        with self.assertRaisesRegex(
+                TypeError, "documents must be a non-empty list"):
+            db.test.insert_many(1)
+
+        with self.assertRaisesRegex(
+                TypeError, "documents must be a non-empty list"):
+            db.test.insert_many(RawBSONDocument(bson.BSON.encode({'_id': 2})))
 
     def test_delete_one(self):
         self.db.test.drop()

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -803,7 +803,7 @@ class TestCollection(IntegrationTest):
 
         with self.assertRaisesRegex(
                 TypeError, "documents must be a non-empty list"):
-            db.test.insert_many(RawBSONDocument(bson.BSON.encode({'_id': 2})))
+            db.test.insert_many(RawBSONDocument(encode({'_id': 2})))
 
     def test_delete_one(self):
         self.db.test.drop()

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -876,7 +876,7 @@ class TestCollection(IntegrationTest):
         id_only = {'ref': {'$id': ObjectId()}}
         self.assertRaises(InvalidDocument, self.db.test.insert_one, ref_only)
         self.assertRaises(InvalidDocument, self.db.test.insert_one, id_only)
-
+x
     @client_context.require_version_min(3, 1, 9, -1)
     def test_insert_bypass_document_validation(self):
         db = self.db

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -23,8 +23,6 @@ import sys
 from codecs import utf_8_decode
 from collections import defaultdict
 
-import bson
-
 sys.path[0:0] = [""]
 
 from bson import encode
@@ -790,7 +788,6 @@ class TestCollection(IntegrationTest):
 
     def test_insert_many_invalid(self):
         db = self.db
-        db.test.drop()
 
         with self.assertRaisesRegex(
                 TypeError, "documents must be a non-empty list"):

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -876,7 +876,7 @@ class TestCollection(IntegrationTest):
         id_only = {'ref': {'$id': ObjectId()}}
         self.assertRaises(InvalidDocument, self.db.test.insert_one, ref_only)
         self.assertRaises(InvalidDocument, self.db.test.insert_one, id_only)
-x
+
     @client_context.require_version_min(3, 1, 9, -1)
     def test_insert_bypass_document_validation(self):
         db = self.db


### PR DESCRIPTION
Changed type checking from `abc.Iterable` to `abc.Sequence` in order to better match 'list-like' types

```
TypeError                                 
Traceback (most recent call last)
<ipython-input-6-9084eaf77999> in <module>
----> 1 client.test.test.insert_many(RawBSONDocument(bson.BSON.encode({'_id':2})))

~/mongo-python-driver/pymongo/collection.py in insert_many(self, documents, ordered, bypass_document_validation, session)
    688         """
    689         if not isinstance(documents, abc.Sequence) or not documents:
--> 690             raise TypeError("documents must be a non-empty list")
    691         inserted_ids = []
    692         def gen():

TypeError: documents must be a non-empty list
```