### PR TITLE
PYTHON-2673 Connection pinning behavior for load balanced clusters

### DIFF
--- a/pymongo/aggregation.py
+++ b/pymongo/aggregation.py
@@ -161,11 +161,13 @@ class _AggregationCommand(object):
             }
 
         # Create and return cursor instance.
-        return self._cursor_class(
+        cmd_cursor = self._cursor_class(
             self._cursor_collection(cursor), cursor, sock_info.address,
             batch_size=self._batch_size or 0,
             max_await_time_ms=self._max_await_time_ms,
             session=session, explicit_session=self._explicit_session)
+        cmd_cursor._maybe_pin_connection(sock_info)
+        return cmd_cursor
 
 
 class _CollectionAggregationCommand(_AggregationCommand):

--- a/pymongo/change_stream.py
+++ b/pymongo/change_stream.py
@@ -181,7 +181,7 @@ class ChangeStream(object):
 
         return self._client._retryable_read(
             cmd.get_cursor, self._target._read_preference_for(session),
-            session)
+            session, pin=self._client._should_pin_cursor(session))
 
     def _create_cursor(self):
         with self._client._tmp_session(self._session, close=False) as s:

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -829,10 +829,6 @@ class ClientSession(object):
         self._server_session.last_use = time.monotonic()
         command['lsid'] = self._server_session.session_id
 
-        if not self.in_transaction:
-            # TODO: Confirm that this is not needed.
-            self._transaction.reset()
-
         if is_retryable:
             command['txnNumber'] = self._server_session.transaction_id
             return

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -807,9 +807,7 @@ class ClientSession(object):
         self._transaction.pinned_conn = None
         if conn:
             # TODO: How do we know conn won't be returned to the pool twice?
-            topology = self.client._topology
-            server = topology.get_server_by_address(conn.address)
-            server.pool.return_socket(conn)
+            self._client._return_socket(conn)
 
     def _txn_read_preference(self):
         """Return read preference of this transaction or None."""

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -108,6 +108,7 @@ from bson.int64 import Int64
 from bson.son import SON
 from bson.timestamp import Timestamp
 
+from pymongo.cursor import _SocketManager
 from pymongo.errors import (ConfigurationError,
                             ConnectionFailure,
                             InvalidOperation,
@@ -117,6 +118,7 @@ from pymongo.errors import (ConfigurationError,
 from pymongo.helpers import _RETRYABLE_ERROR_CODES
 from pymongo.read_concern import ReadConcern
 from pymongo.read_preferences import ReadPreference, _ServerMode
+from pymongo.server_type import SERVER_TYPE
 from pymongo.write_concern import WriteConcern
 
 
@@ -292,7 +294,7 @@ class _Transaction(object):
         self.state = _TxnState.NONE
         self.sharded = False
         self.pinned_address = None
-        self.pinned_conn = None
+        self.sock_mgr = None
         self.recovery_token = None
         self.attempt = 0
 
@@ -302,12 +304,29 @@ class _Transaction(object):
     def starting(self):
         return self.state == _TxnState.STARTING
 
+    @property
+    def pinned_conn(self):
+        if self.active() and self.sock_mgr:
+            return self.sock_mgr.sock
+        return None
+
+    def pin(self, server, sock_info):
+        self.sharded = True
+        self.pinned_address = server.description.address
+        if server.description.server_type == SERVER_TYPE.LoadBalancer:
+            sock_info.pinned = True
+            self.sock_mgr = _SocketManager(sock_info, False)
+
+    def unpin(self):
+        self.pinned_address = None
+        if self.sock_mgr:
+            self.sock_mgr.close()
+        self.sock_mgr = None
+
     def reset(self):
+        self.unpin()
         self.state = _TxnState.NONE
         self.sharded = False
-        self.pinned_address = None
-        # TODO: What if pinned_conn is non-None here?
-        self.pinned_conn = None
         self.recovery_token = None
         self.attempt = 0
 
@@ -590,7 +609,6 @@ class ClientSession(object):
 
         self._transaction.opts = TransactionOptions(
             read_concern, write_concern, read_preference, max_commit_time_ms)
-        self._unpin()
         self._transaction.reset()
         self._transaction.state = _TxnState.STARTING
         self._start_retryable_write()
@@ -786,31 +804,18 @@ class ClientSession(object):
             return self._transaction.pinned_address
         return None
 
-    def _pin(self, server):
-        """Pin this session to the given Server."""
-        self._transaction.sharded = True
-        self._transaction.pinned_address = server.description.address
-
     @property
     def _pinned_connection(self):
         """The connection this transaction was started on."""
-        if self._transaction.active():
-            return self._transaction.pinned_conn
-        return None
+        return self._transaction.pinned_conn
 
-    def _pin_connection(self, conn):
-        """Pin this session to the given connection."""
-        self._transaction.pinned_conn = conn
-        conn.pinned = True
+    def _pin(self, server, sock_info):
+        """Pin this session to the given Server or to the given connection."""
+        self._transaction.pin(server, sock_info)
 
     def _unpin(self):
         """Unpin this session from any pinned Server."""
-        self._transaction.pinned_address = None
-        conn = self._transaction.pinned_conn
-        self._transaction.pinned_conn = None
-        if conn:
-            # TODO: How do we know conn won't be returned to the pool twice?
-            conn.unpin()
+        self._transaction.unpin()
 
     def _txn_read_preference(self):
         """Return read preference of this transaction or None."""
@@ -825,6 +830,7 @@ class ClientSession(object):
         command['lsid'] = self._server_session.session_id
 
         if not self.in_transaction:
+            # TODO: Confirm that this is not needed.
             self._transaction.reset()
 
         if is_retryable:

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -379,7 +379,6 @@ class ClientSession(object):
                     self.abort_transaction()
                 # It's possible we're still pinned here when the transaction
                 # is in the committed state when the session is discarded.
-                # TODO: Write a test for this case.
                 self._unpin()
             finally:
                 self._client._return_server_session(self._server_session, lock)

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -520,7 +520,8 @@ class Collection(common.BaseObject):
         if publish:
             duration = datetime.datetime.now() - start
             listeners.publish_command_start(
-                cmd, self.__database.name, rqst_id, sock_info.address, op_id)
+                cmd, self.__database.name, rqst_id, sock_info.address, op_id,
+                sock_info.service_id)
             start = datetime.datetime.now()
         try:
             result = sock_info.legacy_write(rqst_id, msg, max_size, False)
@@ -534,12 +535,14 @@ class Collection(common.BaseObject):
                         reply = message._convert_write_result(
                             name, cmd, details)
                         listeners.publish_command_success(
-                            dur, reply, name, rqst_id, sock_info.address, op_id)
+                            dur, reply, name, rqst_id, sock_info.address,
+                            op_id, sock_info.service_id)
                         raise
                 else:
                     details = message._convert_exception(exc)
                 listeners.publish_command_failure(
-                    dur, details, name, rqst_id, sock_info.address, op_id)
+                    dur, details, name, rqst_id, sock_info.address, op_id,
+                    sock_info.service_id)
             raise
         if publish:
             if result is not None:
@@ -549,7 +552,8 @@ class Collection(common.BaseObject):
                 reply = {'ok': 1}
             duration = (datetime.datetime.now() - start) + duration
             listeners.publish_command_success(
-                duration, reply, name, rqst_id, sock_info.address, op_id)
+                duration, reply, name, rqst_id, sock_info.address, op_id,
+                sock_info.service_id)
         return result
 
     def _insert_one(

--- a/pymongo/command_cursor.py
+++ b/pymongo/command_cursor.py
@@ -138,7 +138,7 @@ class CommandCursor(object):
         if not client._should_pin_cursor(self.__session):
             return
         if not self.__sock_mgr:
-            sock_mgr = _SocketManager(sock_info, client, False)
+            sock_mgr = _SocketManager(sock_info, False)
             # Ensure the connection gets returned when the entire result is
             # returned in the first batch.
             if self.__id == 0:
@@ -167,7 +167,6 @@ class CommandCursor(object):
         if isinstance(response, PinnedResponse):
             if not self.__sock_mgr:
                 self.__sock_mgr = _SocketManager(response.socket_info,
-                                                 client,
                                                  response.more_to_come)
         if response.from_command:
             cursor = response.docs[0]['cursor']

--- a/pymongo/command_cursor.py
+++ b/pymongo/command_cursor.py
@@ -136,7 +136,7 @@ class CommandCursor(object):
 
         client = self.__collection.database.client
         try:
-            response = client._run_operation_with_response(
+            response = client._run_operation(
                 operation, self._unpack_response, address=self.__address)
         except OperationFailure:
             kill()
@@ -203,7 +203,7 @@ class CommandCursor(object):
                                     self.__session,
                                     self.__collection.database.client,
                                     self.__max_await_time_ms,
-                                    False))
+                                    None, False))
         else:  # Cursor id is zero nothing else to return
             self.__killed = True
             self.__end_session(True)

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -27,7 +27,6 @@ from pymongo import helpers
 from pymongo.common import validate_boolean, validate_is_mapping
 from pymongo.collation import validate_collation_or_none
 from pymongo.errors import (ConnectionFailure,
-                            CursorNotFound,
                             InvalidOperation,
                             OperationFailure)
 from pymongo.message import (_CursorAddress,

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -82,9 +82,8 @@ class CursorType(object):
 class _SocketManager:
     """Used with exhaust cursors to ensure the socket is returned.
     """
-    def __init__(self, sock, client, more_to_come):
+    def __init__(self, sock, more_to_come):
         self.sock = sock
-        self.client = client
         self.more_to_come = more_to_come
         self.__closed = False
         self.lock = threading.Lock()
@@ -100,8 +99,8 @@ class _SocketManager:
         """
         if not self.__closed:
             self.__closed = True
-            self.client._return_socket(self.sock)
-            self.sock, self.client = None, None
+            self.sock.unpin()
+            self.sock = None
 
 
 class Cursor(object):
@@ -1032,7 +1031,6 @@ class Cursor(object):
         if isinstance(response, PinnedResponse):
             if not self.__sock_mgr:
                 self.__sock_mgr = _SocketManager(response.socket_info,
-                                                 client,
                                                  response.more_to_come)
 
         cmd_name = operation.name

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -350,7 +350,7 @@ class Cursor(object):
 
         self.__killed = True
         if self.__id and not already_killed:
-            if self.__exhaust:
+            if self.__exhaust and self.__sock_mgr:
                 # If this is an exhaust cursor and we haven't completely
                 # exhausted the result set we *must* close the socket
                 # to stop the server from sending more data.
@@ -1040,7 +1040,7 @@ class Cursor(object):
             response = client._run_operation(
                 operation, self._unpack_response, address=self.__address)
         except OperationFailure as exc:
-            if exc.code in _CURSOR_CLOSED_ERRORS:
+            if exc.code in _CURSOR_CLOSED_ERRORS or self.__exhaust:
                 # Don't send killCursors because the cursor is already closed.
                 self.__killed = True
             self.close()

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -661,7 +661,6 @@ class Database(common.BaseObject):
         cmd_cursor._maybe_pin_connection(sock_info)
         return cmd_cursor
 
-
     def list_collections(self, session=None, filter=None, **kwargs):
         """Get a cursor over the collectons of this database.
 

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1555,7 +1555,8 @@ class MongoClient(common.BaseObject):
                 # tuple to match the rest of the monitoring
                 # API.
                 listeners.publish_command_start(
-                    spec, db, request_id, tuple(address))
+                    spec, db, request_id, tuple(address),
+                    service_id=sock_info.service_id)
                 start = datetime.datetime.now()
 
             try:
@@ -1566,7 +1567,7 @@ class MongoClient(common.BaseObject):
                     listeners.publish_command_failure(
                         dur, message._convert_exception(exc),
                         'killCursors', request_id,
-                        tuple(address))
+                        tuple(address), service_id=sock_info.service_id)
                 raise
 
             if publish:
@@ -1575,7 +1576,7 @@ class MongoClient(common.BaseObject):
                 reply = {'cursorsUnknown': cursor_ids, 'ok': 1}
                 listeners.publish_command_success(
                     duration, reply, 'killCursors', request_id,
-                    tuple(address))
+                    tuple(address), service_id=sock_info.service_id)
 
     def _process_kill_cursors(self):
         """Process any pending kill cursors requests."""

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1190,13 +1190,6 @@ class MongoClient(common.BaseObject):
                     session._pin_connection(sock_info)
                 yield sock_info
 
-    def _return_socket(self, sock_info):
-        server = self._topology.get_server_by_address(sock_info.address)
-        if server:
-            server.pool.return_socket(sock_info)
-        else:
-            sock_info.close(ConnectionClosedReason.STALE)
-
     def _select_server(self, server_selector, session, address=None):
         """Select a server to run an operation on this client.
 

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1168,12 +1168,8 @@ class MongoClient(common.BaseObject):
             if in_txn and session._pinned_connection:
                 yield session._pinned_connection
                 return
-            # TODO: confirm that pin_conn is not needed.
-            pin_conn = (in_txn and server.description.server_type ==
-                        SERVER_TYPE.LoadBalancer)
-            checkout = pin_conn or pin
             with server.get_socket(
-                    self.__all_credentials, checkout=checkout,
+                    self.__all_credentials, checkout=pin,
                     handler=err_handler) as sock_info:
                 # Pin this session to the selected server or connection.
                 if (in_txn and server.description.server_type in (
@@ -1202,7 +1198,7 @@ class MongoClient(common.BaseObject):
         try:
             topology = self._get_topology()
             if session and not session.in_transaction:
-                session._unpin()
+                session._transaction.reset()
             address = address or (session and session._pinned_address)
             if address:
                 # We're running a getMore or this session is pinned to a mongos.

--- a/pymongo/monitoring.py
+++ b/pymongo/monitoring.py
@@ -1310,7 +1310,8 @@ class _EventListeners(object):
                 self.__topology_listeners[:])
 
     def publish_command_start(self, command, database_name,
-                              request_id, connection_id, op_id=None):
+                              request_id, connection_id, op_id=None,
+                              service_id=None):
         """Publish a CommandStartedEvent to all command listeners.
 
         :Parameters:
@@ -1321,11 +1322,13 @@ class _EventListeners(object):
           - `connection_id`: The address (host, port) of the server this
             command was sent to.
           - `op_id`: The (optional) operation id for this operation.
+          - `service_id`: The service_id this command was sent to, or ``None``.
         """
         if op_id is None:
             op_id = request_id
         event = CommandStartedEvent(
-            command, database_name, request_id, connection_id, op_id)
+            command, database_name, request_id, connection_id, op_id,
+            service_id=service_id)
         for subscriber in self.__command_listeners:
             try:
                 subscriber.started(event)
@@ -1333,7 +1336,8 @@ class _EventListeners(object):
                 _handle_exception()
 
     def publish_command_success(self, duration, reply, command_name,
-                                request_id, connection_id, op_id=None):
+                                request_id, connection_id, op_id=None,
+                                service_id=None):
         """Publish a CommandSucceededEvent to all command listeners.
 
         :Parameters:
@@ -1344,11 +1348,13 @@ class _EventListeners(object):
           - `connection_id`: The address (host, port) of the server this
             command was sent to.
           - `op_id`: The (optional) operation id for this operation.
+          - `service_id`: The service_id this command was sent to, or ``None``.
         """
         if op_id is None:
             op_id = request_id
         event = CommandSucceededEvent(
-            duration, reply, command_name, request_id, connection_id, op_id)
+            duration, reply, command_name, request_id, connection_id, op_id,
+            service_id)
         for subscriber in self.__command_listeners:
             try:
                 subscriber.succeeded(event)
@@ -1356,7 +1362,8 @@ class _EventListeners(object):
                 _handle_exception()
 
     def publish_command_failure(self, duration, failure, command_name,
-                                request_id, connection_id, op_id=None):
+                                request_id, connection_id, op_id=None,
+                                service_id=None):
         """Publish a CommandFailedEvent to all command listeners.
 
         :Parameters:
@@ -1368,11 +1375,13 @@ class _EventListeners(object):
           - `connection_id`: The address (host, port) of the server this
             command was sent to.
           - `op_id`: The (optional) operation id for this operation.
+          - `service_id`: The service_id this command was sent to, or ``None``.
         """
         if op_id is None:
             op_id = request_id
         event = CommandFailedEvent(
-            duration, failure, command_name, request_id, connection_id, op_id)
+            duration, failure, command_name, request_id, connection_id, op_id,
+            service_id=service_id)
         for subscriber in self.__command_listeners:
             try:
                 subscriber.failed(event)

--- a/pymongo/network.py
+++ b/pymongo/network.py
@@ -134,7 +134,8 @@ def command(sock_info, dbname, spec, slave_ok, is_mongos,
 
     if publish:
         encoding_duration = datetime.datetime.now() - start
-        listeners.publish_command_start(orig, dbname, request_id, address)
+        listeners.publish_command_start(orig, dbname, request_id, address,
+                                        service_id=sock_info.service_id)
         start = datetime.datetime.now()
 
     try:
@@ -164,12 +165,14 @@ def command(sock_info, dbname, spec, slave_ok, is_mongos,
             else:
                 failure = message._convert_exception(exc)
             listeners.publish_command_failure(
-                duration, failure, name, request_id, address)
+                duration, failure, name, request_id, address,
+                service_id=sock_info.service_id)
         raise
     if publish:
         duration = (datetime.datetime.now() - start) + encoding_duration
         listeners.publish_command_success(
-            duration, response_doc, name, request_id, address)
+            duration, response_doc, name, request_id, address,
+            service_id=sock_info.service_id)
 
     if client and client._encrypter and reply:
         decrypted = client._encrypter.decrypt(reply.raw_command_response())

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -723,7 +723,7 @@ class SocketInfo(object):
                            unacknowledged=unacknowledged,
                            user_fields=user_fields,
                            exhaust_allowed=exhaust_allowed)
-        except OperationFailure:
+        except (OperationFailure, NotMasterError):
             raise
         # Catch socket.error, KeyboardInterrupt, etc. and close ourselves.
         except BaseException as error:

--- a/pymongo/response.py
+++ b/pymongo/response.py
@@ -69,9 +69,9 @@ class Response(object):
 
 
 class PinnedResponse(Response):
-    __slots__ = ('_socket_info', '_pool', '_more_to_come')
+    __slots__ = ('_socket_info', '_more_to_come')
 
-    def __init__(self, data, address, socket_info, pool, request_id, duration,
+    def __init__(self, data, address, socket_info, request_id, duration,
                  from_command, docs, more_to_come):
         """Represent a response to an exhaust cursor's initial query.
 
@@ -93,7 +93,6 @@ class PinnedResponse(Response):
                                              duration,
                                              from_command, docs)
         self._socket_info = socket_info
-        self._pool = pool
         self._more_to_come = more_to_come
 
     @property
@@ -105,11 +104,6 @@ class PinnedResponse(Response):
         is an error.
         """
         return self._socket_info
-
-    @property
-    def pool(self):
-        """The Pool from which the SocketInfo came."""
-        return self._pool
 
     @property
     def more_to_come(self):

--- a/pymongo/response.py
+++ b/pymongo/response.py
@@ -68,7 +68,7 @@ class Response(object):
         return self._docs
 
 
-class ExhaustResponse(Response):
+class PinnedResponse(Response):
     __slots__ = ('_socket_info', '_pool', '_more_to_come')
 
     def __init__(self, data, address, socket_info, pool, request_id, duration,
@@ -87,11 +87,11 @@ class ExhaustResponse(Response):
           - `more_to_come`: Bool indicating whether cursor is ready to be
             exhausted.
         """
-        super(ExhaustResponse, self).__init__(data,
-                                              address,
-                                              request_id,
-                                              duration,
-                                              from_command, docs)
+        super(PinnedResponse, self).__init__(data,
+                                             address,
+                                             request_id,
+                                             duration,
+                                             from_command, docs)
         self._socket_info = socket_info
         self._pool = pool
         self._more_to_come = more_to_come

--- a/pymongo/server.py
+++ b/pymongo/server.py
@@ -176,11 +176,12 @@ class Server(object):
             else:
                 # In OP_REPLY, the server keeps sending until cursor_id is 0.
                 more_to_come = bool(operation.exhaust and reply.cursor_id)
+            if operation.sock_mgr:
+                operation.sock_mgr.update_exhaust(more_to_come)
             response = PinnedResponse(
                 data=reply,
                 address=self._description.address,
                 socket_info=sock_info,
-                pool=self._pool,
                 duration=duration,
                 request_id=request_id,
                 from_command=use_cmd,

--- a/pymongo/server.py
+++ b/pymongo/server.py
@@ -102,7 +102,8 @@ class Server(object):
         if publish:
             cmd, dbn = operation.as_command(sock_info)
             listeners.publish_command_start(
-                cmd, dbn, request_id, sock_info.address)
+                cmd, dbn, request_id, sock_info.address,
+                service_id=sock_info.service_id)
             start = datetime.now()
 
         try:
@@ -136,7 +137,8 @@ class Server(object):
                     failure = _convert_exception(exc)
                 listeners.publish_command_failure(
                     duration, failure, operation.name,
-                    request_id, sock_info.address)
+                    request_id, sock_info.address,
+                    service_id=sock_info.service_id)
             raise
 
         if publish:
@@ -157,7 +159,7 @@ class Server(object):
                     res["cursor"]["nextBatch"] = docs
             listeners.publish_command_success(
                 duration, res, operation.name, request_id,
-                sock_info.address)
+                sock_info.address, service_id=sock_info.service_id)
 
         # Decrypt response.
         client = operation.client

--- a/pymongo/server.py
+++ b/pymongo/server.py
@@ -21,7 +21,7 @@ from bson import _decode_all_selective
 from pymongo.errors import NotMasterError, OperationFailure
 from pymongo.helpers import _check_command_response
 from pymongo.message import _convert_exception, _OpMsg
-from pymongo.response import Response, ExhaustResponse
+from pymongo.response import Response, PinnedResponse
 from pymongo.server_type import SERVER_TYPE
 
 _CURSOR_DOC_FIELDS = {'cursor': {'firstBatch': 1, 'nextBatch': 1}}
@@ -68,14 +68,8 @@ class Server(object):
         """Check the server's state soon."""
         self._monitor.request_check()
 
-    def run_operation_with_response(
-            self,
-            sock_info,
-            operation,
-            set_slave_okay,
-            listeners,
-            exhaust,
-            unpack_res):
+    def run_operation(self, sock_info, operation, set_slave_okay, listeners,
+                      pin, unpack_res):
         """Run a _Query or _GetMore operation and return a Response object.
 
         This method is used only to run _Query/_GetMore operations from
@@ -87,7 +81,7 @@ class Server(object):
           - `set_slave_okay`: Pass to operation.get_message.
           - `all_credentials`: dict, maps auth source to MongoCredential.
           - `listeners`: Instance of _EventListeners or None.
-          - `exhaust`: If True, then this is an exhaust cursor operation.
+          - `pin`: If True, then this is a pinned cursor operation.
           - `unpack_res`: A callable that decodes the wire protocol response.
         """
         duration = None
@@ -95,9 +89,9 @@ class Server(object):
         if publish:
             start = datetime.now()
 
-        use_cmd = operation.use_command(sock_info, exhaust)
-        more_to_come = (operation.exhaust_mgr
-                        and operation.exhaust_mgr.more_to_come)
+        use_cmd = operation.use_command(sock_info)
+        more_to_come = (operation.sock_mgr
+                        and operation.sock_mgr.more_to_come)
         if more_to_come:
             request_id = 0
         else:
@@ -174,15 +168,15 @@ class Server(object):
                 docs = _decode_all_selective(
                     decrypted, operation.codec_options, user_fields)
 
-        if exhaust:
+        if pin:
             if isinstance(reply, _OpMsg):
                 # In OP_MSG, the server keeps sending only if the
                 # more_to_come flag is set.
                 more_to_come = reply.more_to_come
             else:
                 # In OP_REPLY, the server keeps sending until cursor_id is 0.
-                more_to_come = bool(reply.cursor_id)
-            response = ExhaustResponse(
+                more_to_come = bool(operation.exhaust and reply.cursor_id)
+            response = PinnedResponse(
                 data=reply,
                 address=self._description.address,
                 socket_info=sock_info,
@@ -203,8 +197,8 @@ class Server(object):
 
         return response
 
-    def get_socket(self, all_credentials, checkout=False):
-        return self.pool.get_socket(all_credentials, checkout)
+    def get_socket(self, all_credentials, checkout=False, handler=None):
+        return self.pool.get_socket(all_credentials, checkout, handler)
 
     @property
     def description(self):

--- a/test/load_balancer/test_load_balancer.py
+++ b/test/load_balancer/test_load_balancer.py
@@ -19,8 +19,8 @@ import sys
 
 sys.path[0:0] = [""]
 
-from test import unittest
-
+from test import unittest, IntegrationTest, client_context
+from test.utils import get_pool
 from test.unified_format import generate_test_classes
 
 # Location of JSON test specifications.
@@ -29,6 +29,24 @@ TEST_PATH = os.path.join(
 
 # Generate unified tests.
 globals().update(generate_test_classes(TEST_PATH, module=__name__))
+
+
+class TestLB(IntegrationTest):
+    @client_context.require_load_balancer
+    def test_unpin_committed_transaction(self):
+        pool = get_pool(self.client)
+        with self.client.start_session() as session:
+            with session.start_transaction():
+                self.assertEqual(pool.active_sockets, 0)
+                self.db.test.insert_one({}, session=session)
+                self.assertEqual(pool.active_sockets, 1)  # Pinned.
+            self.assertEqual(pool.active_sockets, 1)  # Still pinned.
+        self.assertEqual(pool.active_sockets, 0)  # Unpinned.
+
+    def test_client_can_be_reopened(self):
+        self.client.close()
+        self.db.test.find_one({})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/load_balancer/unified/cursors.json
+++ b/test/load_balancer/unified/cursors.json
@@ -1,0 +1,1228 @@
+{
+  "description": "cursors are correctly pinned to connections for load-balanced clusters",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent",
+          "connectionReadyEvent",
+          "connectionClosedEvent",
+          "connectionCheckedOutEvent",
+          "connectionCheckedInEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection2",
+        "database": "database0",
+        "collectionName": "coll2"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "database0Name",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "database0Name",
+      "documents": []
+    },
+    {
+      "collectionName": "coll2",
+      "databaseName": "database0Name",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "no connection is pinned if all documents are returned in the initial batch",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {}
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {}
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are returned when the cursor is drained",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 2
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 3
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "ns": {
+                      "$$type": "string"
+                    },
+                    "nextBatch": {
+                      "$$type": "array"
+                    }
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are returned to the pool when the cursor is closed",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are not returned after an network error during getMore",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 2
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are returned after a network error during a killCursors request",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "killCursors"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are not returned to the pool after a non-network error on getMore",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "errorCode": 7
+              }
+            }
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 2
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectError": {
+            "errorCode": 7
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "aggregate pins the cursor to a connection",
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "batchSize": 2
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "cursor": {
+                    "batchSize": 2
+                  }
+                },
+                "commandName": "aggregate"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "aggregate"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "ns": {
+                      "$$type": "string"
+                    },
+                    "nextBatch": {
+                      "$$type": "array"
+                    }
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listCollections pins the cursor to a connection",
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "cursor": {
+                    "batchSize": 2
+                  }
+                },
+                "commandName": "listCollections",
+                "databaseName": "database0Name"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "listCollections"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": {
+                    "$$type": "string"
+                  }
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "ns": {
+                      "$$type": "string"
+                    },
+                    "nextBatch": {
+                      "$$type": "array"
+                    }
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listIndexes pins the cursor to a connection",
+      "operations": [
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "name": "x_1"
+          }
+        },
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "y": 1
+            },
+            "name": "y_1"
+          }
+        },
+        {
+          "name": "listIndexes",
+          "object": "collection0",
+          "arguments": {
+            "batchSize": 2
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "coll0",
+                  "indexes": [
+                    {
+                      "name": "x_1",
+                      "key": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                },
+                "commandName": "createIndexes"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "createIndexes"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "coll0",
+                  "indexes": [
+                    {
+                      "name": "y_1",
+                      "key": {
+                        "y": 1
+                      }
+                    }
+                  ]
+                },
+                "commandName": "createIndexes"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "createIndexes"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listIndexes": "coll0",
+                  "cursor": {
+                    "batchSize": 2
+                  }
+                },
+                "commandName": "listIndexes",
+                "databaseName": "database0Name"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "listIndexes"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "ns": {
+                      "$$type": "string"
+                    },
+                    "nextBatch": {
+                      "$$type": "array"
+                    }
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "change streams pin to a connection",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "changeStream0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "aggregate"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "aggregate"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/load_balancer/unified/cursors.json
+++ b/test/load_balancer/unified/cursors.json
@@ -376,7 +376,7 @@
       ]
     },
     {
-      "description": "pinned connections are not returned after an network error during getMore",
+      "description": "pinned connections are returned after an network error during getMore",
       "operations": [
         {
           "name": "failPoint",
@@ -440,7 +440,7 @@
           "object": "testRunner",
           "arguments": {
             "client": "client0",
-            "connections": 1
+            "connections": 0
           }
         },
         {
@@ -659,7 +659,7 @@
       ]
     },
     {
-      "description": "pinned connections are not returned to the pool after a non-network error on getMore",
+      "description": "pinned connections are returned to the pool after a non-network error on getMore",
       "operations": [
         {
           "name": "failPoint",
@@ -715,7 +715,7 @@
           "object": "testRunner",
           "arguments": {
             "client": "client0",
-            "connections": 1
+            "connections": 0
           }
         },
         {

--- a/test/load_balancer/unified/sdam-error-handling.json
+++ b/test/load_balancer/unified/sdam-error-handling.json
@@ -1,0 +1,508 @@
+{
+  "description": "state change errors are correctly handled",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "observedEvents": [
+      "connectionCreatedEvent",
+      "connectionReadyEvent",
+      "connectionCheckedOutEvent",
+      "connectionCheckOutFailedEvent",
+      "connectionCheckedInEvent",
+      "connectionClosedEvent",
+      "poolClearedEvent"
+    ]
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "failPointClient",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "client": {
+        "id": "singleClient",
+        "useMultipleMongoses": false,
+        "uriOptions": {
+          "appname": "lbSDAMErrorTestClient",
+          "retryWrites": false
+        },
+        "observeEvents": [
+          "connectionCreatedEvent",
+          "connectionReadyEvent",
+          "connectionCheckedOutEvent",
+          "connectionCheckOutFailedEvent",
+          "connectionCheckedInEvent",
+          "connectionClosedEvent",
+          "poolClearedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "singleDB",
+        "client": "singleClient",
+        "databaseName": "singleDB"
+      }
+    },
+    {
+      "collection": {
+        "id": "singleColl",
+        "database": "singleDB",
+        "collectionName": "singleColl"
+      }
+    },
+    {
+      "client": {
+        "id": "multiClient",
+        "useMultipleMongoses": true,
+        "uriOptions": {
+          "retryWrites": false
+        },
+        "observeEvents": [
+          "connectionCreatedEvent",
+          "connectionReadyEvent",
+          "connectionCheckedOutEvent",
+          "connectionCheckOutFailedEvent",
+          "connectionCheckedInEvent",
+          "connectionClosedEvent",
+          "poolClearedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "multiDB",
+        "client": "multiClient",
+        "databaseName": "multiDB"
+      }
+    },
+    {
+      "collection": {
+        "id": "multiColl",
+        "database": "multiDB",
+        "collectionName": "multiColl"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "singleColl",
+      "databaseName": "singleDB",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    },
+    {
+      "collectionName": "multiColl",
+      "databaseName": "multiDB",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "only connections for a specific serviceId are closed when pools are cleared",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "multiColl",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "createFindCursor",
+          "object": "multiColl",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor1"
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "close",
+          "object": "cursor1"
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "multiClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "multiColl",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "errorCode": 11600
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "multiColl",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "multiClient",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "errors during the initial connection hello are ignore",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "isMaster"
+                ],
+                "closeConnection": true,
+                "appName": "lbSDAMErrorTestClient"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "singleColl",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "singleClient",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionCheckOutFailedEvent": {
+                "reason": "connectionError"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "errors during authentication are processed",
+      "runOnRequirements": [
+        {
+          "auth": true
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "saslContinue"
+                ],
+                "closeConnection": true,
+                "appName": "lbSDAMErrorTestClient"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "singleColl",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "singleClient",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionCheckOutFailedEvent": {
+                "reason": "connectionError"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "stale errors are ignored",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "singleColl",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "createFindCursor",
+          "object": "singleColl",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor1"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor1"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor1"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor1",
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor1"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "singleClient",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/load_balancer/unified/sdam-error-handling.json
+++ b/test/load_balancer/unified/sdam-error-handling.json
@@ -240,8 +240,8 @@
               "connectionCheckedInEvent": {}
             },
             {
-              "connectionClosedEvent": {
-                "reason": "error"
+              "connectionClosedEvent":  {
+                "reason": "stale"
               }
             },
             {

--- a/test/load_balancer/unified/sdam-error-handling.json
+++ b/test/load_balancer/unified/sdam-error-handling.json
@@ -367,9 +367,6 @@
               "connectionCreatedEvent": {}
             },
             {
-              "poolClearedEvent": {}
-            },
-            {
               "connectionClosedEvent": {
                 "reason": "error"
               }
@@ -378,6 +375,9 @@
               "connectionCheckOutFailedEvent": {
                 "reason": "connectionError"
               }
+            },
+            {
+              "poolClearedEvent": {}
             }
           ]
         }

--- a/test/load_balancer/unified/transactions.json
+++ b/test/load_balancer/unified/transactions.json
@@ -1,0 +1,1606 @@
+{
+  "description": "transactions are correctly pinned to connections for load-balanced clusters",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent",
+          "connectionReadyEvent",
+          "connectionClosedEvent",
+          "connectionCheckedOutEvent",
+          "connectionCheckedInEvent"
+        ]
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "database0Name",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "documents": [
+      {
+        "_id": 4
+      }
+    ]
+  },
+  "tests": [
+    {
+      "description": "sessions are reused in LB mode",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ]
+    },
+    {
+      "description": "all operations go to the same mongos",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "transaction can be committed multiple times",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is not released after a non-transient CRUD error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 51
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          },
+          "expectError": {
+            "errorCode": 51,
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is not released after a non-transient commit error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction"
+                ],
+                "errorCode": 51
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "expectError": {
+            "errorCode": 51,
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a non-transient abort error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "errorCode": 51
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient non-network CRUD error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 24
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          },
+          "expectError": {
+            "errorCode": 24,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient network CRUD error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          },
+          "expectError": {
+            "isClientError": true,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient non-network commit error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction"
+                ],
+                "errorCode": 24
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "expectError": {
+            "errorCode": 24,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient network commit error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "ignoreResultAndError": true
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient non-network abort error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "errorCode": 24
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient network abort error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released on successful abort",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is returned when a new transaction is started",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is returned when a non-transaction operation uses the session",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "a connection can be shared by a transaction and a cursor",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2,
+            "session": "session0"
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/pymongo_mocks.py
+++ b/test/pymongo_mocks.py
@@ -40,7 +40,7 @@ class MockPool(Pool):
         Pool.__init__(self, (client_context.host, client_context.port), *args, **kwargs)
 
     @contextlib.contextmanager
-    def get_socket(self, all_credentials, checkout=False):
+    def get_socket(self, all_credentials, checkout=False, handler=None):
         client = self.client
         host_and_port = '%s:%s' % (self.mock_host, self.mock_port)
         if host_and_port in client.mock_down_hosts:
@@ -51,7 +51,8 @@ class MockPool(Pool):
             + client.mock_members
             + client.mock_mongoses), "bad host: %s" % host_and_port
 
-        with Pool.get_socket(self, all_credentials, checkout) as sock_info:
+        with Pool.get_socket(
+                self, all_credentials, checkout, handler) as sock_info:
             sock_info.mock_host = self.mock_host
             sock_info.mock_port = self.mock_port
             yield sock_info

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1323,11 +1323,11 @@ class TestClient(IntegrationTest):
         with self.assertRaises(AutoReconnect):
             client = rs_client(connect=False,
                                serverSelectionTimeoutMS=100)
-            client._run_operation_with_response(
+            client._run_operation(
                 operation=message._GetMore('pymongo_test', 'collection',
                                            101, 1234, client.codec_options,
                                            ReadPreference.PRIMARY,
-                                           None, client, None, None),
+                                           None, client, None, None, False),
                 unpack_res=Cursor(
                     client.pymongo_test.collection)._unpack_response,
                 address=('not-a-member', 27017))
@@ -1708,7 +1708,7 @@ class TestExhaustCursor(IntegrationTest):
         cursor.next()
 
         # Cause a network error.
-        sock_info = cursor._Cursor__exhaust_mgr.sock
+        sock_info = cursor._Cursor__sock_mgr.sock
         sock_info.sock.close()
 
         # A getmore fails.

--- a/test/test_monitoring.py
+++ b/test/test_monitoring.py
@@ -20,6 +20,7 @@ import warnings
 
 sys.path[0:0] = [""]
 
+from bson.int64 import Int64
 from bson.objectid import ObjectId
 from bson.son import SON
 from pymongo import CursorType, monitoring, InsertOne, UpdateOne, DeleteOne
@@ -397,7 +398,8 @@ class TestCommandMonitoring(PyMongoTestCase):
     def test_get_more_failure(self):
         address = self.client.address
         coll = self.client.pymongo_test.test
-        cursor_doc = {"id": 12345, "firstBatch": [], "ns": coll.full_name}
+        cursor_id = Int64(12345)
+        cursor_doc = {"id": cursor_id, "firstBatch": [], "ns": coll.full_name}
         cursor = CommandCursor(coll, cursor_doc, address)
         try:
             next(cursor)
@@ -410,7 +412,7 @@ class TestCommandMonitoring(PyMongoTestCase):
         self.assertTrue(
             isinstance(started, monitoring.CommandStartedEvent))
         self.assertEqualCommand(
-            SON([('getMore', 12345),
+            SON([('getMore', cursor_id),
                  ('collection', 'test')]),
             started.command)
         self.assertEqual('getMore', started.command_name)

--- a/test/test_read_preferences.py
+++ b/test/test_read_preferences.py
@@ -322,10 +322,9 @@ class ReadPrefTester(MongoClient):
             yield sock_info, slave_ok
 
     @contextlib.contextmanager
-    def _slaveok_for_server(self, read_preference, server, session,
-                            exhaust=False):
+    def _slaveok_for_server(self, read_preference, server, session, pin=False):
         context = super(ReadPrefTester, self)._slaveok_for_server(
-            read_preference, server, session, exhaust=exhaust)
+            read_preference, server, session, pin=pin)
         with context as (sock_info, slave_ok):
             self.record_a_read(sock_info.address)
             yield sock_info, slave_ok

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -559,8 +559,10 @@ class MatchEvaluatorUtil(object):
             if spec.get('hasServiceId'):
                 self.test.assertIsNotNone(actual.service_id)
                 self.test.assertIsInstance(actual.service_id, ObjectId)
-            else:
-                self.test.assertIsNone(actual.service_id)
+            # TODO: report bug missing hasServiceId:
+            # https://github.com/mongodb/specifications/blob/master/source/load-balancers/tests/sdam-error-handling.yml#L128
+            # else:
+            #     self.test.assertIsNone(actual.service_id)
         elif name == 'poolClosedEvent':
             self.test.assertIsInstance(actual, PoolClosedEvent)
         elif name == 'connectionCreatedEvent':
@@ -569,12 +571,14 @@ class MatchEvaluatorUtil(object):
             self.test.assertIsInstance(actual, ConnectionReadyEvent)
         elif name == 'connectionClosedEvent':
             self.test.assertIsInstance(actual, ConnectionClosedEvent)
-            self.test.assertEqual(actual.reason, spec['reason'])
+            if 'reason' in spec:
+                self.test.assertEqual(actual.reason, spec['reason'])
         elif name == 'connectionCheckOutStartedEvent':
             self.test.assertIsInstance(actual, ConnectionCheckOutStartedEvent)
         elif name == 'connectionCheckOutFailedEvent':
             self.test.assertIsInstance(actual, ConnectionCheckOutFailedEvent)
-            self.test.assertEqual(actual.reason, spec['reason'])
+            if 'reason' in spec:
+                self.test.assertEqual(actual.reason, spec['reason'])
         elif name == 'connectionCheckedOutEvent':
             self.test.assertIsInstance(actual, ConnectionCheckedOutEvent)
         elif name == 'connectionCheckedInEvent':

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -519,6 +519,14 @@ class MatchEvaluatorUtil(object):
             self.test.assertIsInstance(actual, type(expectation))
             self.test.assertEqual(expectation, actual)
 
+    def assertHasServiceId(self, spec, actual):
+        if 'hasServiceId' in spec:
+            if spec.get('hasServiceId'):
+                self.test.assertIsNotNone(actual.service_id)
+                self.test.assertIsInstance(actual.service_id, ObjectId)
+            else:
+                self.test.assertIsNone(actual.service_id)
+
     def match_event(self, event_type, expectation, actual):
         name, spec = next(iter(expectation.items()))
 
@@ -543,26 +551,23 @@ class MatchEvaluatorUtil(object):
             if database_name:
                 self.test.assertEqual(
                     database_name, actual.database_name)
+            self.assertHasServiceId(spec, actual)
         elif name == 'commandSucceededEvent':
             self.test.assertIsInstance(actual, CommandSucceededEvent)
             reply = spec.get('reply')
             if reply:
                 self.match_result(reply, actual.reply)
+            self.assertHasServiceId(spec, actual)
         elif name == 'commandFailedEvent':
             self.test.assertIsInstance(actual, CommandFailedEvent)
+            self.assertHasServiceId(spec, actual)
         elif name == 'poolCreatedEvent':
             self.test.assertIsInstance(actual, PoolCreatedEvent)
         elif name == 'poolReadyEvent':
             self.test.assertIsInstance(actual, PoolReadyEvent)
         elif name == 'poolClearedEvent':
             self.test.assertIsInstance(actual, PoolClearedEvent)
-            if spec.get('hasServiceId'):
-                self.test.assertIsNotNone(actual.service_id)
-                self.test.assertIsInstance(actual.service_id, ObjectId)
-            # TODO: report bug missing hasServiceId:
-            # https://github.com/mongodb/specifications/blob/master/source/load-balancers/tests/sdam-error-handling.yml#L128
-            # else:
-            #     self.test.assertIsNone(actual.service_id)
+            self.assertHasServiceId(spec, actual)
         elif name == 'poolClosedEvent':
             self.test.assertIsInstance(actual, PoolClosedEvent)
         elif name == 'connectionCreatedEvent':

--- a/test/utils.py
+++ b/test/utils.py
@@ -267,7 +267,7 @@ class MockPool(object):
     def stale_generation(self, gen, service_id):
         return self.gen.stale(gen, service_id)
 
-    def get_socket(self, all_credentials, checkout=False):
+    def get_socket(self, all_credentials, checkout=False, handler=None):
         return MockSocketInfo()
 
     def return_socket(self, *args, **kwargs):


### PR DESCRIPTION

- [X] Connection pinning for transactions. In a transaction the first connection checked out of the pool becomes pinned to the session. The session follows the normal rules for unpinning outlined in the transaction spec.
- [X] Connection pinning for find cursors (outside a transaction). The connection gets pinned using the "SocketManager" class.
- [x] Connection pinning for CommandCursors (EG aggregate, list collections, etc..). Should work similarly to the Cursor class but the initial aggregate command uses a different execution path.