### PR TITLE
PYTHON-2666 Unified test runner should not close the global client

### DIFF
--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -571,11 +571,6 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
                 raise unittest.SkipTest(
                     "MMAPv1 does not support retryWrites=True")
 
-    @classmethod
-    def tearDownClass(cls):
-        super(UnifiedSpecTestMixinV1, cls).tearDownClass()
-        cls.client.close()
-
     def setUp(self):
         super(UnifiedSpecTestMixinV1, self).setUp()
 


### PR DESCRIPTION
I suspect this will fix the "error: can't start new thread" we're seeing on SUSE 12 with Python 2.7.