### PR TITLE
PYTHON-2605: Improve mongodb+srv:// error message when dnspython is not installed

### DIFF
--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -16,7 +16,7 @@
 """Tools to parse and validate a MongoDB URI."""
 import re
 import warnings
-import os
+import sys
 
 from urllib.parse import unquote_plus
 
@@ -417,13 +417,12 @@ def parse_uri(uri, default_port=DEFAULT_PORT, validate=True, warn=False,
         scheme_free = uri[SCHEME_LEN:]
     elif uri.startswith(SRV_SCHEME):
         if not _HAVE_DNSPYTHON:
-            python_path = os.getenv('_', "python")
-            raise ConfigurationError('The "dnspython" module must be '
-                                     'installed to use mongodb+srv:// URIs. '
-                                     'To fix this error install pymongo '
-                                     'with the srv extra:\n   '
-                                     '%s -m pip install "pymongo[srv]"'
-                                     % (python_path))
+            python_path = sys.executable or "python"
+            raise ConfigurationError(
+                'The "dnspython" module must be '
+                'installed to use mongodb+srv:// URIs. '
+                'To fix this error install pymongo with the srv extra:\n '
+                '%s -m pip install "pymongo[srv]"' % (python_path))
         is_srv = True
         scheme_free = uri[SRV_SCHEME_LEN:]
     else:

--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -16,6 +16,7 @@
 """Tools to parse and validate a MongoDB URI."""
 import re
 import warnings
+import os
 
 from urllib.parse import unquote_plus
 
@@ -416,8 +417,13 @@ def parse_uri(uri, default_port=DEFAULT_PORT, validate=True, warn=False,
         scheme_free = uri[SCHEME_LEN:]
     elif uri.startswith(SRV_SCHEME):
         if not _HAVE_DNSPYTHON:
+            python_path = os.getenv('_', "python")
             raise ConfigurationError('The "dnspython" module must be '
-                                     'installed to use mongodb+srv:// URIs')
+                                     'installed to use mongodb+srv:// URIs. '
+                                     'To fix this error install pymongo '
+                                     'with the srv extra:\n   '
+                                     '%s -m pip install "pymongo[srv]"'
+                                     % (python_path))
         is_srv = True
         scheme_free = uri[SRV_SCHEME_LEN:]
     else:


### PR DESCRIPTION
# Description
- Generate installation instruction for user to copy paste when dnspython is not installed. 

# Note for reviewers 
- I wasn't sure about getting path for Python so I think this is the most straightforward but having to import `os` only for the path seems a bit excessive. But let me know if you would like me to change it :)