### PR TITLE
PYTHON-2397: MongoClient(ssl=True, tls=False) fails with an AttributeError

### DIFF
--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -647,7 +647,7 @@ class MongoClient(common.BaseObject):
         username = None
         password = None
         dbase = None
-        opts = {}
+        opts = common._CaseInsensitiveDictionary()
         fqdn = None
         for entity in host:
             if "://" in entity:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -445,6 +445,9 @@ class ClientUnitTest(unittest.TestCase):
             MongoClient('mongodb://localhost/?tlsInsecure=true',
                         connect=False, ssl_cert_reqs=True)
 
+        # Conflicting kwargs should raise InvalidURI
+        with self.assertRaises(InvalidURI):
+            MongoClient(ssl=True, tls=False)
 
 class TestClient(IntegrationTest):
 


### PR DESCRIPTION
Switch from common dictionary to CaseInsensitiveDictionary to fix `cased_key` attribute error.