### PR TITLE
PYTHON-2768 Add SDAM and server selection spec tests for load balancers

### DIFF
--- a/test/discovery_and_monitoring/load-balanced/discover_load_balancer.json
+++ b/test/discovery_and_monitoring/load-balanced/discover_load_balancer.json
@@ -1,0 +1,28 @@
+{
+  "description": "Load balancer can be discovered and only has the address property set",
+  "uri": "mongodb://a/?loadBalanced=true",
+  "phases": [
+    {
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "LoadBalancer",
+            "setName": null,
+            "setVersion": null,
+            "electionId": null,
+            "logicalSessionTimeoutMinutes": null,
+            "minWireVersion": null,
+            "maxWireVersion": null,
+            "topologyVersion": null
+          }
+        },
+        "topologyType": "LoadBalanced",
+        "setName": null,
+        "logicalSessionTimeoutMinutes": null,
+        "maxSetVersion": null,
+        "maxElectionId": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/test/sdam_monitoring/load_balancer.json
+++ b/test/sdam_monitoring/load_balancer.json
@@ -1,0 +1,93 @@
+{
+  "description": "Monitoring a load balancer",
+  "uri": "mongodb://a:27017/?loadBalanced=true",
+  "phases": [
+    {
+      "outcome": {
+        "events": [
+          {
+            "topology_opening_event": {
+              "topologyId": "42"
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "Unknown",
+                "servers": []
+              },
+              "newDescription": {
+                "topologyType": "LoadBalanced",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "server_opening_event": {
+              "topologyId": "42",
+              "address": "a:27017"
+            }
+          },
+          {
+            "server_description_changed_event": {
+              "topologyId": "42",
+              "address": "a:27017",
+              "previousDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "Unknown"
+              },
+              "newDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "LoadBalancer"
+              }
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "LoadBalanced",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              },
+              "newDescription": {
+                "topologyType": "LoadBalanced",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "LoadBalancer"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/read/Nearest.json
+++ b/test/server_selection/server_selection/LoadBalanced/read/Nearest.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "Nearest",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/read/Primary.json
+++ b/test/server_selection/server_selection/LoadBalanced/read/Primary.json
@@ -1,0 +1,30 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "Primary"
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/read/PrimaryPreferred.json
+++ b/test/server_selection/server_selection/LoadBalanced/read/PrimaryPreferred.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "PrimaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/read/Secondary.json
+++ b/test/server_selection/server_selection/LoadBalanced/read/Secondary.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "Secondary",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/read/SecondaryPreferred.json
+++ b/test/server_selection/server_selection/LoadBalanced/read/SecondaryPreferred.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "SecondaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/write/Nearest.json
+++ b/test/server_selection/server_selection/LoadBalanced/write/Nearest.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "Nearest",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/write/Primary.json
+++ b/test/server_selection/server_selection/LoadBalanced/write/Primary.json
@@ -1,0 +1,30 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "Primary"
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/write/PrimaryPreferred.json
+++ b/test/server_selection/server_selection/LoadBalanced/write/PrimaryPreferred.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "PrimaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/write/Secondary.json
+++ b/test/server_selection/server_selection/LoadBalanced/write/Secondary.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "Secondary",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/server_selection/server_selection/LoadBalanced/write/SecondaryPreferred.json
+++ b/test/server_selection/server_selection/LoadBalanced/write/SecondaryPreferred.json
@@ -1,0 +1,35 @@
+{
+  "topology_description": {
+    "type": "LoadBalanced",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 0,
+        "type": "LoadBalancer"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "SecondaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 0,
+      "type": "LoadBalancer"
+    }
+  ]
+}

--- a/test/test_discovery_and_monitoring.py
+++ b/test/test_discovery_and_monitoring.py
@@ -61,16 +61,20 @@ def create_mock_topology(uri, monitor_class=DummyMonitor):
     parsed_uri = parse_uri(uri)
     replica_set_name = None
     direct_connection = None
+    load_balanced = None
     if 'replicaset' in parsed_uri['options']:
         replica_set_name = parsed_uri['options']['replicaset']
     if 'directConnection' in parsed_uri['options']:
         direct_connection = parsed_uri['options']['directConnection']
+    if 'loadBalanced' in parsed_uri['options']:
+        load_balanced = parsed_uri['options']['loadBalanced']
 
     topology_settings = TopologySettings(
         parsed_uri['nodelist'],
         replica_set_name=replica_set_name,
         monitor_class=monitor_class,
-        direct_connection=direct_connection)
+        direct_connection=direct_connection,
+        load_balanced=load_balanced)
 
     c = Topology(topology_settings)
     c.open()

--- a/test/test_sdam_monitoring_spec.py
+++ b/test/test_sdam_monitoring_spec.py
@@ -194,7 +194,7 @@ def create_test(scenario_def):
 
         try:
             for phase in scenario_def['phases']:
-                for (source, response) in phase['responses']:
+                for (source, response) in phase.get('responses', []):
                     source_address = clean_node(source)
                     topology.on_change(ServerDescription(
                         address=source_address,

--- a/test/utils_selection_tests.py
+++ b/test/utils_selection_tests.py
@@ -124,6 +124,10 @@ def create_topology(scenario_def, **kwargs):
     seeds, hosts = get_addresses(
         scenario_def['topology_description']['servers'])
 
+    topology_type = get_topology_type_name(scenario_def)
+    if topology_type == 'LoadBalanced':
+        kwargs.setdefault('load_balanced', True)
+
     settings = get_topology_settings_dict(
         heartbeat_frequency=frequency,
         seeds=seeds,
@@ -140,6 +144,9 @@ def create_topology(scenario_def, **kwargs):
     for server in scenario_def['topology_description']['servers']:
         server_description = make_server_description(server, hosts)
         topology.on_change(server_description)
+
+    if topology_type == 'LoadBalanced':
+        assert topology.description.topology_type_name == 'LoadBalanced'
 
     return topology
 


### PR DESCRIPTION
Now we have all the LB tests:

```
$ git grep --name-only oadBala  -- '*.json'
source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.json
source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-replicaSet-errors.json
source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-multiple-hosts.json
source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.json
source/initial-dns-seedlist-discovery/tests/replica-set/loadBalanced-false-txt.json
source/load-balancers/tests/lb-connection-establishment.json
source/load-balancers/tests/non-lb-connection-establishment.json
source/server-discovery-and-monitoring/tests/load-balanced/discover_load_balancer.json
source/server-discovery-and-monitoring/tests/monitoring/load_balancer.json
source/server-selection/tests/server_selection/LoadBalanced/read/Nearest.json
source/server-selection/tests/server_selection/LoadBalanced/read/Primary.json
source/server-selection/tests/server_selection/LoadBalanced/read/PrimaryPreferred.json
source/server-selection/tests/server_selection/LoadBalanced/read/Secondary.json
source/server-selection/tests/server_selection/LoadBalanced/read/SecondaryPreferred.json
source/server-selection/tests/server_selection/LoadBalanced/write/Nearest.json
source/server-selection/tests/server_selection/LoadBalanced/write/Primary.json
source/server-selection/tests/server_selection/LoadBalanced/write/PrimaryPreferred.json
source/server-selection/tests/server_selection/LoadBalanced/write/Secondary.json
source/server-selection/tests/server_selection/LoadBalanced/write/SecondaryPreferred.json
source/uri-options/tests/connection-options.json
```