### PR TITLE
PYTHON-2798 Workaround windows cert issue with SSL_CERT_FILE

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -146,13 +146,15 @@ if [ -n "$TEST_ENCRYPTION" ]; then
     . $DRIVERS_TOOLS/.evergreen/csfle/set-temp-creds.sh
 
     # Start the mock KMS servers.
-    if [ "$OS" != "Windows_NT" ]; then
-        pushd ${DRIVERS_TOOLS}/.evergreen/csfle
-        python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
-        python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
-        trap 'kill $(jobs -p)' EXIT HUP
-        popd
+    if [ "$OS" = "Windows_NT" ]; then
+        # Remove after BUILD-13574.
+        python -m pip install certifi
     fi
+    pushd ${DRIVERS_TOOLS}/.evergreen/csfle
+    python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
+    python -u lib/kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
+    trap 'kill $(jobs -p)' EXIT HUP
+    popd
 fi
 
 if [ -z "$DATA_LAKE" ]; then


### PR DESCRIPTION
Apparently SSL_CERT_FILE does work on Windows. We can use it to workaround the issue in BUILD-13574.