### PR TITLE
PYTHON-2744 Run LB tests against non-LB clusters

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -97,6 +97,9 @@ TEST_LOADBALANCER = bool(os.environ.get("TEST_LOADBALANCER"))
 SINGLE_MONGOS_LB_URI = os.environ.get("SINGLE_MONGOS_LB_URI")
 MULTI_MONGOS_LB_URI = os.environ.get("MULTI_MONGOS_LB_URI")
 if TEST_LOADBALANCER:
+    # Remove after PYTHON-2712
+    from pymongo import pool
+    pool._MOCK_SERVICE_ID = True
     res = parse_uri(SINGLE_MONGOS_LB_URI)
     host, port = res['nodelist'][0]
     db_user = res['username'] or db_user

--- a/test/load_balancer/test_crud_unified.py
+++ b/test/load_balancer/test_crud_unified.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import sys
-import unittest
 
 sys.path[0:0] = [""]
 
+from test import unittest
 from test.test_crud_unified import *
 
 if __name__ == '__main__':

--- a/test/load_balancer/test_dns.py
+++ b/test/load_balancer/test_dns.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import sys
-import unittest
 
 sys.path[0:0] = [""]
 
+from test import unittest
 from test.test_dns import *
 
 if __name__ == '__main__':

--- a/test/load_balancer/test_load_balancer.py
+++ b/test/load_balancer/test_load_balancer.py
@@ -14,38 +14,12 @@
 
 """Test the Load Balancer unified spec tests."""
 
-import os
 import sys
 
 sys.path[0:0] = [""]
 
-from test import unittest, IntegrationTest, client_context
-from test.utils import get_pool
-from test.unified_format import generate_test_classes
-
-# Location of JSON test specifications.
-TEST_PATH = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), 'unified')
-
-# Generate unified tests.
-globals().update(generate_test_classes(TEST_PATH, module=__name__))
-
-
-class TestLB(IntegrationTest):
-    @client_context.require_load_balancer
-    def test_unpin_committed_transaction(self):
-        pool = get_pool(self.client)
-        with self.client.start_session() as session:
-            with session.start_transaction():
-                self.assertEqual(pool.active_sockets, 0)
-                self.db.test.insert_one({}, session=session)
-                self.assertEqual(pool.active_sockets, 1)  # Pinned.
-            self.assertEqual(pool.active_sockets, 1)  # Still pinned.
-        self.assertEqual(pool.active_sockets, 0)  # Unpinned.
-
-    def test_client_can_be_reopened(self):
-        self.client.close()
-        self.db.test.find_one({})
+from test import unittest
+from test.test_load_balancer import *
 
 
 if __name__ == "__main__":

--- a/test/load_balancer/test_retryable_change_stream.py
+++ b/test/load_balancer/test_retryable_change_stream.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import sys
-import unittest
 
 sys.path[0:0] = [""]
 
+from test import unittest
 from test.test_change_stream import *
 
 if __name__ == '__main__':

--- a/test/load_balancer/test_retryable_reads.py
+++ b/test/load_balancer/test_retryable_reads.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import sys
-import unittest
 
 sys.path[0:0] = [""]
 
+from test import unittest
 from test.test_retryable_reads import *
 
 if __name__ == '__main__':

--- a/test/load_balancer/test_retryable_writes.py
+++ b/test/load_balancer/test_retryable_writes.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import sys
-import unittest
 
 sys.path[0:0] = [""]
 
+from test import unittest
 from test.test_retryable_writes import *
 
 if __name__ == '__main__':

--- a/test/load_balancer/test_transactions_unified.py
+++ b/test/load_balancer/test_transactions_unified.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import sys
-import unittest
 
 sys.path[0:0] = [""]
 
+from test import unittest
 from test.test_transactions_unified import *
 
 if __name__ == '__main__':

--- a/test/load_balancer/test_uri_options.py
+++ b/test/load_balancer/test_uri_options.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import sys
-import unittest
 
 sys.path[0:0] = [""]
 
+from test import unittest
 from test.test_uri_spec import *
 
 if __name__ == '__main__':

--- a/test/load_balancer/test_versioned_api.py
+++ b/test/load_balancer/test_versioned_api.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import sys
-import unittest
 
 sys.path[0:0] = [""]
 
+from test import unittest
 from test.test_versioned_api import *
 
 if __name__ == '__main__':

--- a/test/test_load_balancer.py
+++ b/test/test_load_balancer.py
@@ -1,0 +1,52 @@
+# Copyright 2021-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the Load Balancer unified spec tests."""
+
+import os
+import sys
+
+sys.path[0:0] = [""]
+
+from test import unittest, IntegrationTest, client_context
+from test.utils import get_pool
+from test.unified_format import generate_test_classes
+
+# Location of JSON test specifications.
+TEST_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), 'load_balancer', 'unified')
+
+# Generate unified tests.
+globals().update(generate_test_classes(TEST_PATH, module=__name__))
+
+
+class TestLB(IntegrationTest):
+    @client_context.require_load_balancer
+    def test_unpin_committed_transaction(self):
+        pool = get_pool(self.client)
+        with self.client.start_session() as session:
+            with session.start_transaction():
+                self.assertEqual(pool.active_sockets, 0)
+                self.db.test.insert_one({}, session=session)
+                self.assertEqual(pool.active_sockets, 1)  # Pinned.
+            self.assertEqual(pool.active_sockets, 1)  # Still pinned.
+        self.assertEqual(pool.active_sockets, 0)  # Unpinned.
+
+    def test_client_can_be_reopened(self):
+        self.client.close()
+        self.db.test.find_one({})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -891,6 +891,10 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             if expect_error:
                 return self.process_error(exc, expect_error)
             raise
+        else:
+            if expect_error:
+                self.fail('Excepted error %s but "%s" succeeded: %s' % (
+                    expect_error, opname, result))
 
         if expect_result:
             actual = coerce_result(opname, result)


### PR DESCRIPTION
This change fixes a few things:
- Moves test_load_balancer.py to the top-level to ensure we run the LB spec tests against non-LB clusters as well.
- Fixes a bug in the unified test runner where an operation which was expected to fail but actually succeeded unexpectedly passed the test.
- Fixes the serviceId fallback logic. In particular, we only enable the fallback when testing against a LB. 
- Fixes a socket leak when SocketInfo connection handshake fails.

Before the serviceId fallback logic fix:
```
$ python3 test/test_load_balancer.py -v
skipped 'TestUnifiedEventMonitoring runOnRequirements not satisfied'
skipped 'TestUnifiedLbConnectionEstablishment runOnRequirements not satisfied'
test_operations_against_non-load_balanced_clusters_fail_if_URI_contains_loadBalanced=true (__main__.TestUnifiedNonLbConnectionEstablishment) ... FAIL
test_operations_against_non-load_balanced_clusters_succeed_if_URI_contains_loadBalanced=false (__main__.TestUnifiedNonLbConnectionEstablishment) ... ok
skipped 'TestUnifiedServerSelection runOnRequirements not satisfied'

======================================================================
FAIL: test_operations_against_non-load_balanced_clusters_fail_if_URI_contains_loadBalanced=true (__main__.TestUnifiedNonLbConnectionEstablishment)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/test/unified_format.py", line 1083, in test_case
    self.run_scenario(spec)
  File "/Users/shane/git/mongo-python-driver/test/unified_format.py", line 1067, in run_scenario
    self.run_operations(spec['operations'])
  File "/Users/shane/git/mongo-python-driver/test/unified_format.py", line 999, in run_operations
    self.run_entity_operation(op)
  File "/Users/shane/git/mongo-python-driver/test/unified_format.py", line 879, in run_entity_operation
    self.fail('Excepted error %s but "%s" succeeded: %s' % (
AssertionError: Excepted error {'errorContains': 'Driver attempted to initialize in load balancing mode, but the server does not support this mode'} but "runCommand" succeeded: {'ok': 1.0, '$clusterTime': {'clusterTime': Timestamp(1623449267, 3), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1623449267, 3)}

----------------------------------------------------------------------
Ran 2 tests in 0.029s

FAILED (failures=1, skipped=3)
```

Before the socket leak fix:
```
$ python3 test/test_load_balancer.py -v
skipped 'TestUnifiedEventMonitoring runOnRequirements not satisfied'
skipped 'TestUnifiedLbConnectionEstablishment runOnRequirements not satisfied'
test_operations_against_non-load_balanced_clusters_fail_if_URI_contains_loadBalanced=true (__main__.TestUnifiedNonLbConnectionEstablishment) ... /Users/shane/git/mongo-python-driver/test/unified_format.py:876: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 57130), raddr=('127.0.0.1', 27017)>
  raise
ResourceWarning: Enable tracemalloc to get the object allocation traceback
ok
test_operations_against_non-load_balanced_clusters_succeed_if_URI_contains_loadBalanced=false (__main__.TestUnifiedNonLbConnectionEstablishment) ... ok
skipped 'TestUnifiedServerSelection runOnRequirements not satisfied'

----------------------------------------------------------------------
Ran 2 tests in 0.031s

OK (skipped=3)
```

After:
```
python3 test/test_load_balancer.py -v                              
skipped 'TestUnifiedEventMonitoring runOnRequirements not satisfied'
skipped 'TestUnifiedLbConnectionEstablishment runOnRequirements not satisfied'
test_operations_against_non-load_balanced_clusters_fail_if_URI_contains_loadBalanced=true (__main__.TestUnifiedNonLbConnectionEstablishment) ... ok
test_operations_against_non-load_balanced_clusters_succeed_if_URI_contains_loadBalanced=false (__main__.TestUnifiedNonLbConnectionEstablishment) ... ok
skipped 'TestUnifiedServerSelection runOnRequirements not satisfied'

----------------------------------------------------------------------
Ran 2 tests in 0.026s

OK (skipped=3)
```
