### PR TITLE
PYTHON-2926 Unskip test_readConcern_available_with_out_stage on 5.1+

### DIFF
--- a/test/crud/unified/aggregate-out-readConcern.json
+++ b/test/crud/unified/aggregate-out-readConcern.json
@@ -262,11 +262,6 @@
     },
     {
       "description": "readConcern available with out stage",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "5.0.99"
-        }
-      ],
       "operations": [
         {
           "object": "collection_readConcern_available",


### PR DESCRIPTION
Already verified using evergreen patch tool that the `test_crud_unified.TestUnifiedAggregateOutReadConcern.test_readConcern_available_with_out_stage` test is in fact being run on sharded-cluster-latest. 