### PR TITLE
PYTHON-2608 Fix KMS TLS testing on Python <3.5

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -426,6 +426,7 @@ functions:
           fi
 
           PYTHON_BINARY=${PYTHON_BINARY} \
+            PYTHON3_BINARY=${python3_binary} \
             GREEN_FRAMEWORK=${GREEN_FRAMEWORK} \
             C_EXTENSIONS=${C_EXTENSIONS} \
             COVERAGE=${COVERAGE} \
@@ -1697,6 +1698,7 @@ axes:
         run_on: rhel70-small
         batchtime: 10080  # 7 days
         variables:
+          python3_binary: "/opt/python/3.6/bin/python3"
           libmongocrypt_url: https://s3.amazonaws.com/mciuploads/libmongocrypt/rhel-70-64-bit/master/latest/libmongocrypt.tar.gz
       - id: suse12-x86-64-test
         display_name: "SUSE 12 (x86_64)"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -187,11 +187,7 @@ if [ -n "$TEST_ENCRYPTION" ]; then
     # Restore the test virtualenv.
     if [ $IS_PRE_35 = "1" ]; then
         deactivate
-        if [ "Windows_NT" = "$OS" ]; then
-            . venv-encryption/Scripts/activate
-        else
-            . venv-encryption/bin/activate
-        fi
+        activatevritualenv venv-encryption
     fi
 fi
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -187,7 +187,11 @@ if [ -n "$TEST_ENCRYPTION" ]; then
     # Restore the test virtualenv.
     if [ $IS_PRE_35 = "1" ]; then
         deactivate
-        activatevritualenv venv-encryption
+        if [ "Windows_NT" = "$OS" ]; then
+            . venv-encryption/Scripts/activate
+        else
+            . venv-encryption/bin/activate
+        fi
     fi
 fi
 

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -1,18 +1,6 @@
 #!/bin/bash -ex
 
 # Usage:
-# activatevritualenv /path/to/venv
-# * param1: Path to the virtualenv to activate
-activatevritualenv () {
-    VENVPATH=$1
-    if [ "Windows_NT" = "$OS" ]; then
-        . $VENVPATH/Scripts/activate
-    else
-        . $VENVPATH/bin/activate
-    fi
-}
-
-# Usage:
 # createvirtualenv /path/to/python /output/path/for/venv
 # * param1: Python binary to use for the virtualenv
 # * param2: Path to the virtualenv to create
@@ -30,7 +18,11 @@ createvirtualenv () {
         exit 1
     fi
     $VIRTUALENV $VENVPATH
-    activatevritualenv $VENVPATH
+    if [ "Windows_NT" = "$OS" ]; then
+        . $VENVPATH/Scripts/activate
+    else
+        . $VENVPATH/bin/activate
+    fi
     # Upgrade to the latest versions of pip setuptools wheel so that
     # pip can always download the latest cryptography+cffi wheels.
     PYTHON_VERSION=$(python -c 'import sys;print("%s.%s" % sys.version_info[:2])')

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -1,6 +1,18 @@
 #!/bin/bash -ex
 
 # Usage:
+# activatevritualenv /path/to/venv
+# * param1: Path to the virtualenv to activate
+activatevritualenv () {
+    VENVPATH=$1
+    if [ "Windows_NT" = "$OS" ]; then
+        . $VENVPATH/Scripts/activate
+    else
+        . $VENVPATH/bin/activate
+    fi
+}
+
+# Usage:
 # createvirtualenv /path/to/python /output/path/for/venv
 # * param1: Python binary to use for the virtualenv
 # * param2: Path to the virtualenv to create
@@ -18,11 +30,7 @@ createvirtualenv () {
         exit 1
     fi
     $VIRTUALENV $VENVPATH
-    if [ "Windows_NT" = "$OS" ]; then
-        . $VENVPATH/Scripts/activate
-    else
-        . $VENVPATH/bin/activate
-    fi
+    activatevritualenv $VENVPATH
     # Upgrade to the latest versions of pip setuptools wheel so that
     # pip can always download the latest cryptography+cffi wheels.
     PYTHON_VERSION=$(python -c 'import sys;print("%s.%s" % sys.version_info[:2])')


### PR DESCRIPTION
When I backported PYTHON-2608 I didn't realize that the mock KMS script requires Python 3.5+. For <3.5 we need to create yet another virtualenv. This fixes the encryption tests on v3.12. 