### PR TITLE
[PYTHON-2643] Requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+dnspython


### PR DESCRIPTION
Adds a requirements.txt file that tells pip to install dnspython, a required package to connect to a MongoDB server.