### PR TITLE
PYTHON-2672 SDAM, CMAP, and server selection changes for load balancers

### DIFF
--- a/pymongo/client_options.py
+++ b/pymongo/client_options.py
@@ -130,6 +130,7 @@ def _parse_pool_options(options):
         options.get('compressors', []),
         options.get('zlibcompressionlevel', -1))
     ssl_context, ssl_match_hostname = _parse_ssl_options(options)
+    load_balanced = options.get('loadbalanced')
     return PoolOptions(max_pool_size,
                        min_pool_size,
                        max_idle_time_seconds,
@@ -141,7 +142,7 @@ def _parse_pool_options(options):
                        driver,
                        compression_settings,
                        server_api=server_api,
-                       load_balanced=options.get('loadbalanced'))
+                       load_balanced=load_balanced)
 
 
 class ClientOptions(object):

--- a/pymongo/client_options.py
+++ b/pymongo/client_options.py
@@ -140,7 +140,8 @@ def _parse_pool_options(options):
                        appname,
                        driver,
                        compression_settings,
-                       server_api=server_api)
+                       server_api=server_api,
+                       load_balanced=options.get('loadbalanced'))
 
 
 class ClientOptions(object):

--- a/pymongo/ismaster.py
+++ b/pymongo/ismaster.py
@@ -26,7 +26,9 @@ def _get_server_type(doc):
     if not doc.get('ok'):
         return SERVER_TYPE.Unknown
 
-    if doc.get('isreplicaset'):
+    if doc.get('serviceId'):
+        return SERVER_TYPE.LoadBalancer
+    elif doc.get('isreplicaset'):
         return SERVER_TYPE.RSGhost
     elif doc.get('setName'):
         if doc.get('hidden'):
@@ -58,7 +60,8 @@ class IsMaster(object):
         self._is_writable = self._server_type in (
             SERVER_TYPE.RSPrimary,
             SERVER_TYPE.Standalone,
-            SERVER_TYPE.Mongos)
+            SERVER_TYPE.Mongos,
+            SERVER_TYPE.LoadBalancer)
 
         self._is_readable = (
             self.server_type == SERVER_TYPE.RSSecondary
@@ -185,3 +188,7 @@ class IsMaster(object):
     @property
     def awaitable(self):
         return self._awaitable
+
+    @property
+    def service_id(self):
+        return self._doc.get('serviceId')

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -926,7 +926,8 @@ class MongoClient(common.BaseObject):
                 'Cannot use "address" property when load balancing among'
                 ' mongoses, use "nodes" instead.')
         if topology_type not in (TOPOLOGY_TYPE.ReplicaSetWithPrimary,
-                                 TOPOLOGY_TYPE.Single):
+                                 TOPOLOGY_TYPE.Single,
+                                 TOPOLOGY_TYPE.LoadBalanced):
             return None
         return self._server_property('address')
 

--- a/pymongo/server.py
+++ b/pymongo/server.py
@@ -46,7 +46,8 @@ class Server(object):
 
         Multiple calls have no effect.
         """
-        self._monitor.open()
+        if not self._pool.opts.load_balanced:
+            self._monitor.open()
 
     def reset(self):
         """Clear the connection pool."""

--- a/pymongo/server_description.py
+++ b/pymongo/server_description.py
@@ -206,7 +206,8 @@ class ServerDescription(object):
         """Checks if this server supports retryable writes."""
         return (
             self._ls_timeout_minutes is not None and
-            self._server_type in (SERVER_TYPE.Mongos, SERVER_TYPE.RSPrimary))
+            self._server_type in (SERVER_TYPE.Mongos, SERVER_TYPE.RSPrimary,
+                                  SERVER_TYPE.LoadBalancer))
 
     @property
     def retryable_reads_supported(self):

--- a/pymongo/server_type.py
+++ b/pymongo/server_type.py
@@ -20,4 +20,4 @@ from collections import namedtuple
 SERVER_TYPE = namedtuple('ServerType',
                          ['Unknown', 'Mongos', 'RSPrimary', 'RSSecondary',
                           'RSArbiter', 'RSOther', 'RSGhost',
-                          'Standalone'])(*range(8))
+                          'Standalone', 'LoadBalancer'])(*range(9))

--- a/pymongo/settings.py
+++ b/pymongo/settings.py
@@ -132,7 +132,9 @@ class TopologySettings(object):
         return self._load_balanced
 
     def get_topology_type(self):
-        if self.direct:
+        if self.load_balanced:
+            return TOPOLOGY_TYPE.LoadBalanced
+        elif self.direct:
             return TOPOLOGY_TYPE.Single
         elif self.replica_set_name is not None:
             return TOPOLOGY_TYPE.ReplicaSetNoPrimary

--- a/pymongo/topology.py
+++ b/pymongo/topology.py
@@ -34,6 +34,7 @@ from pymongo.errors import (ConnectionFailure,
                             PyMongoError,
                             ServerSelectionTimeoutError,
                             WriteError)
+from pymongo.ismaster import IsMaster
 from pymongo.monitor import SrvMonitor
 from pymongo.pool import PoolOptions
 from pymongo.server import Server
@@ -562,15 +563,7 @@ class Topology(object):
                 self._srv_monitor.open()
 
             if self._settings.load_balanced:
-                # Emit initial SDAM events:
-                # ServerDescriptionChangedEvent. The previousDescription MUST
-                # have ServerType Unknown. The newDescription MUST have
-                # ServerType
-                # LoadBalancer.
-                # TopologyDescriptionChangedEvent. The newDescription MUST have
-                # TopologyType LoadBalanced and one server with ServerType
-                # LoadBalancer.
-                from pymongo.ismaster import IsMaster
+                # Emit initial SDAM events for load balancer mode.
                 self._process_change(ServerDescription(
                     self._seed_addresses[0],
                     IsMaster({'ok': 1, 'serviceId': self._topology_id})))

--- a/pymongo/topology.py
+++ b/pymongo/topology.py
@@ -521,8 +521,8 @@ class Topology(object):
             if not self._settings.load_balanced:
                 session_timeout = self._check_session_support()
             else:
-                # TODO: make this None?
-                session_timeout = (1 << 63) - 1
+                # Sessions never time out in load balanced mode.
+                session_timeout = float('inf')
             return self._session_pool.get_server_session(session_timeout)
 
     def return_server_session(self, server_session, lock):

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -84,7 +84,7 @@ class TopologyDescription(object):
                                            for s in readable_servers)
 
     def _init_incompatible_err(self):
-        """Internal compatibl check helper."""
+        """Internal compatibility check for non-load balanced topologies."""
         for s in self._server_descriptions.values():
             if not s.is_server_type_known:
                 continue


### PR DESCRIPTION
This implements most of the load balancers spec changes: https://github.com/mongodb/specifications/blob/master/source/load-balancers/load-balancers.rst#server-discovery-and-monitoring

- Disable SRV Polling.
- Disable SDAM compatibility check.
- Disable logicalSessionTimeoutMinutes check.
- Disable server session pool pruning.
- Disable server selection.
- Disable Monitors.
- A ServerType of LoadBalancer MUST be considered a data-bearing server.
- "drivers MUST emit the following series of SDAM events" section.
- Send loadBalanced:True with handshakes, validate serviceId.
- Add topologyVersion fallback when serviceId is missing.
- Don't mark load balancers unknown from operation errors.

The notable things left out are testing and the various Connection Pooling changes:
- connection pinning
- serviceId -> generation mapping
- more informative WaitQueueTimeout error messages

I'm still working my way through testing. It is a bit involved because we need to update the retryable writes, reads, crud, change streams, uri options, transactions, SDAM, server selection, and unified format spec tests. Including going from schema version 1.1 to 1.4. I've decided to split that to a separate PR.