### PR TITLE
PYTHON-2534 Avoid race in test_pool_paused_error_is_retryable

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -776,8 +776,8 @@ class ClientContext(object):
         """
         return self._require(
             lambda: (self.test_commands_enabled and (
-                (not self.is_mongos and self.version >= (4, 2, 9))) or
-                (self.is_mongos and self.version >= (4, 4))),
+                (not self.is_mongos and self.version >= (4, 2, 9)) or
+                (self.is_mongos and self.version >= (4, 4)))),
             "failCommand blockConnection is not supported",
             func=func)
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -154,7 +154,7 @@ class client_knobs(object):
         self.old_min_heartbeat_interval = None
         self.old_kill_cursor_frequency = None
         self.old_events_queue_frequency = None
-        self._enabled = True
+        self._enabled = False
         self._stack = None
 
     def enable(self):

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -163,23 +163,33 @@ class TestPoolPausedError(IntegrationTest):
             maxPoolSize=1,
             event_listeners=[cmap_listener, cmd_listener])
         self.addCleanup(client.close)
-        threads = [FindThread(client.pymongo_test.test) for _ in range(2)]
-        fail_command = {
-            'mode': {'times': 1},
-            'data': {
-                'failCommands': ['find'],
-                'blockConnection': True,
-                'blockTimeMS': 1000,
-                'errorCode': 91,
-            },
-        }
-        with self.fail_point(fail_command):
-            for thread in threads:
-                thread.start()
-            for thread in threads:
-                thread.join()
-            for thread in threads:
-                self.assertTrue(thread.passed)
+        for _ in range(10):
+            cmap_listener.reset()
+            cmd_listener.reset()
+            threads = [FindThread(client.pymongo_test.test) for _ in range(2)]
+            fail_command = {
+                'mode': {'times': 1},
+                'data': {
+                    'failCommands': ['find'],
+                    'blockConnection': True,
+                    'blockTimeMS': 1000,
+                    'errorCode': 91,
+                },
+            }
+            with self.fail_point(fail_command):
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+                for thread in threads:
+                    self.assertTrue(thread.passed)
+
+            # It's possible that SDAM can rediscover the server and mark the
+            # pool ready before the thread in the wait queue has a chance
+            # to run. Repeat the test until the thread actually encounters
+            # a PoolClearedError.
+            if cmap_listener.event_count(ConnectionCheckOutFailedEvent):
+                break
 
         # Via CMAP monitoring, assert that the first check out succeeds.
         cmap_events = cmap_listener.events_by_type((

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -515,24 +515,33 @@ class TestPoolPausedError(IntegrationTest):
             maxPoolSize=1,
             event_listeners=[cmap_listener, cmd_listener])
         self.addCleanup(client.close)
-        threads = [InsertThread(client.pymongo_test.test) for _ in range(2)]
-        fail_command = {
-            'mode': {'times': 1},
-            'data': {
-                'failCommands': ['insert'],
-                'blockConnection': True,
-                'blockTimeMS': 1000,
-                'errorCode': 91,
-                'errorLabels': ['RetryableWriteError'],
-            },
-        }
-        with self.fail_point(fail_command):
-            for thread in threads:
-                thread.start()
-            for thread in threads:
-                thread.join()
-            for thread in threads:
-                self.assertTrue(thread.passed)
+        for _ in range(10):
+            cmap_listener.reset()
+            cmd_listener.reset()
+            threads = [InsertThread(client.pymongo_test.test) for _ in range(2)]
+            fail_command = {
+                'mode': {'times': 1},
+                'data': {
+                    'failCommands': ['insert'],
+                    'blockConnection': True,
+                    'blockTimeMS': 1000,
+                    'errorCode': 91,
+                    'errorLabels': ['RetryableWriteError'],
+                },
+            }
+            with self.fail_point(fail_command):
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+                for thread in threads:
+                    self.assertTrue(thread.passed)
+            # It's possible that SDAM can rediscover the server and mark the
+            # pool ready before the thread in the wait queue has a chance
+            # to run. Repeat the test until the thread actually encounters
+            # a PoolClearedError.
+            if cmap_listener.event_count(ConnectionCheckOutFailedEvent):
+                break
 
         # Via CMAP monitoring, assert that the first check out succeeds.
         cmap_events = cmap_listener.events_by_type((


### PR DESCRIPTION
Fixes this test failure:
```
[2021/08/06 23:40:10.617] FAIL [1.020s]: test_pool_paused_error_is_retryable (test_retryable_writes.TestPoolPausedError)
--
[2021/08/06 23:40:10.617] ----------------------------------------------------------------------
[2021/08/06 23:40:10.617] Traceback (most recent call last):
[2021/08/06 23:40:10.617]   File "/data/mci/f83875c397b2c8b56542a4fad582fb33/src/test/__init__.py", line 547, in wrap
[2021/08/06 23:40:10.617]     return f(*args, **kwargs)
[2021/08/06 23:40:10.617]   File "/data/mci/f83875c397b2c8b56542a4fad582fb33/src/test/__init__.py", line 547, in wrap
[2021/08/06 23:40:10.617]     return f(*args, **kwargs)
[2021/08/06 23:40:10.617]   File "/data/mci/f83875c397b2c8b56542a4fad582fb33/src/test/__init__.py", line 199, in wrap
[2021/08/06 23:40:10.617]     return f(*args, **kwargs)
[2021/08/06 23:40:10.617]   File "/data/mci/f83875c397b2c8b56542a4fad582fb33/src/test/test_retryable_writes.py", line 546, in test_pool_paused_error_is_retryable
[2021/08/06 23:40:10.617]     cmap_events[2], ConnectionCheckOutFailedEvent, msg)
[2021/08/06 23:40:10.617] AssertionError: ConnectionCheckedOutEvent(('localhost', 27017), 2) is not an instance of <class 'pymongo.monitoring.ConnectionCheckOutFailedEvent'> : [PoolCreatedEvent(('localhost', 27017), {'maxPoolSize': 1}),
[2021/08/06 23:40:10.617]  PoolReadyEvent(('localhost', 27017)),
[2021/08/06 23:40:10.617]  ConnectionCheckOutStartedEvent(('localhost', 27017)),
[2021/08/06 23:40:10.617]  ConnectionCreatedEvent(('localhost', 27017), 1),
[2021/08/06 23:40:10.617]  ConnectionCheckOutStartedEvent(('localhost', 27017)),
[2021/08/06 23:40:10.617]  ConnectionReadyEvent(('localhost', 27017), 1),
[2021/08/06 23:40:10.617]  ConnectionCheckedOutEvent(('localhost', 27017), 1),
[2021/08/06 23:40:10.617]  PoolClearedEvent(('localhost', 27017), None),
[2021/08/06 23:40:10.617]  ConnectionCheckedInEvent(('localhost', 27017), 1),
[2021/08/06 23:40:10.617]  ConnectionClosedEvent(('localhost', 27017), 1, 'stale'),
[2021/08/06 23:40:10.617]  PoolReadyEvent(('localhost', 27017)),
[2021/08/06 23:40:10.617]  ConnectionCreatedEvent(('localhost', 27017), 2),
[2021/08/06 23:40:10.617]  ConnectionCheckOutStartedEvent(('localhost', 27017)),
[2021/08/06 23:40:10.617]  ConnectionReadyEvent(('localhost', 27017), 2),
[2021/08/06 23:40:10.617]  ConnectionCheckedOutEvent(('localhost', 27017), 2),
[2021/08/06 23:40:10.617]  ConnectionCheckedInEvent(('localhost', 27017), 2),
[2021/08/06 23:40:10.617]  ConnectionCheckedOutEvent(('localhost', 27017), 2),
[2021/08/06 23:40:10.617]  ConnectionCheckedInEvent(('localhost', 27017), 2)]
[2021/08/06 23:40:10.775] ----------------------------------------------------------------------

```