### PR TITLE
PYTHON-2396 Deprecate ssl_keyfile and ssl_certfile URI options

### DIFF
--- a/doc/examples/tls.rst
+++ b/doc/examples/tls.rst
@@ -120,25 +120,26 @@ PyMongo can be configured to present a client certificate using the
 
 If the private key for the client certificate is stored in a separate file,
 it should be concatenated with the certificate file. For example, to
-concatenate PEM-formatted certificate file ``cert.pem`` and keyfile ``key.pem``
-into a single file ``concat_client.pem``, on *nix systems users can run::
+concatenate a PEM-formatted certificate file ``cert.pem`` and a PEM-formatted
+keyfile ``key.pem`` into a single file ``combined.pem``, on *nix systems users
+can run::
 
-  $ cat key.pem cert.pem > concat_client.pem
+  $ cat key.pem cert.pem > combined.pem
 
 PyMongo can be configured with the concatenated certificate keyfile using the
 ``tlsCertificateKeyFile`` option::
 
   >>> client = pymongo.MongoClient('example.com',
   ...                              tls=True,
-  ...                              tlsCertificateKeyFile='/path/to/concat_client.pem')
+  ...                              tlsCertificateKeyFile='/path/to/combined.pem')
 
-Python supports providing a password or passphrase to decrypt encrypted
-private keys. Use the ``tlsCertificateKeyFilePassword`` option::
+If the private key contained in the certificate keyfile is encrypted, users
+can provide a password or passphrase to decrypt the encrypted private keys
+using the ``tlsCertificateKeyFilePassword`` option::
 
   >>> client = pymongo.MongoClient('example.com',
   ...                              tls=True,
-  ...                              tlsCertificateKeyFile='/path/to/client.pem',
-  ...                              ssl_keyfile='/path/to/key.pem',
+  ...                              tlsCertificateKeyFile='/path/to/combined.pem',
   ...                              tlsCertificateKeyFilePassword=<passphrase>)
 
 These options can also be passed as part of the MongoDB URI.

--- a/doc/examples/tls.rst
+++ b/doc/examples/tls.rst
@@ -121,8 +121,8 @@ PyMongo can be configured to present a client certificate using the
 If the private key for the client certificate is stored in a separate file,
 it should be concatenated with the certificate file. For example, to
 concatenate a PEM-formatted certificate file ``cert.pem`` and a PEM-formatted
-keyfile ``key.pem`` into a single file ``combined.pem``, on *nix systems users
-can run::
+keyfile ``key.pem`` into a single file ``combined.pem``, on Unix systems,
+users can run::
 
   $ cat key.pem cert.pem > combined.pem
 

--- a/doc/examples/tls.rst
+++ b/doc/examples/tls.rst
@@ -118,13 +118,19 @@ PyMongo can be configured to present a client certificate using the
   ...                              tls=True,
   ...                              tlsCertificateKeyFile='/path/to/client.pem')
 
-If the private key for the client certificate is stored in a separate file use
-the ``ssl_keyfile`` option::
+If the private key for the client certificate is stored in a separate file,
+it should be concatenated with the certificate file. For example, to
+concatenate PEM-formatted certificate file ``cert.pem`` and keyfile ``key.pem``
+into a single file ``concat_client.pem``, on *nix systems users can run::
+
+  $ cat key.pem cert.pem > concat_client.pem
+
+PyMongo can be configured with the concatenated certificate keyfile using the
+``tlsCertificateKeyFile`` option::
 
   >>> client = pymongo.MongoClient('example.com',
   ...                              tls=True,
-  ...                              tlsCertificateKeyFile='/path/to/client.pem',
-  ...                              ssl_keyfile='/path/to/key.pem')
+  ...                              tlsCertificateKeyFile='/path/to/concat_client.pem')
 
 Python supports providing a password or passphrase to decrypt encrypted
 private keys. Use the ``tlsCertificateKeyFilePassword`` option::
@@ -134,7 +140,6 @@ private keys. Use the ``tlsCertificateKeyFilePassword`` option::
   ...                              tlsCertificateKeyFile='/path/to/client.pem',
   ...                              ssl_keyfile='/path/to/key.pem',
   ...                              tlsCertificateKeyFilePassword=<passphrase>)
-
 
 These options can also be passed as part of the MongoDB URI.
 

--- a/doc/migrate-to-pymongo4.rst
+++ b/doc/migrate-to-pymongo4.rst
@@ -62,20 +62,6 @@ get the same behavior.
 MongoClient
 -----------
 
-Connection options changes
-..........................
-
-Connection options described in this section can be passed as keyword arguments
-to the :class:`pymongo.mongo_client.MongoClient` constructor, or via the
-connection string unless otherwise specified.
-
-#. Removed ``ssl_certfile`` and ``ssl_keyfile``. Instead of passing the client
-   certificate file and private key file separately using the ``ssl_certfile``,
-   and ``ssl_keyfile`` connection options respectively, users must now
-   concatenate their certificate and private key files and pass the resulting
-   concatenated file using the ``tlsCertificateKeyFile`` connection option.
-
-
 MongoClient.fsync is removed
 ............................
 

--- a/doc/migrate-to-pymongo4.rst
+++ b/doc/migrate-to-pymongo4.rst
@@ -62,6 +62,20 @@ get the same behavior.
 MongoClient
 -----------
 
+Connection options changes
+..........................
+
+Connection options described in this section can be passed as keyword arguments
+to the :class:`pymongo.mongo_client.MongoClient` constructor, or via the
+connection string unless otherwise specified.
+
+#. Removed ``ssl_certfile`` and ``ssl_keyfile``. Instead of passing the client
+   certificate file and private key file separately using the ``ssl_certfile``,
+   and ``ssl_keyfile`` connection options respectively, users must now
+   concatenate their certificate and private key files and pass the resulting
+   concatenated file using the ``tlsCertificateKeyFile`` connection option.
+
+
 MongoClient.fsync is removed
 ............................
 

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -706,6 +706,14 @@ URI_OPTIONS_DEPRECATION_MAP = {
     'ssl_match_hostname': ('renamed', 'tlsAllowInvalidHostnames'),
     'ssl_crlfile': ('renamed', 'tlsCRLFile'),
     'ssl_ca_certs': ('renamed', 'tlsCAFile'),
+    'ssl_certfile': ('removed', (
+        'Instead of using ssl_certfile to specify the certificate file, '
+        'use tlsCertificateKeyFile to pass a single file containing both '
+        'the client certificate and the private key')),
+    'ssl_keyfile': ('removed', (
+        'Instead of using ssl_keyfile to specify the private keyfile, '
+        'use tlsCertificateKeyFile to pass a single file containing both '
+        'the client certificate and the private key')),
     'ssl_pem_passphrase': ('renamed', 'tlsCertificateKeyFilePassword'),
     'waitqueuemultiple': ('removed', (
         'Instead of using waitQueueMultiple to bound queuing, limit the size '

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -503,8 +503,8 @@ class MongoClient(common.BaseObject):
            Added the ``server_api`` keyword argument.
            The following keyword arguments were deprecated:
 
-             - ``ssl_certfile``
-             - ``ssl_keyfile``
+             - ``ssl_certfile`` and ``ssl_keyfile`` were deprecated in favor
+               of ``tlsCertificateKeyFile``.
 
         .. versionchanged:: 3.11
            Added the following keyword arguments and URI options:

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -449,28 +449,18 @@ class MongoClient(common.BaseObject):
             certificates passed from the other end of the connection.
             Implies ``tls=True``. Defaults to ``None``.
           - `tlsCertificateKeyFile`: A file containing the client certificate
-            and private key. If you want to pass the certificate and private
-            key as separate files, use the ``ssl_certfile`` and ``ssl_keyfile``
-            options instead. Implies ``tls=True``. Defaults to ``None``.
+            and private key. Implies ``tls=True``. Defaults to ``None``.
           - `tlsCRLFile`: A file containing a PEM or DER formatted
             certificate revocation list. Only supported by python 2.7.9+
             (pypy 2.5.1+). Implies ``tls=True``. Defaults to ``None``.
           - `tlsCertificateKeyFilePassword`: The password or passphrase for
-            decrypting the private key in ``tlsCertificateKeyFile`` or
-            ``ssl_keyfile``. Only necessary if the private key is encrypted.
-            Only supported by python 2.7.9+ (pypy 2.5.1+) and 3.3+. Defaults
-            to ``None``.
+            decrypting the private key in ``tlsCertificateKeyFile``. Only
+            necessary if the private key is encrypted. Only supported by
+            python 2.7.9+ (pypy 2.5.1+) and 3.3+. Defaults to ``None``.
           - `tlsDisableOCSPEndpointCheck`: (boolean) If ``True``, disables
             certificate revocation status checking via the OCSP responder
             specified on the server certificate. Defaults to ``False``.
           - `ssl`: (boolean) Alias for ``tls``.
-          - `ssl_certfile`: The certificate file used to identify the local
-            connection against mongod. Implies ``tls=True``. Defaults to
-            ``None``.
-          - `ssl_keyfile`: The private keyfile used to identify the local
-            connection against mongod. Can be omitted if the keyfile is
-            included with the ``tlsCertificateKeyFile``. Implies ``tls=True``.
-            Defaults to ``None``.
 
           | **Read Concern options:**
           | (If not set explicitly, this will use the server default)
@@ -511,6 +501,10 @@ class MongoClient(common.BaseObject):
 
         .. versionchanged:: 3.12
            Added the ``server_api`` keyword argument.
+           The following keyword arguments were deprecated:
+
+             - ``ssl_certfile``
+             - ``ssl_keyfile``
 
         .. versionchanged:: 3.11
            Added the following keyword arguments and URI options:

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -36,6 +36,7 @@ from test import (IntegrationTest,
 from test.utils import (EventListener,
                         cat_files,
                         connected,
+                        ignore_deprecations,
                         remove_all_users)
 
 
@@ -93,6 +94,7 @@ class TestClientSSL(unittest.TestCase):
                           MongoClient, ssl_certfile=CLIENT_PEM)
 
     @unittest.skipUnless(HAVE_SSL, "The ssl module is not available.")
+    @ignore_deprecations
     def test_config_ssl(self):
         # Tests various ssl configurations
         self.assertRaises(ValueError, MongoClient, ssl='foo')
@@ -196,6 +198,7 @@ class TestSSL(IntegrationTest):
         self.assertClientWorks(self.client)
 
     @client_context.require_ssl_certfile
+    @ignore_deprecations
     def test_ssl_pem_passphrase(self):
         # Expects the server to be running with server.pem and ca.pem
         #
@@ -228,6 +231,7 @@ class TestSSL(IntegrationTest):
 
     @client_context.require_ssl_certfile
     @client_context.require_no_auth
+    @ignore_deprecations
     def test_cert_ssl_implicitly_set(self):
         # Expects the server to be running with server.pem and ca.pem
         #
@@ -251,6 +255,7 @@ class TestSSL(IntegrationTest):
 
     @client_context.require_ssl_certfile
     @client_context.require_no_auth
+    @ignore_deprecations
     def test_cert_ssl_validation(self):
         # Expects the server to be running with server.pem and ca.pem
         #
@@ -288,6 +293,7 @@ class TestSSL(IntegrationTest):
 
     @client_context.require_ssl_certfile
     @client_context.require_no_auth
+    @ignore_deprecations
     def test_cert_ssl_uri_support(self):
         # Expects the server to be running with server.pem and ca.pem
         #
@@ -301,6 +307,7 @@ class TestSSL(IntegrationTest):
 
     @client_context.require_ssl_certfile
     @client_context.require_no_auth
+    @ignore_deprecations
     def test_cert_ssl_validation_optional(self):
         # Expects the server to be running with server.pem and ca.pem
         #
@@ -331,6 +338,7 @@ class TestSSL(IntegrationTest):
 
     @client_context.require_ssl_certfile
     @client_context.require_server_resolvable
+    @ignore_deprecations
     def test_cert_ssl_validation_hostname_matching(self):
         # Expects the server to be running with server.pem and ca.pem
         #
@@ -394,6 +402,7 @@ class TestSSL(IntegrationTest):
                                   **self.credentials))
 
     @client_context.require_ssl_certfile
+    @ignore_deprecations
     def test_ssl_crlfile_support(self):
         if not hasattr(ssl, 'VERIFY_CRL_CHECK_LEAF') or _ssl.IS_PYOPENSSL:
             self.assertRaises(
@@ -432,6 +441,7 @@ class TestSSL(IntegrationTest):
 
     @client_context.require_ssl_certfile
     @client_context.require_server_resolvable
+    @ignore_deprecations
     def test_validation_with_system_ca_certs(self):
         # Expects the server to be running with server.pem and ca.pem.
         #
@@ -546,6 +556,7 @@ class TestSSL(IntegrationTest):
 
     @client_context.require_auth
     @client_context.require_ssl_certfile
+    @ignore_deprecations
     def test_mongodb_x509_auth(self):
         host, port = client_context.host, client_context.port
         self.addCleanup(remove_all_users, client_context.client['$external'])
@@ -647,6 +658,7 @@ class TestSSL(IntegrationTest):
             self.fail("Invalid certificate accepted.")
 
     @client_context.require_ssl_certfile
+    @ignore_deprecations
     def test_connect_with_ca_bundle(self):
         def remove(path):
             try:


### PR DESCRIPTION
Should I create a new section in the PyMongo 4 migration guide for deprecated/remove URI options?