### PR TITLE
PYTHON-2750 Don't mark arbiter pools ready unless directly connected

### DIFF
--- a/pymongo/topology.py
+++ b/pymongo/topology.py
@@ -281,8 +281,12 @@ class Topology(object):
             # This is a stale isMaster response. Ignore it.
             return
 
+        new_td = updated_topology_description(
+            self._description, server_description)
         # CMAP: Ensure the pool is "ready" when the server is selectable.
-        if server_description.is_server_type_known:
+        if (server_description.is_readable
+                or (server_description.is_server_type_known and
+                    new_td.topology_type == TOPOLOGY_TYPE.Single)):
             server = self._servers.get(server_description.address)
             if server:
                 server.pool.ready()
@@ -295,9 +299,7 @@ class Topology(object):
                 (sd_old, server_description,
                  server_description.address, self._topology_id)))
 
-        self._description = updated_topology_description(
-            self._description, server_description)
-
+        self._description = new_td
         self._update_servers()
         self._receive_cluster_time_no_lock(server_description.cluster_time)
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -2044,6 +2044,9 @@ class TestClientPool(MockClientTest):
         # Assert that we do not create connections to unknown servers.
         arbiter = c._topology.get_server_by_address(('d', 4))
         self.assertFalse(arbiter.pool.sockets)
+        # Arbiter pool is not marked ready.
+        self.assertEqual(
+            listener.event_count(monitoring.PoolReadyEvent), 2)
 
     @client_context.require_connection
     def test_direct_client_maintains_pool_to_arbiter(self):
@@ -2068,6 +2071,9 @@ class TestClientPool(MockClientTest):
             listener.event_count(monitoring.ConnectionCreatedEvent), 1)
         arbiter = c._topology.get_server_by_address(('c', 3))
         self.assertEqual(len(arbiter.pool.sockets), 1)
+        # Arbiter pool is marked ready.
+        self.assertEqual(
+            listener.event_count(monitoring.PoolReadyEvent), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See: https://jira.mongodb.org/browse/DRIVERS-1804
And: https://github.com/mongodb/specifications/commit/7c9af915f6e0d8d73e97805cdb501f8a74a40fab