### PR TITLE
PYTHON-2944 Use get-pip for EOL Python versions

### DIFF
--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -26,12 +26,11 @@ createvirtualenv () {
     # Upgrade to the latest versions of pip setuptools wheel so that
     # pip can always download the latest cryptography+cffi wheels.
     PYTHON_VERSION=$(python -c 'import sys;print("%s.%s" % sys.version_info[:2])')
-    if [[ $PYTHON_VERSION == "3.4" ]]; then
-        # pip 19.2 dropped support for Python 3.4.
-        python -m pip install --upgrade 'pip<19.2'
-    elif [[ $PYTHON_VERSION == "2.7" || $PYTHON_VERSION == "3.5" ]]; then
-        # pip 21 will drop support for Python 2.7 and 3.5.
-        python -m pip install --upgrade 'pip<21'
+    if [[ $PYTHON_VERSION == "2.7" || $PYTHON_VERSION == "3.4" || $PYTHON_VERSION == "3.5" ]]; then
+        # Use get-pip for EOL Python versions.
+        curl -sSL https://bootstrap.pypa.io/pip/${PYTHON_VERSION}/get-pip.py -o get-pip.py
+        python get-pip.py
+        rm get-pip.py
     else
         python -m pip install --upgrade pip
     fi


### PR DESCRIPTION
This fixes the error in the macos release task:
```
[2021/08/11 04:53:33.871]   DEPRECATION: Failed to find 'wheel' at https://artifactory.corp.mongodb.com/artifactory/api/pypi/pypi/simple/wheel/. It is suggested to upgrade your index to support normalized names as the name in /simple/{name}.
--
[2021/08/11 04:53:33.923]   Could not find a version that satisfies the requirement wheel (from versions: )
[2021/08/11 04:53:33.955] Collecting wheel
[2021/08/11 04:53:33.955] No matching distribution found for wheel
[2021/08/11 04:53:33.955] Command failed: command encountered problem: error waiting on process '6db7492e-42a4-48bd-a54c-379d4c49e860': exit status 1
[2021/08/11 04:53:33.955] Task completed - FAILURE.
````

Here is a patch: https://spruce.mongodb.com/version/616748c0d6d80a1c9a16dfa9
