### PR TITLE
PYTHON-2554 Support $merge and $out executing on secondaries

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 Changes in Version 4.1
 ----------------------
 
+PyMongo 4.0 brings a number of improvements including:
+
 - :meth:`pymongo.collection.Collection.update_one`,
   :meth:`pymongo.collection.Collection.update_many`,
   :meth:`pymongo.collection.Collection.delete_one`,
@@ -15,6 +17,10 @@ Changes in Version 4.1
   and :meth:`pymongo.collection.Collection.find` all support a new keyword
   argument ``let`` which is a map of parameter names and values. Parameters
   can then be accessed as variables in an aggregate expression context.
+- :meth:`~pymongo.collection.Collection.aggregate` now supports
+  $merge and $out executing on secondaries on MongoDB >=5.0.
+  aggregate() now always obeys the collection's :attr:`read_preference` on
+  MongoDB >= 5.0.
 
 
 Changes in Version 4.0

--- a/pymongo/aggregation.py
+++ b/pymongo/aggregation.py
@@ -19,7 +19,7 @@ from bson.son import SON
 from pymongo import common
 from pymongo.collation import validate_collation_or_none
 from pymongo.errors import ConfigurationError
-from pymongo.read_preferences import _AggWritePref
+from pymongo.read_preferences import _AggWritePref, ReadPreference
 
 
 class _AggregationCommand(object):
@@ -101,7 +101,7 @@ class _AggregationCommand(object):
         if self._write_preference:
             return self._write_preference
         pref = self._target._read_preference_for(session)
-        if self._performs_write:
+        if self._performs_write and pref != ReadPreference.PRIMARY:
             self._write_preference = pref = _AggWritePref(pref)
         return pref
 

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -1937,9 +1937,9 @@ class Collection(common.BaseObject):
         collection.
 
         The :meth:`aggregate` method obeys the :attr:`read_preference` of this
-        :class:`Collection`, except when ``$out`` or ``$merge`` are used, in
-        which case  :attr:`~pymongo.read_preferences.ReadPreference.PRIMARY`
-        is used.
+        :class:`Collection`, except when ``$out`` or ``$merge`` are used on
+        MongoDB <5.0, in which case
+        :attr:`~pymongo.read_preferences.ReadPreference.PRIMARY` is used.
 
         .. note:: This method does not support the 'explain' option. Please
            use :meth:`~pymongo.database.Database.command` instead. An
@@ -1981,6 +1981,8 @@ class Collection(common.BaseObject):
 
         .. versionchanged:: 4.1
            Added ``let`` parameter.
+           Support $merge and $out executing on secondaries according to the
+           collection's :attr:`read_preference`.
         .. versionchanged:: 4.0
            Removed the ``useCursor`` option.
         .. versionchanged:: 3.9

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1161,7 +1161,7 @@ class MongoClient(common.BaseObject):
 
         with self._get_socket(server, session) as sock_info:
             secondary_ok = (single and not sock_info.is_mongos) or (
-                read_preference != ReadPreference.PRIMARY)
+                read_preference.mode != ReadPreference.PRIMARY.mode)
             yield sock_info, secondary_ok
 
     @contextlib.contextmanager

--- a/pymongo/read_preferences.py
+++ b/pymongo/read_preferences.py
@@ -427,7 +427,8 @@ class Nearest(_ServerMode):
 class _AggWritePref:
     """Agg $out/$merge write preference.
 
-    * If selection via pref contains a 5.0 server, uses pref read preference.
+    * If there are no readable servers, or there is any pre-5.0 server, use
+      `pref` read preference.
     * Otherwise uses Primary().
 
     :Parameters:

--- a/pymongo/read_preferences.py
+++ b/pymongo/read_preferences.py
@@ -427,9 +427,9 @@ class Nearest(_ServerMode):
 class _AggWritePref:
     """Agg $out/$merge write preference.
 
-    * If there are no readable servers, or there is any pre-5.0 server, use
-      `pref` read preference.
-    * Otherwise uses Primary().
+    * If there are readable servers and there is any pre-5.0 server, use
+      primary read preference.
+    * Otherwise use `pref` read preference.
 
     :Parameters:
       - `pref`: The read preference to use on MongoDB 5.0+.

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -275,6 +275,8 @@ class TopologyDescription(object):
             return [description] if description else []
         elif (self.topology_type == TOPOLOGY_TYPE.Sharded and
               not isinstance(selector, _AggWritePref)):
+            # TODO: adjust _AggWritePref for sharded clusters once we select
+            # a server.
             # Ignore read preference.
             selection = Selection.from_topology_description(self)
         else:

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -19,7 +19,7 @@ from random import sample
 
 from pymongo import common
 from pymongo.errors import ConfigurationError
-from pymongo.read_preferences import ReadPreference
+from pymongo.read_preferences import ReadPreference, _AggWritePref
 from pymongo.server_description import ServerDescription
 from pymongo.server_selectors import Selection
 from pymongo.server_type import SERVER_TYPE
@@ -273,7 +273,8 @@ class TopologyDescription(object):
             # Ignore selectors when explicit address is requested.
             description = self.server_descriptions().get(address)
             return [description] if description else []
-        elif self.topology_type == TOPOLOGY_TYPE.Sharded:
+        elif (self.topology_type == TOPOLOGY_TYPE.Sharded and
+              not isinstance(selector, _AggWritePref)):
             # Ignore read preference.
             selection = Selection.from_topology_description(self)
         else:

--- a/test/crud/unified/aggregate-write-readPreference.json
+++ b/test/crud/unified/aggregate-write-readPreference.json
@@ -1,0 +1,460 @@
+{
+  "description": "aggregate-write-readPreference",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "readConcern": {
+      "level": "local"
+    },
+    "writeConcern": {
+      "w": 1
+    }
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "db0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0",
+        "collectionOptions": {
+          "readPreference": {
+            "mode": "secondaryPreferred",
+            "maxStalenessSeconds": 600
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "db0",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "db0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $out includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $out omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $merge includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll1"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll1"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $merge omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll1"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll1"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/crud/unified/aggregate-write-readPreference.json
+++ b/test/crud/unified/aggregate-write-readPreference.json
@@ -237,7 +237,7 @@
                     }
                   ],
                   "$readPreference": {
-                    "$$exists": false
+                    "mode": "primary"
                   },
                   "readConcern": {
                     "level": "local"
@@ -425,7 +425,7 @@
                     }
                   ],
                   "$readPreference": {
-                    "$$exists": false
+                    "mode": "primary"
                   },
                   "readConcern": {
                     "level": "local"

--- a/test/crud/unified/db-aggregate-write-readPreference.json
+++ b/test/crud/unified/db-aggregate-write-readPreference.json
@@ -1,0 +1,446 @@
+{
+  "description": "db-aggregate-write-readPreference",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "_yamlAnchors": {
+    "readConcern": {
+      "level": "local"
+    },
+    "writeConcern": {
+      "w": 1
+    }
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "db0",
+        "databaseOptions": {
+          "readPreference": {
+            "mode": "secondaryPreferred",
+            "maxStalenessSeconds": 600
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "db0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Database-level aggregate with $out includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll0"
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $out omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll0"
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $merge includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll0"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll0"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $merge omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll0"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll0"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/crud/unified/db-aggregate-write-readPreference.json
+++ b/test/crud/unified/db-aggregate-write-readPreference.json
@@ -222,7 +222,7 @@
                     }
                   ],
                   "$readPreference": {
-                    "$$exists": false
+                    "mode": "primary"
                   },
                   "readConcern": {
                     "level": "local"
@@ -416,7 +416,7 @@
                     }
                   ],
                   "$readPreference": {
-                    "$$exists": false
+                    "mode": "primary"
                   },
                   "readConcern": {
                     "level": "local"

--- a/test/test_read_preferences.py
+++ b/test/test_read_preferences.py
@@ -433,7 +433,9 @@ class TestCommandAndReadPreference(IntegrationTest):
                                [{'$project': {'_id': 1}}])
 
     def test_aggregate_write(self):
-        self._test_coll_helper(False, self.c.pymongo_test.test,
+        # 5.0 servers support $out on secondaries.
+        secondary_ok = client_context.version.at_least(5, 0)
+        self._test_coll_helper(secondary_ok, self.c.pymongo_test.test,
                                'aggregate',
                                [{'$project': {'_id': 1}}, {'$out': "agg_write_test"}])
 


### PR DESCRIPTION
Implementation of https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#read-preferences-and-server-selection including the changes in DRIVERS-823 and DRIVERS-1969.