### PR TITLE
PYTHON-2915 Skip large txn test on slow Windows hosts

### DIFF
--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -289,6 +289,8 @@ class TestTransactions(TransactionsBase):
     # Require 4.2+ for large (16MB+) transactions.
     @client_context.require_version_min(4, 2)
     @client_context.require_transactions
+    @unittest.skipIf(sys.platform == 'win32',
+                     'Our Windows machines are too slow to pass this test')
     def test_transaction_starts_with_batched_write(self):
         if 'PyPy' in sys.version and client_context.tls:
             self.skipTest('PYTHON-2937 PyPy is so slow sending large '


### PR DESCRIPTION
This test often fails on windows because the host is too slow. For example:
```
 [2021/11/13 01:27:37.211] ERROR: test_transaction_starts_with_batched_write (test_transactions.TestTransactions)
 [2021/11/13 01:27:37.211] ----------------------------------------------------------------------
 [2021/11/13 01:27:37.211] Traceback (most recent call last):
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\test\__init__.py", line 555, in wrap
 [2021/11/13 01:27:37.211]     return f(*args, **kwargs)
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\test\__init__.py", line 555, in wrap
 [2021/11/13 01:27:37.211]     return f(*args, **kwargs)
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\test\test_transactions.py", line 309, in test_transaction_starts_with_batched_write
 [2021/11/13 01:27:37.211]     coll.bulk_write(ops, session=session)
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\client_session.py", line 336, in __exit__
 [2021/11/13 01:27:37.211]     self.__session.commit_transaction()
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\client_session.py", line 712, in commit_transaction
 [2021/11/13 01:27:37.211]     self._finish_transaction_with_retry("commitTransaction")
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\client_session.py", line 771, in _finish_transaction_with_retry
 [2021/11/13 01:27:37.211]     return self._client._retry_internal(True, func, self, None)
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\mongo_client.py", line 1254, in _retry_internal
 [2021/11/13 01:27:37.211]     return func(session, sock_info, retryable)
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\client_session.py", line 770, in func
 [2021/11/13 01:27:37.211]     return self._finish_transaction(sock_info, command_name)
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\client_session.py", line 794, in _finish_transaction
 [2021/11/13 01:27:37.211]     return self._client.admin._command(
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\database.py", line 486, in _command
 [2021/11/13 01:27:37.211]     return sock_info.command(
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\pool.py", line 719, in command
 [2021/11/13 01:27:37.211]     return command(self, dbname, spec, secondary_ok,
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\network.py", line 158, in command
 [2021/11/13 01:27:37.211]     helpers._check_command_response(
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\helpers.py", line 127, in _check_command_response
 [2021/11/13 01:27:37.211]     _raise_write_concern_error(_error)
 [2021/11/13 01:27:37.211]   File "C:\data\mci\095314dcd9cb2f3eef50d8f626aa69ad\src\pymongo\helpers.py", line 187, in _raise_write_concern_error
 [2021/11/13 01:27:37.211]     raise WriteConcernError(
 [2021/11/13 01:27:37.211] pymongo.errors.WriteConcernError: operation was interrupted because the transaction exceeded the configured 'transactionLifetimeLimitSeconds', full error: {'code': 290, 'codeName': 'TransactionExceededLifetimeLimitSeconds', 'errmsg': "operation was interrupted because the transaction exceeded the configured 'transactionLifetimeLimitSeconds'", 'errInfo': {'writeConcern': {'w': 'majority', 'wtimeout': 0, 'provenance': 'implicitDefault'}}}
```