### PR TITLE
PYTHON-1880: Raise a warning when no_cursor_timeout is used with an implicit session

### DIFF
--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -144,10 +144,13 @@ class Cursor(object):
         if not isinstance(limit, int):
             raise TypeError("limit must be an instance of int")
         validate_boolean("no_cursor_timeout", no_cursor_timeout)
-        if no_cursor_timeout:
-            warnings.warn("use an explicit session with no_cursor_timeout=True"\
-                          "otherwise the cursor may still timeout after 30 minutes,"\
-                          "for more info see DOCS-11255",
+        if no_cursor_timeout and not self.__explicit_session:
+            warnings.warn("use an explicit session with no_cursor_timeout=True "
+                          "otherwise the cursor may still timeout after "
+                          "30 minutes, for more info see "
+                          "https://docs.mongodb.com/v4.4/reference/method/"
+                          "cursor.noCursorTimeout/"
+                          "#session-idle-timeout-overrides-nocursortimeout",
                           UserWarning, stacklevel=2)
         if cursor_type not in (CursorType.NON_TAILABLE, CursorType.TAILABLE,
                                CursorType.TAILABLE_AWAIT, CursorType.EXHAUST):

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -144,6 +144,11 @@ class Cursor(object):
         if not isinstance(limit, int):
             raise TypeError("limit must be an instance of int")
         validate_boolean("no_cursor_timeout", no_cursor_timeout)
+        if no_cursor_timeout:
+            warnings.warn("use an explicit session with no_cursor_timeout=True"\
+                          "otherwise the cursor may still timeout after 30 minutes,"\
+                          "for more info see DOCS-11255",
+                          UserWarning, stacklevel=2)
         if cursor_type not in (CursorType.NON_TAILABLE, CursorType.TAILABLE,
                                CursorType.TAILABLE_AWAIT, CursorType.EXHAUST):
             raise ValueError("not a valid value for cursor_type")


### PR DESCRIPTION
# Description
- Add a informative UserWarning when no_cursor_timeout is set