### PR TITLE
PYTHON-2678 Resync SRV spec tests

### DIFF
--- a/test/srv_seedlist/encoded-userinfo-and-db.json
+++ b/test/srv_seedlist/encoded-userinfo-and-db.json
@@ -1,0 +1,21 @@
+{
+  "uri": "mongodb+srv://b*b%40f3tt%3D:%244to%40L8%3DMC@test3.test.build.10gen.cc/mydb%3F?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "user": "b*b@f3tt=",
+    "password": "$4to@L8=MC",
+    "db": "mydb?"
+  },
+  "comment": "Encoded user, pass, and DB parse correctly"
+}

--- a/test/srv_seedlist/txt-record-not-allowed-option.json
+++ b/test/srv_seedlist/txt-record-not-allowed-option.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test10.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because socketTimeoutMS is not an allowed option."
+}

--- a/test/srv_seedlist/txt-record-with-overridden-ssl-option.json
+++ b/test/srv_seedlist/txt-record-with-overridden-ssl-option.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?ssl=false",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "authSource": "thisDB",
+    "ssl": false
+  }
+}

--- a/test/srv_seedlist/uri-with-admin-database.json
+++ b/test/srv_seedlist/uri-with-admin-database.json
@@ -1,0 +1,19 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/adminDB?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "auth_database": "adminDB"
+  }
+}

--- a/test/srv_seedlist/uri-with-auth.json
+++ b/test/srv_seedlist/uri-with-auth.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "parsed_options": {
+    "user": "auser",
+    "password": "apass"
+  },
+  "comment": "Should preserve auth credentials"
+}

--- a/test/test_dns.py
+++ b/test/test_dns.py
@@ -72,16 +72,13 @@ def create_test(test_case):
                     opts['readPreferenceTags'] = rpts
                 self.assertEqual(result['options'], options)
             if parsed_options:
-                for opt in parsed_options:
+                for opt, expected in parsed_options.items():
                     if opt == 'user':
-                        self.assertEqual(result['username'],
-                                         parsed_options[opt])
+                        self.assertEqual(result['username'], expected)
                     elif opt == 'password':
-                        self.assertEqual(result['password'],
-                                         parsed_options[opt])
+                        self.assertEqual(result['password'], expected)
                     elif opt == 'auth_database' or opt == 'db':
-                        self.assertEqual(result['database'],
-                                         parsed_options[opt])
+                        self.assertEqual(result['database'], expected)
 
             hostname = next(iter(client_context.client.nodes))[0]
             # The replica set members must be configured as 'localhost'.
@@ -89,7 +86,7 @@ def create_test(test_case):
                 copts = client_context.default_client_options.copy()
                 # Remove tls since SRV parsing should add it automatically.
                 copts.pop('tls', None)
-                if client_context.tls is True:
+                if client_context.tls:
                     # Our test certs don't support the SRV hosts used in these
                     # tests.
                     copts['tlsAllowInvalidHostnames'] = True

--- a/test/test_dns.py
+++ b/test/test_dns.py
@@ -30,7 +30,7 @@ from test import client_context, unittest
 from test.utils import wait_until
 
 
-_TEST_PATH = os.path.join(
+TEST_PATH = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'srv_seedlist')
 
 class TestDNS(unittest.TestCase):
@@ -40,7 +40,6 @@ class TestDNS(unittest.TestCase):
 def create_test(test_case):
 
     @client_context.require_replica_set
-    @client_context.require_tls
     def run_test(self):
         if not _HAVE_DNSPYTHON:
             raise unittest.SkipTest("DNS tests require the dnspython module")
@@ -48,6 +47,15 @@ def create_test(test_case):
         seeds = test_case['seeds']
         hosts = test_case['hosts']
         options = test_case.get('options')
+        parsed_options = test_case.get('parsed_options')
+        # See DRIVERS-1324, unless tls is explicitly set to False we need TLS.
+        needs_tls = not (options and (options.get('ssl') == False or
+                                      options.get('tls') == False))
+        if needs_tls and not client_context.tls:
+            self.skipTest('this test requires a TLS cluster')
+        if not needs_tls and client_context.tls:
+            self.skipTest('this test requires a non-TLS cluster')
+
         if seeds:
             seeds = split_hosts(','.join(seeds))
         if hosts:
@@ -63,18 +71,30 @@ def create_test(test_case):
                         'readPreferenceTags', opts.pop('readpreferencetags'))
                     opts['readPreferenceTags'] = rpts
                 self.assertEqual(result['options'], options)
+            if parsed_options:
+                for opt in parsed_options:
+                    if opt == 'user':
+                        self.assertEqual(result['username'],
+                                         parsed_options[opt])
+                    elif opt == 'password':
+                        self.assertEqual(result['password'],
+                                         parsed_options[opt])
+                    elif opt == 'auth_database' or opt == 'db':
+                        self.assertEqual(result['database'],
+                                         parsed_options[opt])
 
             hostname = next(iter(client_context.client.nodes))[0]
             # The replica set members must be configured as 'localhost'.
             if hostname == 'localhost':
                 copts = client_context.default_client_options.copy()
+                # Remove tls since SRV parsing should add it automatically.
+                copts.pop('tls', None)
                 if client_context.tls is True:
-                    # Our test certs don't support the SRV hosts used in these tests.
-                    copts['ssl_match_hostname'] = False
+                    # Our test certs don't support the SRV hosts used in these
+                    # tests.
+                    copts['tlsAllowInvalidHostnames'] = True
 
                 client = MongoClient(uri, **copts)
-                # Force server selection
-                client.admin.command('ismaster')
                 wait_until(
                     lambda: hosts == client.nodes,
                     'match test hosts to client nodes')
@@ -90,7 +110,7 @@ def create_test(test_case):
 
 
 def create_tests():
-    for filename in glob.glob(os.path.join(_TEST_PATH, '*.json')):
+    for filename in glob.glob(os.path.join(TEST_PATH, '*.json')):
         test_suffix, _ = os.path.splitext(os.path.basename(filename))
         with open(filename) as dns_test_file:
             test_method = create_test(json.load(dns_test_file))


### PR DESCRIPTION
Add support for validating parsed_options and running non-TLS tests.

This implements the following (ancient) spec changes which never has drivers tickets created for them: 
- https://github.com/mongodb/specifications/commit/53c8c19400f7808f472c5013db194e9af34153e9
- https://github.com/mongodb/specifications/commit/643a8790c65a864835cb1014d5b5939e5e65daa5
- https://github.com/mongodb/specifications/commit/120a529a95a16e7980ace0c78f07133db8c9578c