### PR TITLE
PYTHON-2634 Skip arbiter tests when no server is running

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -2009,7 +2009,6 @@ class TestClientPool(MockClientTest):
         )
         self.addCleanup(c.close)
 
-        print(c.topology_description)
         wait_until(lambda: len(c.nodes) == 1, 'connect')
         self.assertEqual(c.address, ('c', 3))
         # Assert that we create 1 pooled connection.

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1964,6 +1964,7 @@ class TestMongoClientFailover(MockClientTest):
 
 class TestClientPool(MockClientTest):
 
+    @client_context.require_connection
     def test_rs_client_does_not_maintain_pool_to_arbiters(self):
         listener = CMAPListener()
         c = MockClient(
@@ -1993,6 +1994,7 @@ class TestClientPool(MockClientTest):
         arbiter = c._topology.get_server_by_address(('d', 4))
         self.assertFalse(arbiter.pool.sockets)
 
+    @client_context.require_connection
     def test_direct_client_maintains_pool_to_arbiter(self):
         listener = CMAPListener()
         c = MockClient(


### PR DESCRIPTION
Fixes the "no server" test failures: 
```
 [2021/04/19 22:43:38.653] FAIL [10.026s]: test_direct_client_maintains_pool_to_arbiter (test_client.TestClientPool)
 [2021/04/19 22:43:38.653] ----------------------------------------------------------------------
 [2021/04/19 22:43:38.653] Traceback (most recent call last):
 [2021/04/19 22:43:38.653]   File "/data/mci/c3fd0d8a3cd0109c13fe181f4d100ef4/src/test/test_client.py", line 2082, in test_direct_client_maintains_pool_to_arbiter
 [2021/04/19 22:43:38.653]     listener.wait_for_event(monitoring.ConnectionReadyEvent, 1)
 [2021/04/19 22:43:38.653]   File "/data/mci/c3fd0d8a3cd0109c13fe181f4d100ef4/src/test/utils.py", line 93, in wait_for_event
 [2021/04/19 22:43:38.653]     'find %s %s event(s)' % (count, event))
 [2021/04/19 22:43:38.653]   File "/data/mci/c3fd0d8a3cd0109c13fe181f4d100ef4/src/test/utils.py", line 731, in wait_until
 [2021/04/19 22:43:38.653]     raise AssertionError("Didn't ever %s" % success_description)
 [2021/04/19 22:43:38.653] AssertionError: Didn't ever find 1 <class 'pymongo.monitoring.ConnectionReadyEvent'> event(s)
 [2021/04/19 22:43:38.653] ======================================================================
 [2021/04/19 22:43:38.653] FAIL [10.179s]: test_rs_client_does_not_maintain_pool_to_arbiters (test_client.TestClientPool)
 [2021/04/19 22:43:38.653] ----------------------------------------------------------------------
 [2021/04/19 22:43:38.653] Traceback (most recent call last):
 [2021/04/19 22:43:38.653]   File "/data/mci/c3fd0d8a3cd0109c13fe181f4d100ef4/src/test/test_client.py", line 2055, in test_rs_client_does_not_maintain_pool_to_arbiters
 [2021/04/19 22:43:38.653]     listener.wait_for_event(monitoring.ConnectionReadyEvent, 2)
 [2021/04/19 22:43:38.653]   File "/data/mci/c3fd0d8a3cd0109c13fe181f4d100ef4/src/test/utils.py", line 93, in wait_for_event
 [2021/04/19 22:43:38.653]     'find %s %s event(s)' % (count, event))
 [2021/04/19 22:43:38.653]   File "/data/mci/c3fd0d8a3cd0109c13fe181f4d100ef4/src/test/utils.py", line 731, in wait_until
 [2021/04/19 22:43:38.653]     raise AssertionError("Didn't ever %s" % success_description)
 [2021/04/19 22:43:38.653] AssertionError: Didn't ever find 2 <class 'pymongo.monitoring.ConnectionReadyEvent'> event(s)
 [2021/04/19 22:43:38.653] ----------------------------------------------------------------------
 ```