### PR TITLE
PYTHON-1690: Fix error message when insert_many is given a single Raw…

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -745,7 +745,9 @@ class Collection(common.BaseObject):
 
         .. versionadded:: 3.0
         """
-        if not isinstance(documents, abc.Iterable) or not documents:
+        if (not isinstance(documents, abc.Iterable)
+                or isinstance(documents, abc.Mapping)
+                or not documents):
             raise TypeError("documents must be a non-empty list")
         inserted_ids = []
         def gen():

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -826,6 +826,25 @@ class TestCollection(IntegrationTest):
         self.assertFalse(result.acknowledged)
         self.assertEqual(20, db.test.count_documents({}))
 
+    def test_insert_many_invalid(self):
+        db = self.db
+
+        with self.assertRaisesRegex(
+                TypeError, "documents must be a non-empty list"):
+            db.test.insert_many({})
+
+        with self.assertRaisesRegex(
+                TypeError, "documents must be a non-empty list"):
+            db.test.insert_many([])
+
+        with self.assertRaisesRegex(
+                TypeError, "documents must be a non-empty list"):
+            db.test.insert_many(1)
+
+        with self.assertRaisesRegex(
+                TypeError, "documents must be a non-empty list"):
+            db.test.insert_many(RawBSONDocument(encode({'_id': 2})))
+
     def test_delete_one(self):
         self.db.test.drop()
 


### PR DESCRIPTION
…BSONDocument instead of a list (#580)

(cherry picked from commit 94f4de1f2e58209e1e8c1db46975b76c3cee6abb)

[Evergreen patch build](https://spruce.mongodb.com/version/6058e9c732f417409a396687/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&statuses=failed&variant=tests-python-version-amazon1-test-encryption__platform~awslinux_auth-ssl~noauth-nossl_python-version~2.7_encryption~encryption)