### PR TITLE
PYTHON-2634 Only update pools for data-bearing servers

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -449,7 +449,7 @@ class ClientUnitTest(unittest.TestCase):
 
 class TestClient(IntegrationTest):
 
-    def test_max_idle_time_reaper(self):
+    def test_max_idle_time_reaper_default(self):
         with client_knobs(kill_cursor_frequency=0.1):
             # Assert reaper doesn't remove sockets when maxIdleTimeMS not set
             client = rs_or_single_client()
@@ -460,6 +460,8 @@ class TestClient(IntegrationTest):
             self.assertTrue(sock_info in server._pool.sockets)
             client.close()
 
+    def test_max_idle_time_reaper_removes_stale_minPoolSize(self):
+        with client_knobs(kill_cursor_frequency=0.1):
             # Assert reaper removes idle socket and replaces it with a new one
             client = rs_or_single_client(maxIdleTimeMS=500,
                                          minPoolSize=1)
@@ -475,6 +477,8 @@ class TestClient(IntegrationTest):
                        "replace stale socket")
             client.close()
 
+    def test_max_idle_time_reaper_does_not_exceed_maxPoolSize(self):
+        with client_knobs(kill_cursor_frequency=0.1):
             # Assert reaper respects maxPoolSize when adding new sockets.
             client = rs_or_single_client(maxIdleTimeMS=500,
                                          minPoolSize=1,
@@ -491,6 +495,8 @@ class TestClient(IntegrationTest):
                        "replace stale socket")
             client.close()
 
+    def test_max_idle_time_reaper_removes_stale(self):
+        with client_knobs(kill_cursor_frequency=0.1):
             # Assert reaper has removed idle socket and NOT replaced it
             client = rs_or_single_client(maxIdleTimeMS=500)
             server = client._get_topology().select_server(any_server_selector)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -57,7 +57,7 @@ from pymongo.driver_info import DriverInfo
 from pymongo.pool import SocketInfo, _METADATA
 from pymongo.read_preferences import ReadPreference
 from pymongo.server_description import ServerDescription
-from pymongo.server_selectors import (any_server_selector,
+from pymongo.server_selectors import (readable_server_selector,
                                       writable_server_selector)
 from pymongo.server_type import SERVER_TYPE
 from pymongo.settings import TOPOLOGY_TYPE
@@ -453,7 +453,8 @@ class TestClient(IntegrationTest):
         with client_knobs(kill_cursor_frequency=0.1):
             # Assert reaper doesn't remove sockets when maxIdleTimeMS not set
             client = rs_or_single_client()
-            server = client._get_topology().select_server(any_server_selector)
+            server = client._get_topology().select_server(
+                readable_server_selector)
             with server._pool.get_socket({}) as sock_info:
                 pass
             self.assertEqual(1, len(server._pool.sockets))
@@ -465,7 +466,8 @@ class TestClient(IntegrationTest):
             # Assert reaper removes idle socket and replaces it with a new one
             client = rs_or_single_client(maxIdleTimeMS=500,
                                          minPoolSize=1)
-            server = client._get_topology().select_server(any_server_selector)
+            server = client._get_topology().select_server(
+                readable_server_selector)
             with server._pool.get_socket({}) as sock_info:
                 pass
             # When the reaper runs at the same time as the get_socket, two
@@ -483,7 +485,8 @@ class TestClient(IntegrationTest):
             client = rs_or_single_client(maxIdleTimeMS=500,
                                          minPoolSize=1,
                                          maxPoolSize=1)
-            server = client._get_topology().select_server(any_server_selector)
+            server = client._get_topology().select_server(
+                readable_server_selector)
             with server._pool.get_socket({}) as sock_info:
                 pass
             # When the reaper runs at the same time as the get_socket,
@@ -499,7 +502,8 @@ class TestClient(IntegrationTest):
         with client_knobs(kill_cursor_frequency=0.1):
             # Assert reaper has removed idle socket and NOT replaced it
             client = rs_or_single_client(maxIdleTimeMS=500)
-            server = client._get_topology().select_server(any_server_selector)
+            server = client._get_topology().select_server(
+                readable_server_selector)
             with server._pool.get_socket({}) as sock_info_one:
                 pass
             # Assert that the pool does not close sockets prematurely.
@@ -515,12 +519,14 @@ class TestClient(IntegrationTest):
     def test_min_pool_size(self):
         with client_knobs(kill_cursor_frequency=.1):
             client = rs_or_single_client()
-            server = client._get_topology().select_server(any_server_selector)
+            server = client._get_topology().select_server(
+                readable_server_selector)
             self.assertEqual(0, len(server._pool.sockets))
 
             # Assert that pool started up at minPoolSize
             client = rs_or_single_client(minPoolSize=10)
-            server = client._get_topology().select_server(any_server_selector)
+            server = client._get_topology().select_server(
+                readable_server_selector)
             wait_until(lambda: 10 == len(server._pool.sockets),
                        "pool initialized with 10 sockets")
 
@@ -535,7 +541,8 @@ class TestClient(IntegrationTest):
         # Use high frequency to test _get_socket_no_auth.
         with client_knobs(kill_cursor_frequency=99999999):
             client = rs_or_single_client(maxIdleTimeMS=500)
-            server = client._get_topology().select_server(any_server_selector)
+            server = client._get_topology().select_server(
+                readable_server_selector)
             with server._pool.get_socket({}) as sock_info:
                 pass
             self.assertEqual(1, len(server._pool.sockets))
@@ -549,7 +556,8 @@ class TestClient(IntegrationTest):
 
             # Test that sockets are reused if maxIdleTimeMS is not set.
             client = rs_or_single_client()
-            server = client._get_topology().select_server(any_server_selector)
+            server = client._get_topology().select_server(
+                readable_server_selector)
             with server._pool.get_socket({}) as sock_info:
                 pass
             self.assertEqual(1, len(server._pool.sockets))

--- a/test/test_cmap.py
+++ b/test/test_cmap.py
@@ -237,7 +237,8 @@ class TestCMAP(IntegrationTest):
             # PoolReadyEvents. Instead, update the initial state before
             # opening the Topology.
             td = client_context.client._topology.description
-            sd = td.server_descriptions()[(client.HOST, client.PORT)]
+            sd = td.server_descriptions()[(client_context.host,
+                                           client_context.port)]
             client._topology._description = updated_topology_description(
                 client._topology._description, sd)
             client._get_topology()

--- a/test/test_cmap.py
+++ b/test/test_cmap.py
@@ -41,6 +41,7 @@ from pymongo.monitoring import (ConnectionCheckedInEvent,
                                 PoolClosedEvent)
 from pymongo.read_preferences import ReadPreference
 from pymongo.pool import _PoolClosedError, PoolState
+from pymongo.topology_description import updated_topology_description
 
 from test import (client_knobs,
                   IntegrationTest,
@@ -226,12 +227,22 @@ class TestCMAP(IntegrationTest):
         opts = test['poolOptions'].copy()
         opts['event_listeners'] = [self.listener]
         opts['_monitor_class'] = DummyMonitor
+        opts['connect'] = False
         with client_knobs(kill_cursor_frequency=.05,
                           min_heartbeat_interval=.05):
             client = single_client(**opts)
+            # Update the SD to a known type because the DummyMonitor will not.
+            # Note we cannot simply call topology.on_change because that would
+            # internally call pool.ready() which introduces unexpected
+            # PoolReadyEvents. Instead, update the initial state before
+            # opening the Topology.
+            td = client_context.client._topology.description
+            sd = td.server_descriptions()[(client.HOST, client.PORT)]
+            client._topology._description = updated_topology_description(
+                client._topology._description, sd)
+            client._get_topology()
         self.addCleanup(client.close)
-        # self.pool = get_pools(client)[0]
-        self.pool = list(client._get_topology()._servers.values())[0].pool
+        self.pool = list(client._topology._servers.values())[0].pool
 
         # Map of target names to Thread objects.
         self.targets = dict()


### PR DESCRIPTION
Fixes a noisy OperationFailure: Authentication failed error.
Do not attempt to create unneeded connections to arbiters, ghosts,
hidden members, or unknown members.