### PR TITLE
PYTHON-2164 Remove client max_bson_size/max_message_size/max_write_batch_size

### DIFF
--- a/doc/api/pymongo/mongo_client.rst
+++ b/doc/api/pymongo/mongo_client.rst
@@ -26,9 +26,6 @@
       .. autoattribute:: min_pool_size
       .. autoattribute:: max_idle_time_ms
       .. autoattribute:: nodes
-      .. autoattribute:: max_bson_size
-      .. autoattribute:: max_message_size
-      .. autoattribute:: max_write_batch_size
       .. autoattribute:: local_threshold_ms
       .. autoattribute:: server_selection_timeout
       .. autoattribute:: codec_options

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -33,6 +33,9 @@ Breaking Changes in 4.0
   :meth:`pymongo.mongo_client.MongoClient.unlock`, and
   :attr:`pymongo.mongo_client.MongoClient.is_locked`.
 - Removed :meth:`pymongo.mongo_client.MongoClient.database_names`.
+- Removed :attr:`pymongo.mongo_client.MongoClient.max_bson_size`.
+- Removed :attr:`pymongo.mongo_client.MongoClient.max_message_size`.
+- Removed :attr:`pymongo.mongo_client.MongoClient.max_write_batch_size`.
 - Removed :meth:`pymongo.database.Database.eval`,
   :data:`pymongo.database.Database.system_js` and
   :class:`pymongo.database.SystemJS`.

--- a/doc/migrate-to-pymongo4.rst
+++ b/doc/migrate-to-pymongo4.rst
@@ -173,6 +173,27 @@ can be changed to this::
 
     names = client.list_database_names()
 
+MongoClient.max_bson_size/max_message_size/max_write_batch_size are removed
+...........................................................................
+
+Removed :attr:`pymongo.mongo_client.MongoClient.max_bson_size`,
+:attr:`pymongo.mongo_client.MongoClient.max_message_size`, and
+:attr:`pymongo.mongo_client.MongoClient.max_write_batch_size`.
+Use the `hello command`_ instead. Code like this::
+
+    max_bson_size = client.max_bson_size
+    max_message_size = client.max_message_size
+    max_write_batch_size = client.max_write_batch_size
+
+can be changed to this::
+
+    doc = client.admin.command('hello')
+    max_bson_size = doc['maxBsonObjectSize']
+    max_message_size = doc['maxMessageSizeBytes']
+    max_write_batch_size = doc['maxWriteBatchSize']
+
+.. _hello command: https://docs.mongodb.com/manual/reference/command/hello/
+
 ``tz_aware`` defaults to ``False``
 ..................................
 

--- a/doc/migrate-to-pymongo4.rst
+++ b/doc/migrate-to-pymongo4.rst
@@ -178,8 +178,10 @@ MongoClient.max_bson_size/max_message_size/max_write_batch_size are removed
 
 Removed :attr:`pymongo.mongo_client.MongoClient.max_bson_size`,
 :attr:`pymongo.mongo_client.MongoClient.max_message_size`, and
-:attr:`pymongo.mongo_client.MongoClient.max_write_batch_size`.
-Use the `hello command`_ instead. Code like this::
+:attr:`pymongo.mongo_client.MongoClient.max_write_batch_size`. These helpers
+were incorrect when in ``loadBalanced=true mode`` and ambiguous in clusters
+with mixed versions. Use the `hello command`_ to get the authoritative
+value from the remote server instead. Code like this::
 
     max_bson_size = client.max_bson_size
     max_message_size = client.max_message_size

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1054,39 +1054,6 @@ class MongoClient(common.BaseObject):
         return frozenset(s.address for s in description.known_servers)
 
     @property
-    def max_bson_size(self):
-        """The largest BSON object the connected server accepts in bytes.
-
-        If the client is not connected, this will block until a connection is
-        established or raise ServerSelectionTimeoutError if no server is
-        available.
-        """
-        return self._server_property('max_bson_size')
-
-    @property
-    def max_message_size(self):
-        """The largest message the connected server accepts in bytes.
-
-        If the client is not connected, this will block until a connection is
-        established or raise ServerSelectionTimeoutError if no server is
-        available.
-        """
-        return self._server_property('max_message_size')
-
-    @property
-    def max_write_batch_size(self):
-        """The maxWriteBatchSize reported by the server.
-
-        If the client is not connected, this will block until a connection is
-        established or raise ServerSelectionTimeoutError if no server is
-        available.
-
-        Returns a default value when connected to server versions prior to
-        MongoDB 2.6.
-        """
-        return self._server_property('max_write_batch_size')
-
-    @property
     def local_threshold_ms(self):
         """The local threshold for this instance."""
         return self.__options.local_threshold_ms

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -60,7 +60,8 @@ from pymongo.errors import (AutoReconnect,
                             ServerSelectionTimeoutError)
 from pymongo.pool import ConnectionClosedReason
 from pymongo.read_preferences import ReadPreference
-from pymongo.server_selectors import writable_server_selector
+from pymongo.server_selectors import (any_server_selector,
+                                      writable_server_selector)
 from pymongo.server_type import SERVER_TYPE
 from pymongo.topology import (Topology,
                               _ErrorContext)
@@ -796,9 +797,8 @@ class MongoClient(common.BaseObject):
         the server may change. In such cases, store a local reference to a
         ServerDescription first, then use its properties.
         """
-        server = self._topology.select_server(
-            writable_server_selector)
-
+        topology = self._get_topology()  # Starts monitors if necessary.
+        server = topology.select_server(writable_server_selector)
         return getattr(server.description, attr_name)
 
     def watch(self, pipeline=None, full_document=None, resume_after=None,
@@ -937,16 +937,16 @@ class MongoClient(common.BaseObject):
 
         .. versionadded:: 3.0
         """
-        topology_type = self._topology._description.topology_type
+        # Block until we discover the topology type.
+        self._get_topology().select_server(any_server_selector)
+        td = self.topology_description
+        topology_type = td.topology_type
         if (topology_type == TOPOLOGY_TYPE.Sharded and
-                len(self.topology_description.server_descriptions()) > 1):
+                len(td.server_descriptions()) > 1):
             raise InvalidOperation(
                 'Cannot use "address" property when load balancing among'
                 ' mongoses, use "nodes" instead.')
-        if topology_type not in (TOPOLOGY_TYPE.ReplicaSetWithPrimary,
-                                 TOPOLOGY_TYPE.Single,
-                                 TOPOLOGY_TYPE.LoadBalanced,
-                                 TOPOLOGY_TYPE.Sharded):
+        if topology_type == TOPOLOGY_TYPE.ReplicaSetNoPrimary:
             return None
         return self._server_property('address')
 

--- a/test/test_bulk.py
+++ b/test/test_bulk.py
@@ -283,7 +283,7 @@ class TestBulk(BulkTestBase):
 
     def test_numerous_inserts(self):
         # Ensure we don't exceed server's maxWriteBatchSize size limit.
-        n_docs = self.client.max_write_batch_size + 100
+        n_docs = client_context.max_write_batch_size + 100
         requests = [InsertOne({}) for _ in range(n_docs)]
         result = self.coll.bulk_write(requests, ordered=False)
         self.assertEqual(n_docs, result.inserted_count)
@@ -344,7 +344,7 @@ class TestBulk(BulkTestBase):
             self.coll.bulk_write([{}])
 
     def test_upsert_large(self):
-        big = 'a' * (client_context.client.max_bson_size - 37)
+        big = 'a' * (client_context.max_bson_size - 37)
         result = self.coll.bulk_write([
             UpdateOne({'x': 1}, {'$set': {'s': big}}, upsert=True)])
         self.assertEqualResponse(
@@ -566,7 +566,7 @@ class TestBulk(BulkTestBase):
             result)
 
     def test_large_inserts_ordered(self):
-        big = 'x' * self.coll.database.client.max_bson_size
+        big = 'x' * client_context.max_bson_size
         requests = [
             InsertOne({'b': 1, 'a': 1}),
             InsertOne({'big': big}),
@@ -599,7 +599,7 @@ class TestBulk(BulkTestBase):
         self.assertEqual(6, self.coll.count_documents({}))
 
     def test_large_inserts_unordered(self):
-        big = 'x' * self.coll.database.client.max_bson_size
+        big = 'x' * client_context.max_bson_size
         requests = [
             InsertOne({'b': 1, 'a': 1}),
             InsertOne({'big': big}),

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -646,7 +646,8 @@ class TestClient(IntegrationTest):
         c = rs_or_single_client(connect=False)
         self.assertIsInstance(c.topology_description, TopologyDescription)
         self.assertEqual(c.topology_description, c._topology._description)
-
+        self.assertIsNone(c.address)  # PYTHON-2981
+        c.admin.command('ping')  # connect
         if client_context.is_rs:
             # The primary's host and port are from the replica set config.
             self.assertIsNotNone(c.address)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -640,12 +640,10 @@ class TestClient(IntegrationTest):
 
         c = rs_or_single_client(connect=False)
         self.assertEqual(c.codec_options, CodecOptions())
-        self.assertIsInstance(c.max_bson_size, int)
         c = rs_or_single_client(connect=False)
         self.assertFalse(c.primary)
         self.assertFalse(c.secondaries)
         c = rs_or_single_client(connect=False)
-        self.assertIsInstance(c.max_write_batch_size, int)
         self.assertIsInstance(c.topology_description, TopologyDescription)
         self.assertEqual(c.topology_description, c._topology._description)
 
@@ -1834,17 +1832,6 @@ class TestClientLazyConnect(IntegrationTest):
             self.assertEqual(NTHREADS, len(results))
 
         lazy_client_trial(reset, find_one, test, self._get_client)
-
-    def test_max_bson_size(self):
-        c = self._get_client()
-
-        # max_bson_size will cause the client to connect.
-        hello = c.db.command(HelloCompat.LEGACY_CMD)
-        self.assertEqual(hello['maxBsonObjectSize'], c.max_bson_size)
-        if 'maxMessageSizeBytes' in hello:
-            self.assertEqual(
-                hello['maxMessageSizeBytes'],
-                c.max_message_size)
 
 
 class TestMongoClientFailover(MockClientTest):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -644,18 +644,18 @@ class TestClient(IntegrationTest):
         self.assertFalse(c.primary)
         self.assertFalse(c.secondaries)
         c = rs_or_single_client(connect=False)
-        self.assertIsInstance(c.topology_description, TopologyDescription)
-        self.assertEqual(c.topology_description, c._topology._description)
-
         if client_context.is_rs:
             # The primary's host and port are from the replica set config.
             self.assertIsNotNone(c.address)
         else:
             self.assertEqual(c.address, (host, port))
+        self.assertIsInstance(c.topology_description, TopologyDescription)
+        self.assertEqual(c.topology_description, c._topology._description)
 
         bad_host = "somedomainthatdoesntexist.org"
         c = MongoClient(bad_host, port, connectTimeoutMS=1,
-                        serverSelectionTimeoutMS=10)
+                        serverSelectionTimeoutMS=10, connect=False)
+        self.assertRaises(ServerSelectionTimeoutError, lambda: c.address)
         self.assertRaises(ConnectionFailure, c.pymongo_test.test.find_one)
 
     def test_init_disconnected_with_auth(self):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -644,18 +644,18 @@ class TestClient(IntegrationTest):
         self.assertFalse(c.primary)
         self.assertFalse(c.secondaries)
         c = rs_or_single_client(connect=False)
+        self.assertIsInstance(c.topology_description, TopologyDescription)
+        self.assertEqual(c.topology_description, c._topology._description)
+
         if client_context.is_rs:
             # The primary's host and port are from the replica set config.
             self.assertIsNotNone(c.address)
         else:
             self.assertEqual(c.address, (host, port))
-        self.assertIsInstance(c.topology_description, TopologyDescription)
-        self.assertEqual(c.topology_description, c._topology._description)
 
         bad_host = "somedomainthatdoesntexist.org"
         c = MongoClient(bad_host, port, connectTimeoutMS=1,
-                        serverSelectionTimeoutMS=10, connect=False)
-        self.assertRaises(ServerSelectionTimeoutError, lambda: c.address)
+                        serverSelectionTimeoutMS=10)
         self.assertRaises(ConnectionFailure, c.pymongo_test.test.find_one)
 
     def test_init_disconnected_with_auth(self):

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -851,7 +851,7 @@ class TestCollection(IntegrationTest):
             lambda: 0 == db.test.count_documents({}), 'delete 2 documents')
 
     def test_command_document_too_large(self):
-        large = '*' * (self.client.max_bson_size + _COMMAND_OVERHEAD)
+        large = '*' * (client_context.max_bson_size + _COMMAND_OVERHEAD)
         coll = self.db.test
         self.assertRaises(
             DocumentTooLarge, coll.insert_one, {'data': large})
@@ -862,7 +862,7 @@ class TestCollection(IntegrationTest):
             DocumentTooLarge, coll.delete_one, {'data': large})
 
     def test_write_large_document(self):
-        max_size = self.db.client.max_bson_size
+        max_size = client_context.max_bson_size
         half_size = int(max_size / 2)
         max_str = "x" * max_size
         half_str = "x" * half_size
@@ -1879,7 +1879,7 @@ class TestCollection(IntegrationTest):
     def test_numerous_inserts(self):
         # Ensure we don't exceed server's maxWriteBatchSize size limit.
         self.db.test.drop()
-        n_docs = self.client.max_write_batch_size + 100
+        n_docs = client_context.max_write_batch_size + 100
         self.db.test.insert_many([{} for _ in range(n_docs)])
         self.assertEqual(n_docs, self.db.test.count_documents({}))
         self.db.test.drop()
@@ -1888,7 +1888,7 @@ class TestCollection(IntegrationTest):
         # Tests legacy insert.
         db = self.client.test_insert_large_batch
         self.addCleanup(self.client.drop_database, 'test_insert_large_batch')
-        max_bson_size = self.client.max_bson_size
+        max_bson_size = client_context.max_bson_size
         # Write commands are limited to 16MB + 16k per batch
         big_string = 'x' * int(max_bson_size / 2)
 


### PR DESCRIPTION
Apps should use the hello command instead:
```python
doc = client.admin.command('hello')
max_bson_size = doc['maxBsonObjectSize']
max_message_size = doc['maxMessageSizeBytes']
max_write_batch_size = doc['maxWriteBatchSize']
```

I'll address the remaining configuration attributes (max_pool_size, min_pool_size, max_idle_time_ms, local_threshold_ms, server_selection_timeout, etc.) in a new PR.