### PR TITLE
PYTHON-2364 Replace deprecated dns.resolver.query with dns.resolver.resolve

### DIFF
--- a/pymongo/srv_resolver.py
+++ b/pymongo/srv_resolver.py
@@ -56,7 +56,7 @@ class _SrvResolver(object):
     def get_options(self):
         try:
             results = _resolve(self.__fqdn, 'TXT',
-                                     lifetime=self.__connect_timeout)
+                               lifetime=self.__connect_timeout)
         except (resolver.NoAnswer, resolver.NXDOMAIN):
             # No TXT records
             return None
@@ -71,7 +71,7 @@ class _SrvResolver(object):
     def _resolve_uri(self, encapsulate_errors):
         try:
             results = _resolve('_mongodb._tcp.' + self.__fqdn, 'SRV',
-                                     lifetime=self.__connect_timeout)
+                               lifetime=self.__connect_timeout)
         except Exception as exc:
             if not encapsulate_errors:
                 # Raise the original error.

--- a/pymongo/srv_resolver.py
+++ b/pymongo/srv_resolver.py
@@ -16,6 +16,13 @@
 
 try:
     from dns import resolver
+
+    try:
+        # dnspython >= 2
+        from dns.resolver import resolve as _resolve
+    except ImportError:
+        # dnspython 1.X
+        from dns.resolver import query as _resolve
     _HAVE_DNSPYTHON = True
 except ImportError:
     _HAVE_DNSPYTHON = False
@@ -48,7 +55,7 @@ class _SrvResolver(object):
 
     def get_options(self):
         try:
-            results = resolver.resolve(self.__fqdn, 'TXT',
+            results = _resolve(self.__fqdn, 'TXT',
                                      lifetime=self.__connect_timeout)
         except (resolver.NoAnswer, resolver.NXDOMAIN):
             # No TXT records
@@ -63,7 +70,7 @@ class _SrvResolver(object):
 
     def _resolve_uri(self, encapsulate_errors):
         try:
-            results = resolver.resolve('_mongodb._tcp.' + self.__fqdn, 'SRV',
+            results = _resolve('_mongodb._tcp.' + self.__fqdn, 'SRV',
                                      lifetime=self.__connect_timeout)
         except Exception as exc:
             if not encapsulate_errors:

--- a/pymongo/srv_resolver.py
+++ b/pymongo/srv_resolver.py
@@ -48,7 +48,7 @@ class _SrvResolver(object):
 
     def get_options(self):
         try:
-            results = resolver.query(self.__fqdn, 'TXT',
+            results = resolver.resolve(self.__fqdn, 'TXT',
                                      lifetime=self.__connect_timeout)
         except (resolver.NoAnswer, resolver.NXDOMAIN):
             # No TXT records
@@ -63,7 +63,7 @@ class _SrvResolver(object):
 
     def _resolve_uri(self, encapsulate_errors):
         try:
-            results = resolver.query('_mongodb._tcp.' + self.__fqdn, 'SRV',
+            results = resolver.resolve('_mongodb._tcp.' + self.__fqdn, 'SRV',
                                      lifetime=self.__connect_timeout)
         except Exception as exc:
             if not encapsulate_errors:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -393,10 +393,10 @@ class ClientUnitTest(unittest.TestCase):
     def test_connection_timeout_ms_propagates_to_DNS_resolver(self):
         # Patch the resolver.
         from pymongo.srv_resolver import resolver
-        patched_resolver = FunctionCallRecorder(resolver.query)
-        pymongo.srv_resolver.resolver.query = patched_resolver
+        patched_resolver = FunctionCallRecorder(resolver.resolve)
+        pymongo.srv_resolver.resolver.resolve = patched_resolver
         def reset_resolver():
-            pymongo.srv_resolver.resolver.query = resolver.query
+            pymongo.srv_resolver.resolver.resolve = resolver.resolve
         self.addCleanup(reset_resolver)
 
         # Setup.

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -392,11 +392,11 @@ class ClientUnitTest(unittest.TestCase):
         _HAVE_DNSPYTHON, "DNS-related tests need dnspython to be installed")
     def test_connection_timeout_ms_propagates_to_DNS_resolver(self):
         # Patch the resolver.
-        from pymongo.srv_resolver import resolver
-        patched_resolver = FunctionCallRecorder(resolver.resolve)
-        pymongo.srv_resolver.resolver.resolve = patched_resolver
+        from pymongo.srv_resolver import _resolve
+        patched_resolver = FunctionCallRecorder(_resolve)
+        pymongo.srv_resolver._resolve = patched_resolver
         def reset_resolver():
-            pymongo.srv_resolver.resolver.resolve = resolver.resolve
+            pymongo.srv_resolver._resolve = _resolve
         self.addCleanup(reset_resolver)
 
         # Setup.


### PR DESCRIPTION
Fixes the following deprecation warning:

```txt
/home/jr769/miniconda3/envs/py38/lib/python3.8/site-packages/pymongo/srv_resolver.py:72: DeprecationWarning: please use dns.resolver.resolve() instead
  results = resolver.query('_mongodb._tcp.' + self.__fqdn, 'SRV',
/home/jr769/miniconda3/envs/py38/lib/python3.8/site-packages/pymongo/srv_resolver.py:57: DeprecationWarning: please use dns.resolver.resolve() instead
  results = resolver.query(self.__fqdn, 'TXT',
```