### PR TITLE
PYTHON-2602 Test that pool paused errors are retryable

### DIFF
--- a/pymongo/topology.py
+++ b/pymongo/topology.py
@@ -125,7 +125,7 @@ class Topology(object):
 
             executor = periodic_executor.PeriodicExecutor(
                 interval=common.EVENTS_QUEUE_FREQUENCY,
-                min_interval=0.5,
+                min_interval=common.MIN_HEARTBEAT_INTERVAL,
                 target=target,
                 name="pymongo_events_thread")
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -774,10 +774,12 @@ class ClientContext(object):
     def require_failCommand_blockConnection(self, func):
         """Run a test only if the server supports failCommand blockConnection.
         """
-        return self._require(lambda: (self.test_commands_enabled and
-                                      self.version >= (4, 2, 9)),
-                             "failCommand blockConnection is not supported",
-                             func=func)
+        return self._require(
+            lambda: (self.test_commands_enabled and (
+                (not self.is_mongos and self.version >= (4, 2, 9))) or
+                (self.is_mongos and self.version >= (4, 4))),
+            "failCommand blockConnection is not supported",
+            func=func)
 
     def require_tls(self, func):
         """Run a test only if the client can connect over TLS."""

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -163,33 +163,23 @@ class TestPoolPausedError(IntegrationTest):
             maxPoolSize=1,
             event_listeners=[cmap_listener, cmd_listener])
         self.addCleanup(client.close)
-        for _ in range(10):
-            cmap_listener.reset()
-            cmd_listener.reset()
-            threads = [FindThread(client.pymongo_test.test) for _ in range(2)]
-            fail_command = {
-                'mode': {'times': 1},
-                'data': {
-                    'failCommands': ['find'],
-                    'blockConnection': True,
-                    'blockTimeMS': 1000,
-                    'errorCode': 91,
-                },
-            }
-            with self.fail_point(fail_command):
-                for thread in threads:
-                    thread.start()
-                for thread in threads:
-                    thread.join()
-                for thread in threads:
-                    self.assertTrue(thread.passed)
-
-            # It's possible that SDAM can rediscover the server and mark the
-            # pool ready before the thread in the wait queue has a chance
-            # to run. Repeat the test until the thread actually encounters
-            # a PoolClearedError.
-            if cmap_listener.event_count(ConnectionCheckOutFailedEvent):
-                break
+        threads = [FindThread(client.pymongo_test.test) for _ in range(2)]
+        fail_command = {
+            'mode': {'times': 1},
+            'data': {
+                'failCommands': ['find'],
+                'blockConnection': True,
+                'blockTimeMS': 1000,
+                'errorCode': 91,
+            },
+        }
+        with self.fail_point(fail_command):
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+            for thread in threads:
+                self.assertTrue(thread.passed)
 
         # Via CMAP monitoring, assert that the first check out succeeds.
         cmap_events = cmap_listener.events_by_type((

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -180,19 +180,27 @@ class TestPoolPausedError(SpeedyTest):
             ConnectionCheckedOutEvent,
             ConnectionCheckOutFailedEvent,
             PoolClearedEvent))
-        self.assertIsInstance(cmap_events[0], ConnectionCheckedOutEvent)
-        self.assertIsInstance(cmap_events[1], PoolClearedEvent)
-        self.assertIsInstance(cmap_events[2], ConnectionCheckOutFailedEvent)
+        self.assertIsInstance(cmap_events[0], ConnectionCheckedOutEvent,
+                              msg=cmap_events)
+        self.assertIsInstance(cmap_events[1], PoolClearedEvent,
+                              msg=cmap_events)
+        self.assertIsInstance(cmap_events[2], ConnectionCheckOutFailedEvent,
+                              msg=cmap_events)
         self.assertEqual(cmap_events[2].reason,
-                         ConnectionCheckOutFailedReason.CONN_ERROR)
-        self.assertIsInstance(cmap_events[3], ConnectionCheckedOutEvent)
+                         ConnectionCheckOutFailedReason.CONN_ERROR,
+                         msg=cmap_events)
+        self.assertIsInstance(cmap_events[3], ConnectionCheckedOutEvent,
+                              msg=cmap_events)
 
         # Connection check out failures are not reflected in command
         # monitoring because we only publish command events _after_ checking
         # out a connection.
-        self.assertEqual(3, len(cmd_listener.results['started']))
-        self.assertEqual(2, len(cmd_listener.results['succeeded']))
-        self.assertEqual(1, len(cmd_listener.results['failed']))
+        started = cmd_listener.results['started']
+        self.assertEqual(3, len(started), msg=started)
+        succeeded = cmd_listener.results['succeeded']
+        self.assertEqual(2, len(succeeded), msg=succeeded)
+        failed = cmd_listener.results['failed']
+        self.assertEqual(1, len(failed), msg=failed)
 
 
 if __name__ == "__main__":

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -180,27 +180,27 @@ class TestPoolPausedError(SpeedyTest):
             ConnectionCheckedOutEvent,
             ConnectionCheckOutFailedEvent,
             PoolClearedEvent))
-        self.assertIsInstance(cmap_events[0], ConnectionCheckedOutEvent,
-                              msg=cmap_events)
-        self.assertIsInstance(cmap_events[1], PoolClearedEvent,
-                              msg=cmap_events)
-        self.assertIsInstance(cmap_events[2], ConnectionCheckOutFailedEvent,
-                              msg=cmap_events)
+        import pprint
+        msg = pprint.pformat(cmap_listener.events)
+        self.assertIsInstance(cmap_events[0], ConnectionCheckedOutEvent, msg)
+        self.assertIsInstance(cmap_events[1], PoolClearedEvent, msg)
+        self.assertIsInstance(
+            cmap_events[2], ConnectionCheckOutFailedEvent, msg)
         self.assertEqual(cmap_events[2].reason,
                          ConnectionCheckOutFailedReason.CONN_ERROR,
-                         msg=cmap_events)
-        self.assertIsInstance(cmap_events[3], ConnectionCheckedOutEvent,
-                              msg=cmap_events)
+                         msg)
+        self.assertIsInstance(cmap_events[3], ConnectionCheckedOutEvent, msg)
 
         # Connection check out failures are not reflected in command
         # monitoring because we only publish command events _after_ checking
         # out a connection.
         started = cmd_listener.results['started']
-        self.assertEqual(3, len(started), msg=started)
+        msg = pprint.pformat(cmd_listener.results)
+        self.assertEqual(3, len(started), msg)
         succeeded = cmd_listener.results['succeeded']
-        self.assertEqual(2, len(succeeded), msg=succeeded)
+        self.assertEqual(2, len(succeeded), msg)
         failed = cmd_listener.results['failed']
-        self.assertEqual(1, len(failed), msg=failed)
+        self.assertEqual(1, len(failed), msg)
 
 
 if __name__ == "__main__":

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -146,6 +146,7 @@ class FindThread(threading.Thread):
 
 class TestPoolPausedError(SpeedyTest):
     RUN_ON_LOAD_BALANCER = True
+    RUN_ON_SERVERLESS = True
 
     @client_context.require_failCommand_blockConnection
     @client_context.require_retryable_writes

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -502,6 +502,7 @@ class InsertThread(threading.Thread):
 
 class TestPoolPausedError(SpeedyTest):
     RUN_ON_LOAD_BALANCER = True
+    RUN_ON_SERVERLESS = True
 
     @client_context.require_failCommand_blockConnection
     @client_context.require_retryable_writes

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -537,19 +537,27 @@ class TestPoolPausedError(SpeedyTest):
             ConnectionCheckedOutEvent,
             ConnectionCheckOutFailedEvent,
             PoolClearedEvent))
-        self.assertIsInstance(cmap_events[0], ConnectionCheckedOutEvent)
-        self.assertIsInstance(cmap_events[1], PoolClearedEvent)
-        self.assertIsInstance(cmap_events[2], ConnectionCheckOutFailedEvent)
+        self.assertIsInstance(cmap_events[0], ConnectionCheckedOutEvent,
+                              msg=cmap_events)
+        self.assertIsInstance(cmap_events[1], PoolClearedEvent,
+                              msg=cmap_events)
+        self.assertIsInstance(cmap_events[2], ConnectionCheckOutFailedEvent,
+                              msg=cmap_events)
         self.assertEqual(cmap_events[2].reason,
-                         ConnectionCheckOutFailedReason.CONN_ERROR)
-        self.assertIsInstance(cmap_events[3], ConnectionCheckedOutEvent)
+                         ConnectionCheckOutFailedReason.CONN_ERROR,
+                         msg=cmap_events)
+        self.assertIsInstance(cmap_events[3], ConnectionCheckedOutEvent,
+                              msg=cmap_events)
 
         # Connection check out failures are not reflected in command
         # monitoring because we only publish command events _after_ checking
         # out a connection.
-        self.assertEqual(3, len(cmd_listener.results['started']))
-        self.assertEqual(2, len(cmd_listener.results['succeeded']))
-        self.assertEqual(1, len(cmd_listener.results['failed']))
+        started = cmd_listener.results['started']
+        self.assertEqual(3, len(started), msg=started)
+        succeeded = cmd_listener.results['succeeded']
+        self.assertEqual(2, len(succeeded), msg=succeeded)
+        failed = cmd_listener.results['failed']
+        self.assertEqual(1, len(failed), msg=failed)
 
 
 # TODO: Make this a real integration test where we stepdown the primary.

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -537,27 +537,27 @@ class TestPoolPausedError(SpeedyTest):
             ConnectionCheckedOutEvent,
             ConnectionCheckOutFailedEvent,
             PoolClearedEvent))
-        self.assertIsInstance(cmap_events[0], ConnectionCheckedOutEvent,
-                              msg=cmap_events)
-        self.assertIsInstance(cmap_events[1], PoolClearedEvent,
-                              msg=cmap_events)
-        self.assertIsInstance(cmap_events[2], ConnectionCheckOutFailedEvent,
-                              msg=cmap_events)
+        import pprint
+        msg = pprint.pformat(cmap_listener.events)
+        self.assertIsInstance(cmap_events[0], ConnectionCheckedOutEvent, msg)
+        self.assertIsInstance(cmap_events[1], PoolClearedEvent, msg)
+        self.assertIsInstance(
+            cmap_events[2], ConnectionCheckOutFailedEvent, msg)
         self.assertEqual(cmap_events[2].reason,
                          ConnectionCheckOutFailedReason.CONN_ERROR,
-                         msg=cmap_events)
-        self.assertIsInstance(cmap_events[3], ConnectionCheckedOutEvent,
-                              msg=cmap_events)
+                         msg)
+        self.assertIsInstance(cmap_events[3], ConnectionCheckedOutEvent, msg)
 
         # Connection check out failures are not reflected in command
         # monitoring because we only publish command events _after_ checking
         # out a connection.
         started = cmd_listener.results['started']
-        self.assertEqual(3, len(started), msg=started)
+        msg = pprint.pformat(cmd_listener.results)
+        self.assertEqual(3, len(started), msg)
         succeeded = cmd_listener.results['succeeded']
-        self.assertEqual(2, len(succeeded), msg=succeeded)
+        self.assertEqual(2, len(succeeded), msg)
         failed = cmd_listener.results['failed']
-        self.assertEqual(1, len(failed), msg=failed)
+        self.assertEqual(1, len(failed), msg)
 
 
 # TODO: Make this a real integration test where we stepdown the primary.


### PR DESCRIPTION
Implements:
- https://github.com/mongodb/specifications/blob/master/source/retryable-writes/tests/README.rst#prose-tests
- https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.rst#poolclearederror-retryability-test