### PR TITLE
PYTHON-2734 Document that find_raw_batches now sends user-specified R…

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1485,7 +1485,7 @@ class Collection(common.BaseObject):
 
         .. versionchanged:: 3.12
            Instead of ignoring the user-specified read concern, this method
-           now sends it to the server when connected to MongoDB 3.2+.
+           now sends it to the server when connected to MongoDB 3.6+.
 
         .. versionadded:: 3.6
         """

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1484,8 +1484,8 @@ class Collection(common.BaseObject):
            encryption.
 
         .. versionchanged:: 3.12
-           Instead of raising ConfigurationError, this method now sends the
-           user-specified read concern to the server.
+           Instead of ignoring the user-specified read concern, this method
+           now sends it to the server.
 
         .. versionadded:: 3.6
         """

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1485,7 +1485,7 @@ class Collection(common.BaseObject):
 
         .. versionchanged:: 3.12
            Instead of ignoring the user-specified read concern, this method
-           now sends it to the server.
+           now sends it to the server when connected to MongoDB 3.2+.
 
         .. versionadded:: 3.6
         """

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1483,6 +1483,10 @@ class Collection(common.BaseObject):
         .. note:: find_raw_batches does not support sessions or auto
            encryption.
 
+        .. versionchanged:: 3.12
+           Instead of raising ConfigurationError, this method now sends the
+           user-specified read concern to the server.
+
         .. versionadded:: 3.6
         """
         # OP_MSG with document stream returns is required to support

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -1514,6 +1514,7 @@ class TestRawBatchCursor(IntegrationTest):
             next(self.db.test.find_raw_batches(collation=Collation('en_US')))
 
     @client_context.require_version_min(3, 2)
+    @client_context.require_no_mmap   # MMAPv1 does not support read concern
     def test_read_concern(self):
         self.db.get_collection(
             "test", write_concern=WriteConcern(w="majority")).insert_one({})


### PR DESCRIPTION
…eadConcern to the server instead of raising ConfigurationError