### PR TITLE
PYTHON-2776 Raise error on unsupported snapshot read commands

### DIFF
--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -869,6 +869,9 @@ class ClientSession(object):
     def _apply_to(self, command, is_retryable, read_preference, sock_info):
         self._check_ended()
 
+        if self.options.snapshot:
+            self._update_read_concern(command, sock_info)
+
         self._server_session.last_use = time.monotonic()
         command['lsid'] = self._server_session.session_id
 

--- a/test/sessions/unified/snapshot-sessions-unsupported-ops.json
+++ b/test/sessions/unified/snapshot-sessions-unsupported-ops.json
@@ -454,7 +454,7 @@
             "session": "session0",
             "commandName": "listCollections",
             "command": {
-              "listIndexes": "collection0"
+              "listCollections": 1
             }
           },
           "expectError": {
@@ -482,7 +482,7 @@
             },
             {
               "commandFailedEvent": {
-                "listCollections": "insert"
+                "commandName": "listCollections"
               }
             }
           ]

--- a/test/sessions/unified/snapshot-sessions-unsupported-ops.json
+++ b/test/sessions/unified/snapshot-sessions-unsupported-ops.json
@@ -1,0 +1,468 @@
+{
+  "description": "snapshot-sessions-unsupported-ops",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0",
+        "sessionOptions": {
+          "snapshot": true
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Server returns an error on insertOne with snapshot",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 22,
+              "x": 22
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on insertMany with snapshot",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "documents": [
+              {
+                "_id": 22,
+                "x": 22
+              },
+              {
+                "_id": 33,
+                "x": 33
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on deleteOne with snapshot",
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {}
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "delete"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on updateOne with snapshot",
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "update"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on findOneAndUpdate with snapshot",
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "findAndModify"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on listDatabases with snapshot",
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client0",
+          "arguments": {
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listDatabases": 1,
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "listDatabases"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on listCollections with snapshot",
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database0",
+          "arguments": {
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "listCollections"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on listIndexes with snapshot",
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listIndexes": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "listIndexes"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on runComand with snapshot",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "session": "session0",
+            "commandName": "insert",
+            "command": {
+              "insert": "collection0",
+              "documents": [
+                {}
+              ]
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/sessions/unified/snapshot-sessions-unsupported-ops.json
+++ b/test/sessions/unified/snapshot-sessions-unsupported-ops.json
@@ -59,6 +59,13 @@
   "tests": [
     {
       "description": "Server returns an error on insertOne with snapshot",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "insertOne",
@@ -104,6 +111,13 @@
     },
     {
       "description": "Server returns an error on insertMany with snapshot",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "insertMany",
@@ -155,6 +169,13 @@
     },
     {
       "description": "Server returns an error on deleteOne with snapshot",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "deleteOne",
@@ -197,6 +218,13 @@
     },
     {
       "description": "Server returns an error on updateOne with snapshot",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "updateOne",
@@ -417,19 +445,16 @@
       ]
     },
     {
-      "description": "Server returns an error on runComand with snapshot",
+      "description": "Server returns an error on runCommand with snapshot",
       "operations": [
         {
           "name": "runCommand",
           "object": "database0",
           "arguments": {
             "session": "session0",
-            "commandName": "insert",
+            "commandName": "listCollections",
             "command": {
-              "insert": "collection0",
-              "documents": [
-                {}
-              ]
+              "listIndexes": "collection0"
             }
           },
           "expectError": {
@@ -445,7 +470,7 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "insert": "collection0",
+                  "listCollections": 1,
                   "readConcern": {
                     "level": "snapshot",
                     "atClusterTime": {
@@ -457,7 +482,7 @@
             },
             {
               "commandFailedEvent": {
-                "commandName": "insert"
+                "listCollections": "insert"
               }
             }
           ]

--- a/test/sessions/unified/snapshot-sessions.json
+++ b/test/sessions/unified/snapshot-sessions.json
@@ -656,6 +656,62 @@
       ]
     },
     {
+      "description": "countDocuments operation with snapshot",
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "session": "session0"
+          },
+          "expectResult": 2
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "session": "session0"
+          },
+          "expectResult": 2
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": true
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "description": "Mixed operation with snapshot",
       "operations": [
         {
@@ -813,7 +869,6 @@
           "name": "insertOne",
           "object": "collection0",
           "arguments": {
-            "session": "session0",
             "document": {
               "_id": 22,
               "x": 33
@@ -827,7 +882,6 @@
             "filter": {
               "_id": 1
             },
-            "session": "session0",
             "update": {
               "$inc": {
                 "x": 1

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -729,6 +729,24 @@ class TestSession(IntegrationTest):
                                            snapshot=True):
                 pass
 
+    @client_context.require_version_min(5, 0, -1)
+    def test_snapshot_writes(self):
+        with self.client.start_session(snapshot=True) as session:
+            with self.assertRaises(OperationFailure):
+                self.db.test.insert_one({}, session=session)
+            with self.assertRaises(OperationFailure):
+                self.db.test.insert_many([{}, {}], session=session)
+            with self.assertRaises(OperationFailure):
+                self.db.test.update_one({}, {'$set': {'x': 1}}, session=session)
+            with self.assertRaises(OperationFailure):
+                self.db.test.delete_one({}, session=session)
+            with self.assertRaises(OperationFailure):
+                self.db.test.find_one_and_delete({}, session=session)
+            with self.assertRaises(OperationFailure):
+                self.db.list_collections(session=session)
+            with self.assertRaises(OperationFailure):
+                self.db.test.list_indexes(session=session)
+
 
 class TestCausalConsistency(unittest.TestCase):
 

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -729,24 +729,6 @@ class TestSession(IntegrationTest):
                                            snapshot=True):
                 pass
 
-    @client_context.require_version_min(5, 0, -1)
-    def test_snapshot_writes(self):
-        with self.client.start_session(snapshot=True) as session:
-            with self.assertRaises(OperationFailure):
-                self.db.test.insert_one({}, session=session)
-            with self.assertRaises(OperationFailure):
-                self.db.test.insert_many([{}, {}], session=session)
-            with self.assertRaises(OperationFailure):
-                self.db.test.update_one({}, {'$set': {'x': 1}}, session=session)
-            with self.assertRaises(OperationFailure):
-                self.db.test.delete_one({}, session=session)
-            with self.assertRaises(OperationFailure):
-                self.db.test.find_one_and_delete({}, session=session)
-            with self.assertRaises(OperationFailure):
-                self.db.list_collections(session=session)
-            with self.assertRaises(OperationFailure):
-                self.db.test.list_indexes(session=session)
-
 
 class TestCausalConsistency(unittest.TestCase):
 

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -556,7 +556,7 @@ class MatchEvaluatorUtil(object):
                 if actual.command_name == 'update':
                     # TODO: remove this once PYTHON-1744 is done.
                     # Add upsert and multi fields back into expectations.
-                    for update in command['updates']:
+                    for update in command.get('updates', []):
                         update.setdefault('upsert', False)
                         update.setdefault('multi', False)
                 self.match_result(command, actual.command)


### PR DESCRIPTION
Implements: https://github.com/mongodb/specifications/pull/1033