### PR TITLE
PYTHON-2883 Regex decoding error tests in top.json have unexpected, invalid syntax

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -634,13 +634,13 @@ def _parse_canonical_code(doc):
 def _parse_canonical_regex(doc):
     """Decode a JSON regex to bson.regex.Regex."""
     regex = doc['$regularExpression']
-    if not isinstance(regex['options'], str):
-        raise TypeError('Bad $regularExpression options, options must be string')
     if len(doc) != 1:
         raise TypeError('Bad $regularExpression, extra field(s): %s' % (doc,))
     if len(regex) != 2:
         raise TypeError('Bad $regularExpression must include only "pattern"'
                         'and "options" components: %s' % (doc,))
+    if not isinstance(regex['options'], str):
+        raise TypeError('Bad $regularExpression options, options must be string, was type %s' % (type(regex['options'])))
     return Regex(regex['pattern'], regex['options'])
 
 

--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -467,7 +467,6 @@ def object_hook(dct, json_options=DEFAULT_JSON_OPTIONS):
     if "$dbPointer" in dct:
         return _parse_canonical_dbpointer(dct)
     if "$regularExpression" in dct:
-        print(_parse_canonical_regex(dct))
         return _parse_canonical_regex(dct)
     if "$symbol" in dct:
         return _parse_canonical_symbol(dct)
@@ -633,7 +632,6 @@ def _parse_canonical_code(doc):
 
 
 def _parse_canonical_regex(doc):
-
     """Decode a JSON regex to bson.regex.Regex."""
     regex = doc['$regularExpression']
     if not isinstance(regex['options'], str):

--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -639,10 +639,11 @@ def _parse_canonical_regex(doc):
     if len(regex) != 2:
         raise TypeError('Bad $regularExpression must include only "pattern"'
                         'and "options" components: %s' % (doc,))
-    if not isinstance(regex['options'], str):
+    opts = regex['options']
+    if not isinstance(opts, str):
         raise TypeError('Bad $regularExpression options, options must be '
-                        'string, was type %s' % (type(regex['options'])))
-    return Regex(regex['pattern'], regex['options'])
+                        'string, was type %s' % (type(opts)))
+    return Regex(regex['pattern'], opts)
 
 
 def _parse_canonical_dbref(doc):

--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -467,6 +467,7 @@ def object_hook(dct, json_options=DEFAULT_JSON_OPTIONS):
     if "$dbPointer" in dct:
         return _parse_canonical_dbpointer(dct)
     if "$regularExpression" in dct:
+        print(_parse_canonical_regex(dct))
         return _parse_canonical_regex(dct)
     if "$symbol" in dct:
         return _parse_canonical_symbol(dct)
@@ -632,8 +633,11 @@ def _parse_canonical_code(doc):
 
 
 def _parse_canonical_regex(doc):
+
     """Decode a JSON regex to bson.regex.Regex."""
     regex = doc['$regularExpression']
+    if not isinstance(regex['options'], str):
+        raise TypeError('Bad $regularExpression options, options must be string')
     if len(doc) != 1:
         raise TypeError('Bad $regularExpression, extra field(s): %s' % (doc,))
     if len(regex) != 2:

--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -640,7 +640,8 @@ def _parse_canonical_regex(doc):
         raise TypeError('Bad $regularExpression must include only "pattern"'
                         'and "options" components: %s' % (doc,))
     if not isinstance(regex['options'], str):
-        raise TypeError('Bad $regularExpression options, options must be string, was type %s' % (type(regex['options'])))
+        raise TypeError('Bad $regularExpression options, options must be '
+                        'string, was type %s' % (type(regex['options'])))
     return Regex(regex['pattern'], regex['options'])
 
 

--- a/test/bson_corpus/top.json
+++ b/test/bson_corpus/top.json
@@ -92,11 +92,11 @@
         },
         {
             "description": "Bad $regularExpression (pattern is number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"$options\" : \"\"}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"options\" : \"\"}}}"
         },
         {
             "description": "Bad $regularExpression (options are number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"$options\" : 0}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"options\" : 0}}}"
         },
         {
             "description" : "Bad $regularExpression (missing pattern field)",


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-2883