### PR TITLE
PYTHON-2729 PYTHON-2721 PYTHON-2730 Make 5.0 tests green

### DIFF
--- a/test/command_monitoring/find.json
+++ b/test/command_monitoring/find.json
@@ -415,6 +415,7 @@
     {
       "description": "A successful find event with a getmore and the server kills the cursor",
       "ignore_if_server_version_less_than": "3.1",
+      "ignore_if_server_version_greater_than": "4.9.0",
       "ignore_if_topology_type": [
         "sharded"
       ],

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1175,6 +1175,7 @@ class TestCollection(IntegrationTest):
         self.assertTrue("x" not in db.test.find_one(projection={"x": 0}))
         self.assertTrue("mike" in db.test.find_one(projection={"x": 0}))
 
+    @client_context.require_version_max(4, 9, -1)  # PYTHON-2721
     def test_find_w_regex(self):
         db = self.db
         db.test.delete_many({})

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -579,6 +579,9 @@ class TestCollection(IntegrationTest):
                 stage = self.get_plan_stage(i, stage)
                 if stage:
                     return stage
+        elif "queryPlan" in root:
+            # queryPlan (and slotBasedPlan) are new in 5.0.
+            return self.get_plan_stage(root["queryPlan"], stage)
         elif "shards" in root:
             for i in root['shards']:
                 stage = self.get_plan_stage(i['winningPlan'], stage)

--- a/test/unified-test-format/valid-pass/poc-command-monitoring.json
+++ b/test/unified-test-format/valid-pass/poc-command-monitoring.json
@@ -61,6 +61,7 @@
       "runOnRequirements": [
         {
           "minServerVersion": "3.1",
+          "maxServerVersion": "4.9.0",
           "topologies": [
             "single",
             "replicaset"


### PR DESCRIPTION
3 Changes to get the tests green:
- PYTHON-2729 Update explain response format parsing for 5.0
- PYTHON-2721 Temporarily skip failing regex test on 5.0
- PYTHON-2730 Temporarily skip failing killCursors tests on 5.0