### PR TITLE
PYTHON-2919 Remove MongoDB 2.6-3.4 from performance testing

### DIFF
--- a/.evergreen/perf.yml
+++ b/.evergreen/perf.yml
@@ -200,28 +200,6 @@ post:
   - func: "cleanup"
 
 tasks:
-    - name: "perf-3.0-standalone"
-      tags: ["perf"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.0"
-            TOPOLOGY: "server"
-        - func: "run perf tests"
-        - func: "attach benchmark test results"
-        - func: "send dashboard data"
-
-    - name: "perf-3.4-standalone"
-      tags: ["perf"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.4"
-            TOPOLOGY: "server"
-        - func: "run perf tests"
-        - func: "attach benchmark test results"
-        - func: "send dashboard data"
-
     - name: "perf-3.6-standalone"
       tags: ["perf"]
       commands:
@@ -273,8 +251,6 @@ buildvariants:
   batchtime: 10080  # 7 days
   run_on: centos6-perf
   tasks:
-     - name: "perf-3.0-standalone"
-     - name: "perf-3.4-standalone"
      - name: "perf-3.6-standalone"
      - name: "perf-4.0-standalone"
      - name: "perf-4.2-standalone"


### PR DESCRIPTION
We don't support 3.0 or 3.4 anymore.