### PR TITLE
PYTHON-3001 Bump minimum pymongocrypt version to 1.2.0

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -179,6 +179,8 @@ Breaking Changes in 4.0
   parsing MongoDB URIs.
 - Removed the `disable_md5` parameter for :class:`~gridfs.GridFSBucket` and
   :class:`~gridfs.GridFS`. See :ref:`removed-gridfs-checksum` for details.
+- PyMongoCrypt 1.2.0 or later is now required for client side field level
+  encryption support.
 
 Notable improvements
 ....................
@@ -194,6 +196,9 @@ Notable improvements
   choose a `srvMaxHosts` sized subset of hosts.
 - Added :attr:`pymongo.mongo_client.MongoClient.options` for read-only access
   to a client's configuration options.
+- Support for the "kmip" KMS provider for client side field level encryption.
+  See the docstring for :class:`~pymongo.encryption_options.AutoEncryptionOpts`
+  and :mod:`~pymongo.encryption`.
 
 Issues Resolved
 ...............

--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -426,6 +426,10 @@ class ClientEncryption(object):
 
               kms_tls_options={'kmip': {'tlsCAFile': certifi.where()}}
 
+            Or to supply a client certificate::
+
+              kms_tls_options={'kmip': {'tlsCertificateKeyFile': 'client.pem'}}
+
         .. versionchanged:: 4.0
            Added the `kms_tls_options` parameter and the "kmip" KMS provider.
 

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -129,6 +129,10 @@ class AutoEncryptionOpts(object):
 
               kms_tls_options={'kmip': {'tlsCAFile': certifi.where()}}
 
+            Or to supply a client certificate::
+
+              kms_tls_options={'kmip': {'tlsCertificateKeyFile': 'client.pem'}}
+
         .. versionchanged:: 4.0
            Added the `kms_tls_options` parameter and the "kmip" KMS provider.
 

--- a/setup.py
+++ b/setup.py
@@ -277,7 +277,7 @@ if sys.platform in ('win32', 'darwin'):
     pyopenssl_reqs.append('certifi')
 
 extras_require = {
-    'encryption': ['pymongocrypt>=1.1.0,<2.0.0'],
+    'encryption': ['pymongocrypt>=1.2.0,<2.0.0'],
     'ocsp': pyopenssl_reqs,
     'snappy': ['python-snappy'],
     'zstd': ['zstandard'],


### PR DESCRIPTION
Depends on https://github.com/mongodb/libmongocrypt/pull/218