### PR TITLE
PYTHON-2899 Fix "no server" tests and cleanup docs

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -125,7 +125,7 @@ Breaking Changes in 4.0
   ignored by pip.
 - ``tz_aware``, an argument for :class:`~bson.json_util.JSONOptions`,
   now defaults to ``False`` instead of ``True``. ``json_util.loads`` now
-decodes datetime as naive by default.
+  decodes datetime as naive by default.
 - ``directConnection`` URI option and keyword argument to :class:`~pymongo.mongo_client.MongoClient`
   defaults to ``False`` instead of ``None``, allowing for the automatic
   discovery of replica sets. This means that if you

--- a/doc/migrate-to-pymongo4.rst
+++ b/doc/migrate-to-pymongo4.rst
@@ -141,32 +141,22 @@ instead. For example::
 MongoClient.unlock is removed
 .............................
 
-Removed :meth:`pymongo.mongo_client.MongoClient.unlock`. Users of MongoDB
-version 3.2 or newer can run the `fsyncUnlock command`_ directly with
-:meth:`~pymongo.database.Database.command`::
+Removed :meth:`pymongo.mongo_client.MongoClient.unlock`. Run the
+`fsyncUnlock command`_ directly with
+:meth:`~pymongo.database.Database.command` instead. For example::
 
      client.admin.command('fsyncUnlock')
-
-Users of MongoDB version 2.6 and 3.0 can query the "unlock" virtual
-collection::
-
-    client.admin["$cmd.sys.unlock"].find_one()
 
 .. _fsyncUnlock command: https://docs.mongodb.com/manual/reference/command/fsyncUnlock/
 
 MongoClient.is_locked is removed
 ................................
 
-Removed :attr:`pymongo.mongo_client.MongoClient.is_locked`. Users of MongoDB
-version 3.2 or newer can run the `currentOp command`_ directly with
-:meth:`~pymongo.database.Database.command`::
+Removed :attr:`pymongo.mongo_client.MongoClient.is_locked`. Run the
+`currentOp command`_ directly with
+:meth:`~pymongo.database.Database.command` instead. For example::
 
     is_locked = client.admin.command('currentOp').get('fsyncLock')
-
-Users of MongoDB version 2.6 and 3.0 can query the "inprog" virtual
-collection::
-
-    is_locked = client.admin["$cmd.sys.inprog"].find_one().get('fsyncLock')
 
 .. _currentOp command: https://docs.mongodb.com/manual/reference/command/currentOp/
 

--- a/test/test_decimal128.py
+++ b/test/test_decimal128.py
@@ -26,6 +26,7 @@ from test import client_context, unittest
 
 class TestDecimal128(unittest.TestCase):
 
+    @client_context.require_connection
     def test_round_trip(self):
         coll = client_context.client.pymongo_test.test
         coll.drop()


### PR DESCRIPTION
Fixes this "no server" test failure: https://evergreen.mongodb.com/task/mongo_python_driver_no_server_no_server_11752ed594f8d0fd3dac342b01b6c2e1a594e458_21_09_16_23_53_50

Also removes some more MongoDB <= 3.4 info from the migration guide.