### PR TITLE
PYTHON-2856 Properly assert 0 events in snapshot reads tests

### DIFF
--- a/test/sessions/unified/snapshot-sessions-not-supported-client-error.json
+++ b/test/sessions/unified/snapshot-sessions-not-supported-client-error.json
@@ -70,7 +70,12 @@
           }
         }
       ],
-      "expectEvents": []
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
     },
     {
       "description": "Client error on aggregate with snapshot",
@@ -88,7 +93,12 @@
           }
         }
       ],
-      "expectEvents": []
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
     },
     {
       "description": "Client error on distinct with snapshot",
@@ -107,7 +117,12 @@
           }
         }
       ],
-      "expectEvents": []
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
     }
   ]
 }

--- a/test/unified-test-format/invalid/test-expectEvents-minItems.json
+++ b/test/unified-test-format/invalid/test-expectEvents-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "test-expectEvents-minItems",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": []
+    }
+  ]
+}

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1132,7 +1132,10 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         self.run_operations(spec['operations'])
 
         # process expectEvents
-        self.check_events(spec.get('expectEvents', []))
+        if 'expectEvents' in spec:
+            expect_events = spec['expectEvents']
+            self.assertTrue(expect_events, 'expectEvents must be non-empty')
+            self.check_events(expect_events)
 
         # process outcome
         self.verify_outcome(spec.get('outcome', []))


### PR DESCRIPTION
Implementing https://github.com/mongodb/specifications/pull/1046