### PR TITLE
PYTHON-2799 Use namespace returned from initial command response for killCursors

### DIFF
--- a/pymongo/command_cursor.py
+++ b/pymongo/command_cursor.py
@@ -74,7 +74,7 @@ class CommandCursor(object):
         if self.__id and not already_killed:
             cursor_id = self.__id
             address = _CursorAddress(
-                self.__address, self.__collection.full_name)
+                self.__address, self.__ns)
         else:
             # Skip killCursors.
             cursor_id = 0

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -346,7 +346,7 @@ class Cursor(object):
         if self.__id and not already_killed:
             cursor_id = self.__id
             address = _CursorAddress(
-                self.__address, self.__collection.full_name)
+                self.__address, "%s.%s" % (self.__dbname, self.__collname))
         else:
             # Skip killCursors.
             cursor_id = 0


### PR DESCRIPTION
This will be tested by the ADL prose test being added in #665 