### PR TITLE
PYTHON-2608 Test that KMS TLS connections verify peer certificates

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -97,7 +97,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone git://github.com/ShaneHarvey/drivers-evergreen-tools.git --branch DRIVERS-1560-fix-self-signed-cert $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -359,32 +359,6 @@ functions:
            PYTHON_BINARY=${PYTHON_BINARY} sh ${PROJECT_DIRECTORY}/.evergreen/run-doctests.sh
 
   "run tests":
-    # If testing encryption start the mock KMS servers.
-    # First create the virtualenv and install dependencies.
-    - command: shell.exec
-      type: setup
-      params:
-        working_dir: src
-        script: |
-          if [ -n "${test_encryption}" -a "$OS" != "Windows_NT" ]; then
-            . .evergreen/utils.sh
-            createvirtualenv ${python3_binary} venvmockkms
-            python -m pip install boto3
-          fi
-    # Start the mock KMS responders.
-    - command: shell.exec
-      type: setup
-      params:
-        working_dir: src
-        background: true
-        script: |
-          if [ -n "${test_encryption}" -a "$OS" != "Windows_NT" ]; then
-            ${PREPARE_SHELL}
-            . ./venvmockkms/bin/activate
-            cd ${DRIVERS_TOOLS}/.evergreen/csfle
-            python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
-            python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001
-          fi
     - command: shell.exec
       type: test
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -97,7 +97,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/ShaneHarvey/drivers-evergreen-tools.git --branch DRIVERS-1560-allow-mock-kms-port $DRIVERS_TOOLS
+            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -292,7 +292,7 @@ functions:
             DISABLE_TEST_COMMANDS=${DISABLE_TEST_COMMANDS} \
             ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
             REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
-            sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+            bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
       params:
@@ -310,7 +310,7 @@ functions:
         script: |
           set -o xtrace
           ${PREPARE_SHELL}
-          sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+          bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
     - command: shell.exec
       type: setup
       params:
@@ -318,7 +318,7 @@ functions:
         script: |
           set -o xtrace
           ${PREPARE_SHELL}
-          sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+          bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
 
   "stop mongo-orchestration":
     - command: shell.exec
@@ -326,7 +326,7 @@ functions:
         script: |
           set -o xtrace
           ${PREPARE_SHELL}
-          sh ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
+          bash ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
 
   "run mod_wsgi tests":
     - command: shell.exec
@@ -336,7 +336,7 @@ functions:
         script: |
           set -o xtrace
           ${PREPARE_SHELL}
-          PYTHON_BINARY=${PYTHON_BINARY} MOD_WSGI_VERSION=${MOD_WSGI_VERSION} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} sh ${PROJECT_DIRECTORY}/.evergreen/run-mod-wsgi-tests.sh
+          PYTHON_BINARY=${PYTHON_BINARY} MOD_WSGI_VERSION=${MOD_WSGI_VERSION} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} bash ${PROJECT_DIRECTORY}/.evergreen/run-mod-wsgi-tests.sh
 
   "run mockupdb tests":
     - command: shell.exec
@@ -346,7 +346,7 @@ functions:
         script: |
           set -o xtrace
           ${PREPARE_SHELL}
-          PYTHON_BINARY=${PYTHON_BINARY} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} sh ${PROJECT_DIRECTORY}/.evergreen/run-mockupdb-tests.sh
+          PYTHON_BINARY=${PYTHON_BINARY} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} bash ${PROJECT_DIRECTORY}/.evergreen/run-mockupdb-tests.sh
 
   "run doctests":
      - command: shell.exec
@@ -356,7 +356,7 @@ functions:
          script: |
            set -o xtrace
            ${PREPARE_SHELL}
-           PYTHON_BINARY=${PYTHON_BINARY} sh ${PROJECT_DIRECTORY}/.evergreen/run-doctests.sh
+           PYTHON_BINARY=${PYTHON_BINARY} bash ${PROJECT_DIRECTORY}/.evergreen/run-doctests.sh
 
   "run tests":
     - command: shell.exec
@@ -425,7 +425,7 @@ functions:
             SSL=${SSL} \
             DATA_LAKE=${DATA_LAKE} \
             MONGODB_API_VERSION=${MONGODB_API_VERSION} \
-            sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+            bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "run enterprise auth tests":
     - command: shell.exec
@@ -435,7 +435,7 @@ functions:
         working_dir: "src"
         script: |
           # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
-          PYTHON_BINARY=${PYTHON_BINARY} SASL_HOST=${sasl_host} SASL_PORT=${sasl_port} SASL_USER=${sasl_user} SASL_PASS=${sasl_pass} SASL_DB=${sasl_db} PRINCIPAL=${principal} GSSAPI_DB=${gssapi_db} KEYTAB_BASE64=${keytab_base64} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} sh ${PROJECT_DIRECTORY}/.evergreen/run-enterprise-auth-tests.sh
+          PYTHON_BINARY=${PYTHON_BINARY} SASL_HOST=${sasl_host} SASL_PORT=${sasl_port} SASL_USER=${sasl_user} SASL_PASS=${sasl_pass} SASL_DB=${sasl_db} PRINCIPAL=${principal} GSSAPI_DB=${gssapi_db} KEYTAB_BASE64=${keytab_base64} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} bash ${PROJECT_DIRECTORY}/.evergreen/run-enterprise-auth-tests.sh
 
   "run atlas tests":
     - command: shell.exec
@@ -705,7 +705,7 @@ functions:
           ${PREPARE_SHELL}
           file="${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
           # Don't use ${file} syntax here because evergreen treats it as an empty expansion.
-          [ -f "$file" ] && sh $file || echo "$file not available, skipping"
+          [ -f "$file" ] && bash $file || echo "$file not available, skipping"
 
   "run-ocsp-test":
     - command: shell.exec
@@ -717,7 +717,7 @@ functions:
           PYTHON_BINARY=${PYTHON_BINARY} \
           CA_FILE="$DRIVERS_TOOLS/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem" \
           OCSP_TLS_SHOULD_SUCCEED="${OCSP_TLS_SHOULD_SUCCEED}" \
-          sh ${PROJECT_DIRECTORY}/.evergreen/run-ocsp-tests.sh
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-ocsp-tests.sh
 
   run-valid-ocsp-server:
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -360,16 +360,16 @@ functions:
 
   "run tests":
     # If testing encryption start the mock KMS servers.
-    # First create the virtualenv upfront.
+    # First create the virtualenv and install dependencies.
     - command: shell.exec
       type: system
       params:
         working_dir: src
         script: |
-          if [ -n "${test_encryption}" ]; then
-            ${PREPARE_SHELL}
-            cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-            . ./activate_venv.sh
+          if [ -n "${test_encryption}" -a "$OS" != "Windows_NT" ]; then
+            . .evergreen/utils.sh
+            createvirtualenv ${python3_binary} venvmockkms
+            python -m pip install boto3
           fi
     # Start the first mock KMS responder.
     - command: shell.exec
@@ -378,10 +378,9 @@ functions:
         working_dir: src
         background: true
         script: |
-          if [ -n "${test_encryption}" ]; then
+          if [ -n "${test_encryption}" -a "$OS" != "Windows_NT" ]; then
             ${PREPARE_SHELL}
-            cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-            . ./activate_venv.sh
+            . ./venvmockkms/bin/activate
             cd ${DRIVERS_TOOLS}/.evergreen/csfle
             python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000
           fi
@@ -392,10 +391,9 @@ functions:
         working_dir: src
         background: true
         script: |
-          if [ -n "${test_encryption}" ]; then
+          if [ -n "${test_encryption}" -a "$OS" != "Windows_NT" ]; then
             ${PREPARE_SHELL}
-            cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-            . ./activate_venv.sh
+            . ./venvmockkms/bin/activate
             cd ${DRIVERS_TOOLS}/.evergreen/csfle
             python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001
           fi

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -97,7 +97,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone git://github.com/ShaneHarvey/drivers-evergreen-tools.git --branch DRIVERS-1560-allow-mock-kms-port $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 
@@ -359,6 +359,47 @@ functions:
            PYTHON_BINARY=${PYTHON_BINARY} sh ${PROJECT_DIRECTORY}/.evergreen/run-doctests.sh
 
   "run tests":
+    # If testing encryption start the mock KMS servers.
+    - command: shell.exec
+      type: system
+      params:
+        working_dir: src
+        background: true
+        script: |
+          if [ -n "${test_encryption}" ]; then
+            ${PREPARE_SHELL}
+            cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+            . ./activate_venv.sh
+            cd ${DRIVERS_TOOLS}/.evergreen/csfle
+            cat <<EOF > kms_setup.json
+            {
+                "kms_ca_file": "ca.pem",
+                "kms_cert_file": "expired.pem",
+                "kms_port": "8000"
+            }
+          EOF
+            mongo --nodb mock_kms.js
+          fi
+    - command: shell.exec
+      type: system
+      params:
+        working_dir: src
+        background: true
+        script: |
+          if [ -n "${test_encryption}" ]; then
+            ${PREPARE_SHELL}
+            cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+            . ./activate_venv.sh
+            cd ${DRIVERS_TOOLS}/.evergreen/csfle
+            cat <<EOF > kms_setup.json
+            {
+                "kms_ca_file": "ca.pem",
+                "kms_cert_file": "wrong-host.pem",
+                "kms_port": "8001"
+            }
+          EOF
+            mongo --nodb mock_kms.js
+          fi
     - command: shell.exec
       type: test
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -97,7 +97,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/ShaneHarvey/drivers-evergreen-tools.git --branch DRIVERS-1560-fix-self-signed-cert $DRIVERS_TOOLS
+            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -362,7 +362,7 @@ functions:
     # If testing encryption start the mock KMS servers.
     # First create the virtualenv and install dependencies.
     - command: shell.exec
-      type: system
+      type: setup
       params:
         working_dir: src
         script: |
@@ -371,9 +371,9 @@ functions:
             createvirtualenv ${python3_binary} venvmockkms
             python -m pip install boto3
           fi
-    # Start the first mock KMS responder.
+    # Start the mock KMS responders.
     - command: shell.exec
-      type: system
+      type: setup
       params:
         working_dir: src
         background: true
@@ -382,19 +382,7 @@ functions:
             ${PREPARE_SHELL}
             . ./venvmockkms/bin/activate
             cd ${DRIVERS_TOOLS}/.evergreen/csfle
-            python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000
-          fi
-    # Start the second mock KMS responder.
-    - command: shell.exec
-      type: system
-      params:
-        working_dir: src
-        background: true
-        script: |
-          if [ -n "${test_encryption}" -a "$OS" != "Windows_NT" ]; then
-            ${PREPARE_SHELL}
-            . ./venvmockkms/bin/activate
-            cd ${DRIVERS_TOOLS}/.evergreen/csfle
+            python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
             python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001
           fi
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -360,26 +360,18 @@ functions:
 
   "run tests":
     # If testing encryption start the mock KMS servers.
+    # First create the virtualenv upfront.
     - command: shell.exec
       type: system
       params:
         working_dir: src
-        background: true
         script: |
           if [ -n "${test_encryption}" ]; then
             ${PREPARE_SHELL}
             cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
             . ./activate_venv.sh
-            cd ${DRIVERS_TOOLS}/.evergreen/csfle
-            cat <<EOF > kms_setup.json
-            {
-                "kms_ca_file": "ca.pem",
-                "kms_cert_file": "expired.pem",
-                "kms_port": "8000"
-            }
-          EOF
-            mongo --nodb mock_kms.js
           fi
+    # Start the first mock KMS responder.
     - command: shell.exec
       type: system
       params:
@@ -391,14 +383,21 @@ functions:
             cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
             . ./activate_venv.sh
             cd ${DRIVERS_TOOLS}/.evergreen/csfle
-            cat <<EOF > kms_setup.json
-            {
-                "kms_ca_file": "ca.pem",
-                "kms_cert_file": "wrong-host.pem",
-                "kms_port": "8001"
-            }
-          EOF
-            mongo --nodb mock_kms.js
+            python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000
+          fi
+    # Start the second mock KMS responder.
+    - command: shell.exec
+      type: system
+      params:
+        working_dir: src
+        background: true
+        script: |
+          if [ -n "${test_encryption}" ]; then
+            ${PREPARE_SHELL}
+            cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+            . ./activate_venv.sh
+            cd ${DRIVERS_TOOLS}/.evergreen/csfle
+            python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000
           fi
     - command: shell.exec
       type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -397,7 +397,7 @@ functions:
             cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
             . ./activate_venv.sh
             cd ${DRIVERS_TOOLS}/.evergreen/csfle
-            python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000
+            python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001
           fi
     - command: shell.exec
       type: test

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 

--- a/.evergreen/run-mod-wsgi-tests.sh
+++ b/.evergreen/run-mod-wsgi-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -o xtrace
 set -o errexit
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -150,6 +150,7 @@ if [ -n "$TEST_ENCRYPTION" ]; then
         pushd ${DRIVERS_TOOLS}/.evergreen/csfle
         python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
         python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
+        trap 'kill $(jobs -p)' EXIT HUP
         popd
     fi
 fi

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -144,6 +144,14 @@ if [ -n "$TEST_ENCRYPTION" ]; then
     # Get access to the AWS temporary credentials:
     # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
     . $DRIVERS_TOOLS/.evergreen/csfle/set-temp-creds.sh
+
+    # Start the mock KMS servers.
+    if [ "$OS" != "Windows_NT" ]; then
+        pushd ${DRIVERS_TOOLS}/.evergreen/csfle
+        python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
+        python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
+        popd
+    fi
 fi
 
 if [ -z "$DATA_LAKE" ]; then

--- a/.evergreen/test-encryption-requirements.txt
+++ b/.evergreen/test-encryption-requirements.txt
@@ -2,5 +2,3 @@ cffi>=1.12.0,<2
 cryptography>=2
 # boto3 is required by drivers-evergreen-tools/.evergreen/csfle/set-temp-creds.sh
 boto3<2
-# Needed on Windows due to PYTHON-2798.
-certifi; platform_system == 'Windows'

--- a/.evergreen/test-encryption-requirements.txt
+++ b/.evergreen/test-encryption-requirements.txt
@@ -2,3 +2,5 @@ cffi>=1.12.0,<2
 cryptography>=2
 # boto3 is required by drivers-evergreen-tools/.evergreen/csfle/set-temp-creds.sh
 boto3<2
+# Needed on Windows due to PYTHON-2798.
+certifi; platform_system == 'Windows'

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -1661,18 +1661,18 @@ class TestKmsTLSProse(EncryptionIntegrationTest):
                   "89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
            "endpoint": "mongodb://127.0.0.1:8000",
         }
-        with self.assertRaisesRegex(EncryptionError, 'expired'):
-            self.client_encrypted.create_data_key('aws', master_key=key)
+        # with self.assertRaisesRegex(EncryptionError, 'expired'):
+        self.client_encrypted.create_data_key('aws', master_key=key)
 
     def test_invalid_hostname_in_kms_certificate(self):
         key = {
            "region": "us-east-1",
            "key": "arn:aws:kms:us-east-1:579766882180:key/"
                   "89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
-           "endpoint": "mongodb://127.0.0.1:8001",
+           "endpoint": "mongodb://localhost:8001",
         }
-        with self.assertRaisesRegex(EncryptionError, 'SANs'):
-            self.client_encrypted.create_data_key('aws', master_key=key)
+        # with self.assertRaisesRegex(EncryptionError, 'SANs'):
+        self.client_encrypted.create_data_key('aws', master_key=key)
 
 
 if __name__ == "__main__":

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -1659,8 +1659,11 @@ class TestKmsTLSProse(EncryptionIntegrationTest):
                   "89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
            "endpoint": "mongodb://127.0.0.1:8000",
         }
+        # Some examples:
         # certificate verify failed: certificate has expired (_ssl.c:1129)
-        with self.assertRaisesRegex(EncryptionError, 'expired'):
+        # amazon1-2018 Python 3.6: certificate verify failed (_ssl.c:852)
+        with self.assertRaisesRegex(
+                EncryptionError, 'expired|certificate verify failed'):
             self.client_encrypted.create_data_key('aws', master_key=key)
 
     def test_invalid_hostname_in_kms_certificate(self):
@@ -1670,8 +1673,11 @@ class TestKmsTLSProse(EncryptionIntegrationTest):
                   "89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
            "endpoint": "mongodb://127.0.0.1:8001",
         }
+        # Some examples:
         # certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'. (_ssl.c:1129)"
-        with self.assertRaisesRegex(EncryptionError, 'IP address mismatch'):
+        # hostname '127.0.0.1' doesn't match 'wronghost.com'
+        with self.assertRaisesRegex(
+                EncryptionError, 'IP address mismatch|wronghost'):
             self.client_encrypted.create_data_key('aws', master_key=key)
 
 


### PR DESCRIPTION
Implements the tests described here: https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#kms-tls-tests

Patch (Note the Windows failures are unrelated see PYTHON-2798): https://spruce.mongodb.com/version/60e643e47742ae7acd922fe3/tasks