### PR TITLE
PYTHON-2615 Reinstate TLS network timeout workaround due to eventlet

### DIFF
--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -237,6 +237,12 @@ def _raise_connection_failure(address, error, msg_prefix=None):
         msg = msg_prefix + msg
     if isinstance(error, socket.timeout):
         raise NetworkTimeout(msg) from error
+    elif isinstance(error, _SSLError) and 'timed out' in str(error):
+        # Eventlet does not distinguish TLS network timeouts from other
+        # SSLErrors (https://github.com/eventlet/eventlet/issues/692).
+        # Luckily, we can work around this limitation because the phrase
+        # 'timed out' appears in all the timeout related SSLErrors raised.
+        raise NetworkTimeout(msg) from error
     else:
         raise AutoReconnect(msg) from error
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1576,7 +1576,7 @@ class TestClient(IntegrationTest):
         with self.fail_point({'mode': {'times': 1},
                               'data': {'closeConnection': True,
                                        'failCommands': ['find']}}):
-            expected = '%s:%s: connection closed' % client.address
+            expected = '%s:%s: ' % client.address
             with self.assertRaisesRegex(AutoReconnect, expected):
                 client.pymongo_test.test.find_one({})
 


### PR DESCRIPTION
PYTHON-2616 Fix test_network_error_message when TLS is enabled.