### PR TITLE
PYTHON-2667 Fix SRV support when running with eventlet

### DIFF
--- a/pymongo/srv_resolver.py
+++ b/pymongo/srv_resolver.py
@@ -16,13 +16,6 @@
 
 try:
     from dns import resolver
-
-    try:
-        # dnspython >= 2
-        from dns.resolver import resolve as _resolve
-    except ImportError:
-        # dnspython 1.X
-        from dns.resolver import query as _resolve
     _HAVE_DNSPYTHON = True
 except ImportError:
     _HAVE_DNSPYTHON = False
@@ -37,6 +30,15 @@ def maybe_decode(text):
     if isinstance(text, bytes):
         return text.decode()
     return text
+
+
+# PYTHON-2667 Lazily call dns.resolver methods for compatibility with eventlet.
+def _resolve(*args, **kwargs):
+    if hasattr(resolver, 'resolve'):
+        # dnspython >= 2
+        return resolver.resolve(*args, **kwargs)
+    # dnspython 1.X
+    return resolver.query(*args, **kwargs)
 
 
 class _SrvResolver(object):


### PR DESCRIPTION
This change works around the following eventlet bug:
```
$ python green_framework_test.py eventlet -s test.test_srv_polling.TestSrvPolling.test_addition
...
test_addition (test.test_srv_polling.TestSrvPolling) ... ERROR

======================================================================
ERROR: test_addition (test.test_srv_polling.TestSrvPolling)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/shane/pymongo-pycharm-3.8/lib/python3.8/site-packages/dns/resolver.py", line 212, in __init__
    rrset = response.find_rrset(response.answer, qname,
  File "/Users/shane/pymongo-pycharm-3.8/lib/python3.8/site-packages/dns/message.py", line 341, in find_rrset
    raise KeyError
KeyError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/shane/pymongo-pycharm-3.8/lib/python3.8/site-packages/dns/resolver.py", line 220, in __init__
    crrset = response.find_rrset(response.answer,
  File "/Users/shane/pymongo-pycharm-3.8/lib/python3.8/site-packages/dns/message.py", line 341, in find_rrset
    raise KeyError
KeyError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/pymongo/srv_resolver.py", line 58, in get_options
    results = _resolve(self.__fqdn, 'TXT',
  File "/Users/shane/pymongo-pycharm-3.8/lib/python3.8/site-packages/dns/resolver.py", line 1100, in query
    return get_default_resolver().query(qname, rdtype, rdclass, tcp, source,
  File "/Users/shane/pymongo-pycharm-3.8/lib/python3.8/site-packages/dns/resolver.py", line 1003, in query
    answer = Answer(_qname, rdtype, rdclass, response,
  File "/Users/shane/pymongo-pycharm-3.8/lib/python3.8/site-packages/dns/resolver.py", line 232, in __init__
    raise NoAnswer(response=response)
dns.resolver.NoAnswer: The DNS response does not contain an answer to the question: test1.test.build.10gen.cc. IN TXT

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/test/test_srv_polling.py", line 165, in test_addition
    self.run_scenario(response, True)
  File "/Users/shane/git/mongo-python-driver/test/test_srv_polling.py", line 153, in run_scenario
    client = MongoClient(self.CONNECTION_STRING)
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 659, in __init__
    res = uri_parser.parse_uri(
  File "/Users/shane/git/mongo-python-driver/pymongo/uri_parser.py", line 497, in parse_uri
    dns_options = dns_resolver.get_options()
  File "/Users/shane/git/mongo-python-driver/pymongo/srv_resolver.py", line 64, in get_options
    raise ConfigurationError(str(exc))
pymongo.errors.ConfigurationError: The DNS response does not contain an answer to the question: test1.test.build.10gen.cc. IN TXT
```