### PR TITLE
PYTHON-2816 Generate pip < 20.3 compatible manylinux wheels (#679)

### DIFF
--- a/.evergreen/build-manylinux-internal.sh
+++ b/.evergreen/build-manylinux-internal.sh
@@ -19,9 +19,9 @@ for PYTHON in /opt/python/*/bin/python; do
     $PYTHON setup.py bdist_wheel
     rm -rf build
 
-    # Audit wheels and write multilinux tag
+    # Audit wheels and write manylinux tag
     for whl in dist/*.whl; do
-        # Skip already built manylinux1 wheels.
+        # Skip already built manylinux wheels.
         if [[ "$whl" != *"manylinux"* ]]; then
             auditwheel repair $whl -w dist
             rm $whl

--- a/.evergreen/build-manylinux.sh
+++ b/.evergreen/build-manylinux.sh
@@ -2,16 +2,32 @@
 
 docker version
 
-# 2020-03-20-2fda31c Was the last release to include Python 3.4.
-images=(quay.io/pypa/manylinux1_x86_64:2020-03-20-2fda31c \
-        quay.io/pypa/manylinux1_i686:2020-03-20-2fda31c \
-        quay.io/pypa/manylinux1_x86_64 \
-        quay.io/pypa/manylinux1_i686 \
-        quay.io/pypa/manylinux2014_x86_64 \
-        quay.io/pypa/manylinux2014_i686 \
-        quay.io/pypa/manylinux2014_aarch64 \
-        quay.io/pypa/manylinux2014_ppc64le \
-        quay.io/pypa/manylinux2014_s390x)
+# manylinux1 2021-05-05-b64d921 and manylinux2014 2021-05-05-1ac6ef3 were
+# the last releases to generate pip < 20.3 compatible wheels. After that
+# auditwheel was upgraded to v4 which produces PEP 600 manylinux_x_y wheels
+# which requires pip >= 20.3. We use the older docker image to support older
+# pip versions.
+BUILD_WITH_TAG="$1"
+if [ -n "$BUILD_WITH_TAG" ]; then
+  # 2020-03-20-2fda31c Was the last release to include Python 3.4.
+  images=(quay.io/pypa/manylinux1_x86_64:2020-03-20-2fda31c \
+          quay.io/pypa/manylinux1_i686:2020-03-20-2fda31c \
+          quay.io/pypa/manylinux1_x86_64:2021-05-05-b64d921 \
+          quay.io/pypa/manylinux1_i686:2021-05-05-b64d921 \
+          quay.io/pypa/manylinux2014_x86_64:2021-05-05-1ac6ef3 \
+          quay.io/pypa/manylinux2014_i686:2021-05-05-1ac6ef3 \
+          quay.io/pypa/manylinux2014_aarch64:2021-05-05-1ac6ef3 \
+          quay.io/pypa/manylinux2014_ppc64le:2021-05-05-1ac6ef3 \
+          quay.io/pypa/manylinux2014_s390x:2021-05-05-1ac6ef3)
+else
+  images=(quay.io/pypa/manylinux1_x86_64 \
+          quay.io/pypa/manylinux1_i686 \
+          quay.io/pypa/manylinux2014_x86_64 \
+          quay.io/pypa/manylinux2014_i686 \
+          quay.io/pypa/manylinux2014_aarch64 \
+          quay.io/pypa/manylinux2014_ppc64le \
+          quay.io/pypa/manylinux2014_s390x)
+fi
 
 for image in "${images[@]}"; do
   docker pull $image

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -827,6 +827,24 @@ functions:
           # Remove all Docker images
           docker rmi -f $(docker images -a -q) &> /dev/null || true
 
+  "upload release":
+    - command: archive.targz_pack
+      params:
+        target: "release-files.tgz"
+        source_dir: "src/dist"
+        include:
+          - "*"
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: release-files.tgz
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/release/${task_id}-${execution}-release-files.tar.gz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/gzip}
+        display_name: Release files
+
 pre:
   - func: "fetch source"
   - func: "prepare resources"
@@ -878,7 +896,6 @@ tasks:
                genhtml --version || true
                valgrind --version || true
 
-
     - name: "release"
       tags: ["release"]
       exec_timeout_secs: 216000  # 60 minutes (manylinux task is slow).
@@ -891,22 +908,21 @@ tasks:
               set -o xtrace
               ${PREPARE_SHELL}
               .evergreen/release.sh
-        - command: archive.targz_pack
+        - func: "upload release"
+
+    - name: "release-old-manylinux"
+      tags: ["release"]
+      exec_timeout_secs: 216000  # 60 minutes (manylinux task is slow).
+      commands:
+        - command: shell.exec
+          type: test
           params:
-            target: "release-files.tgz"
-            source_dir: "src/dist"
-            include:
-              - "*"
-        - command: s3.put
-          params:
-            aws_key: ${aws_key}
-            aws_secret: ${aws_secret}
-            local_file: release-files.tgz
-            remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/release/${task_id}-${execution}-release-files.tar.gz
-            bucket: mciuploads
-            permissions: public-read
-            content_type: ${content_type|application/gzip}
-            display_name: Release files
+            working_dir: "src"
+            script: |
+              set -o xtrace
+              ${PREPARE_SHELL}
+              .evergreen/build-manylinux.sh BUILD_WITH_TAG
+        - func: "upload release"
 
 # Standard test tasks {{{
 
@@ -2757,6 +2773,12 @@ buildvariants:
   batchtime: 20160 # 14 days
   tasks:
     - name: "release"
+  rules:
+    - if:
+        platform: ubuntu-20.04
+      then:
+        add_tasks:
+          - name: "release-old-manylinux"
 
       # Platform notes
       # i386 builds of OpenSSL or Cyrus SASL are not available


### PR DESCRIPTION
Split old/new manylinux wheel generation into two tasks.

(cherry picked from commit a949142480856ebce0f9b769ba61b011564e9f2a)

Testing before merging.