### PR TITLE
Preserve traceback when configuration errors occur

### DIFF
--- a/pymongo/srv_resolver.py
+++ b/pymongo/srv_resolver.py
@@ -62,8 +62,8 @@ class _SrvResolver(object):
 
         try:
             self.__plist = self.__fqdn.split(".")[1:]
-        except Exception:
-            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,))
+        except Exception as exc:
+            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,)) from exc
         self.__slen = len(self.__plist)
         if self.__slen < 2:
             raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,))
@@ -76,7 +76,7 @@ class _SrvResolver(object):
             # No TXT records
             return None
         except Exception as exc:
-            raise ConfigurationError(str(exc))
+            raise ConfigurationError(str(exc)) from exc
         if len(results) > 1:
             raise ConfigurationError('Only one TXT record is supported')
         return (
@@ -92,7 +92,7 @@ class _SrvResolver(object):
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
-            raise ConfigurationError(str(exc))
+            raise ConfigurationError(str(exc)) from exc
         return results
 
     def _get_srv_response_and_hosts(self, encapsulate_errors):


### PR DESCRIPTION
When resolving SRV records, the pymongo library disregards the previous error which lead to the configuration error.

This is making them harder to debug, especially when they occur only in CI (which is the case for us with [Celery](https://github.com/celery/celery/runs/4371284502?check_suite_focus=true#step:8:3264)).