### PR TITLE
Removed references to outdated server versions

### DIFF
--- a/bson/decimal128.py
+++ b/bson/decimal128.py
@@ -15,8 +15,6 @@
 """Tools for working with the BSON decimal128 type.
 
 .. versionadded:: 3.4
-
-.. note:: The Decimal128 BSON type requires MongoDB 3.4+.
 """
 
 import decimal

--- a/doc/examples/authentication.rst
+++ b/doc/examples/authentication.rst
@@ -97,9 +97,8 @@ the "MongoDB Challenge-Response" protocol::
 Default Authentication Mechanism
 --------------------------------
 
-If no mechanism is specified, PyMongo automatically uses MONGODB-CR when
-connected to a pre-3.0 version of MongoDB, SCRAM-SHA-1 when connected to
-MongoDB 3.0 through 3.6, and negotiates the mechanism to use (SCRAM-SHA-1
+If no mechanism is specified, PyMongo automatically SCRAM-SHA-1 when connected
+to MongoDB 3.6 and negotiates the mechanism to use (SCRAM-SHA-1
 or SCRAM-SHA-256) when connected to MongoDB 4.0+.
 
 Default Database and "authSource"
@@ -125,15 +124,12 @@ MONGODB-X509
 ------------
 .. versionadded:: 2.6
 
-The MONGODB-X509 mechanism authenticates a username derived from the
-distinguished subject name of the X.509 certificate presented by the driver
-during TLS/SSL negotiation. This authentication method requires the use of
-TLS/SSL connections with certificate validation and is available in
-MongoDB 2.6 and newer::
+The MONGODB-X509 mechanism authenticates via the X.509 certificate presented
+by the driver during TLS/SSL negotiation. This authentication method requires
+the use of TLS/SSL connections with certificate validation::
 
   >>> from pymongo import MongoClient
   >>> client = MongoClient('example.com',
-  ...                      username="<X.509 derived username>"
   ...                      authMechanism="MONGODB-X509",
   ...                      tls=True,
   ...                      tlsCertificateKeyFile='/path/to/client.pem',
@@ -142,15 +138,12 @@ MongoDB 2.6 and newer::
 MONGODB-X509 authenticates against the $external virtual database, so you
 do not have to specify a database in the URI::
 
-  >>> uri = "mongodb://<X.509 derived username>@example.com/?authMechanism=MONGODB-X509"
+  >>> uri = "mongodb://example.com/?authMechanism=MONGODB-X509"
   >>> client = MongoClient(uri,
   ...                      tls=True,
   ...                      tlsCertificateKeyFile='/path/to/client.pem',
   ...                      tlsCAFile='/path/to/ca.pem')
   >>>
-
-.. versionchanged:: 3.4
-  When connected to MongoDB >= 3.4 the username is no longer required.
 
 .. _gssapi:
 

--- a/doc/examples/bulk.rst
+++ b/doc/examples/bulk.rst
@@ -74,11 +74,6 @@ of operations performed.
    'writeConcernErrors': [],
    'writeErrors': []}
 
-.. warning:: ``nModified`` is only reported by MongoDB 2.6 and later. When
-  connected to an earlier server version, or in certain mixed version sharding
-  configurations, PyMongo omits this field from the results of a bulk
-  write operation.
-
 The first write failure that occurs (e.g. duplicate key error) aborts the
 remaining operations, and PyMongo raises
 :class:`~pymongo.errors.BulkWriteError`. The :attr:`details` attibute of

--- a/pymongo/aggregation.py
+++ b/pymongo/aggregation.py
@@ -147,7 +147,7 @@ class _AggregationCommand(object):
         if 'cursor' in result:
             cursor = result['cursor']
         else:
-            # Pre-MongoDB 2.6 or unacknowledged write. Fake a cursor.
+            # Unacknowledged $out/$merge write. Fake a cursor.
             cursor = {
                 "id": 0,
                 "firstBatch": result.get("result", []),

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -14,8 +14,6 @@
 
 """Logical sessions for ordering sequential operations.
 
-Requires MongoDB 3.6.
-
 .. versionadded:: 3.6
 
 Causally Consistent Reads

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -107,8 +107,7 @@ class Collection(common.BaseObject):
             default) database.read_concern is used.
           - `collation` (optional): An instance of
             :class:`~pymongo.collation.Collation`. If a collation is provided,
-            it will be passed to the create collection command. This option is
-            only supported on MongoDB 3.4 and above.
+            it will be passed to the create collection command.
           - `session` (optional): a
             :class:`~pymongo.client_session.ClientSession` that is used with
             the create collection command
@@ -209,8 +208,7 @@ class Collection(common.BaseObject):
           - `read_concern` (optional) - An instance of
             :class:`~pymongo.read_concern.ReadConcern`.
           - `write_concern`: An instance of
-            :class:`~pymongo.write_concern.WriteConcern`. This option is only
-            valid for MongoDB 3.4 and above.
+            :class:`~pymongo.write_concern.WriteConcern`.
           - `collation` (optional) - An instance of
             :class:`~pymongo.collation.Collation`.
           - `session` (optional): a
@@ -720,10 +718,9 @@ class Collection(common.BaseObject):
             match the filter.
           - `bypass_document_validation`: (optional) If ``True``, allows the
             write to opt-out of document level validation. Default is
-            ``False``. This option is only supported on MongoDB 3.2 and above.
+            ``False``.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only supported
-            on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -790,13 +787,11 @@ class Collection(common.BaseObject):
             match the filter.
           - `bypass_document_validation`: (optional) If ``True``, allows the
             write to opt-out of document level validation. Default is
-            ``False``. This option is only supported on MongoDB 3.2 and above.
+            ``False``.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only supported
-            on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `array_filters` (optional): A list of filters specifying which
-            array elements an update should apply. This option is only
-            supported on MongoDB 3.6 and above.
+            array elements an update should apply.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -872,13 +867,11 @@ class Collection(common.BaseObject):
             match the filter.
           - `bypass_document_validation` (optional): If ``True``, allows the
             write to opt-out of document level validation. Default is
-            ``False``. This option is only supported on MongoDB 3.2 and above.
+            ``False``.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only supported
-            on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `array_filters` (optional): A list of filters specifying which
-            array elements an update should apply. This option is only
-            supported on MongoDB 3.6 and above.
+            array elements an update should apply.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -1028,8 +1021,7 @@ class Collection(common.BaseObject):
         :Parameters:
           - `filter`: A query that matches the document to delete.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only supported
-            on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -1079,8 +1071,7 @@ class Collection(common.BaseObject):
         :Parameters:
           - `filter`: A query that matches the documents to delete.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only supported
-            on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -1226,8 +1217,7 @@ class Collection(common.BaseObject):
           - `batch_size` (optional): Limits the number of documents returned in
             a single batch.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only supported
-            on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `return_key` (optional): If True, return only the index keys in
             each document.
           - `show_record_id` (optional): If True, adds a field ``$recordId`` in
@@ -1472,12 +1462,10 @@ class Collection(common.BaseObject):
           - `maxTimeMS` (int): The maximum amount of time to allow this
             operation to run, in milliseconds.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only supported
-            on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `hint` (string or list of tuples): The index to use. Specify either
             the index name as a string or the index specification as a list of
             tuples (e.g. [('a', pymongo.ASCENDING), ('b', pymongo.ASCENDING)]).
-            This option is only supported on MongoDB 3.6 and above.
 
         The :meth:`count_documents` method obeys the :attr:`read_preference` of
         this :class:`Collection`.
@@ -1494,8 +1482,6 @@ class Collection(common.BaseObject):
            +-------------+-------------------------------------+
            | $nearSphere | `$geoWithin`_ with `$centerSphere`_ |
            +-------------+-------------------------------------+
-
-           $expr requires MongoDB 3.6+
 
         :Parameters:
           - `filter` (required): A query document that selects which documents
@@ -1554,13 +1540,8 @@ class Collection(common.BaseObject):
           - `**kwargs` (optional): optional arguments to the createIndexes
             command (like maxTimeMS) can be passed as keyword arguments.
 
-        .. note:: `create_indexes` uses the `createIndexes`_ command
-           introduced in MongoDB **2.6** and cannot be used with earlier
-           versions.
-
         .. note:: The :attr:`~pymongo.collection.Collection.write_concern` of
-           this collection is automatically applied to this operation when using
-           MongoDB >= 3.4.
+           this collection is automatically applied to this operation.
 
         .. versionchanged:: 3.6
            Added ``session`` parameter. Added support for arbitrary keyword
@@ -1665,9 +1646,9 @@ class Collection(common.BaseObject):
             this collection after <int> seconds. The indexed field must
             be a UTC datetime or the data will not expire.
           - `partialFilterExpression`: A document that specifies a filter for
-            a partial index. Requires MongoDB >=3.2.
+            a partial index.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. Requires MongoDB >= 3.4.
+            :class:`~pymongo.collation.Collation`.
           - `wildcardProjection`: Allows users to include or exclude specific
             field paths from a `wildcard index`_ using the {"$**" : 1} key
             pattern. Requires MongoDB >= 4.2.
@@ -1683,8 +1664,7 @@ class Collection(common.BaseObject):
           using the option will fail if a duplicate value is detected.
 
         .. note:: The :attr:`~pymongo.collection.Collection.write_concern` of
-           this collection is automatically applied to this operation when using
-           MongoDB >= 3.4.
+           this collection is automatically applied to this operation.
 
         :Parameters:
           - `keys`: a single key or a list of (key, direction)
@@ -1733,8 +1713,7 @@ class Collection(common.BaseObject):
             command (like maxTimeMS) can be passed as keyword arguments.
 
         .. note:: The :attr:`~pymongo.collection.Collection.write_concern` of
-           this collection is automatically applied to this operation when using
-           MongoDB >= 3.4.
+           this collection is automatically applied to this operation.
 
         .. versionchanged:: 3.6
            Added ``session`` parameter. Added support for arbitrary keyword
@@ -1772,8 +1751,7 @@ class Collection(common.BaseObject):
             command (like maxTimeMS) can be passed as keyword arguments.
 
         .. note:: The :attr:`~pymongo.collection.Collection.write_concern` of
-           this collection is automatically applied to this operation when using
-           MongoDB >= 3.4.
+           this collection is automatically applied to this operation.
 
         .. versionchanged:: 3.6
            Added ``session`` parameter. Added support for arbitrary keyword
@@ -1946,8 +1924,7 @@ class Collection(common.BaseObject):
            example is included in the :ref:`aggregate-examples` documentation.
 
         .. note:: The :attr:`~pymongo.collection.Collection.write_concern` of
-           this collection is automatically applied to this operation when using
-           MongoDB >= 3.4.
+           this collection is automatically applied to this operation.
 
         :Parameters:
           - `pipeline`: a list of aggregation pipeline stages
@@ -2060,8 +2037,6 @@ class Collection(common.BaseObject):
         :class:`~pymongo.change_stream.CollectionChangeStream` cursor which
         iterates over changes on this collection.
 
-        Introduced in MongoDB 3.6.
-
         .. code-block:: python
 
            with db.collection.watch() as stream:
@@ -2172,8 +2147,7 @@ class Collection(common.BaseObject):
             (i.e. ``dropTarget=True``)
 
         .. note:: The :attr:`~pymongo.collection.Collection.write_concern` of
-           this collection is automatically applied to this operation when using
-           MongoDB >= 3.4.
+           this collection is automatically applied to this operation.
 
         .. versionchanged:: 3.6
            Added ``session`` parameter.
@@ -2219,8 +2193,7 @@ class Collection(common.BaseObject):
           - `maxTimeMS` (int): The maximum amount of time to allow the count
             command to run, in milliseconds.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only supported
-            on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
 
         The :meth:`distinct` method obeys the :attr:`read_preference` of
         this :class:`Collection`.
@@ -2576,8 +2549,7 @@ class Collection(common.BaseObject):
             :attr:`ReturnDocument.AFTER`, returns the updated
             or inserted document.
           - `array_filters` (optional): A list of filters specifying which
-            array elements an update should apply. This option is only
-            supported on MongoDB 3.6 and above.
+            array elements an update should apply.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -102,7 +102,7 @@ RETRY_WRITES = True
 # Default value for retryReads.
 RETRY_READS = True
 
-# mongod/s 2.6 and above return code 59 when a command doesn't exist.
+# The error code returned when a command doesn't exist.
 COMMAND_NOT_FOUND_CODES = (59,)
 
 # Error codes to ignore if GridFS calls createIndex on a secondary

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -773,8 +773,7 @@ class Cursor(object):
                     ('field2', pymongo.DESCENDING)]):
                 print(doc)
 
-        Beginning with MongoDB version 2.6, text search results can be
-        sorted by relevance::
+        Text search results can be sorted by relevance::
 
             cursor = db.test.find(
                 {'$text': {'$search': 'some words'}},
@@ -837,8 +836,8 @@ class Cursor(object):
     def explain(self):
         """Returns an explain plan record for this cursor.
 
-        .. note:: Starting with MongoDB 3.2 :meth:`explain` uses
-          the default verbosity mode of the `explain command
+        .. note:: This method uses the default verbosity mode of the
+          `explain command
           <https://docs.mongodb.com/manual/reference/command/explain/>`_,
           ``allPlansExecution``. To use a different verbosity use
           :meth:`~pymongo.database.Database.command` to run the explain
@@ -943,8 +942,6 @@ class Cursor(object):
 
     def collation(self, collation):
         """Adds a :class:`~pymongo.collation.Collation` to this query.
-
-        This option is only supported on MongoDB 3.4 and above.
 
         Raises :exc:`TypeError` if `collation` is not an instance of
         :class:`~pymongo.collation.Collation` or a ``dict``. Raises

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -321,8 +321,6 @@ class Database(common.BaseObject):
         See the `aggregation pipeline`_ documentation for a list of stages
         that are supported.
 
-        Introduced in MongoDB 3.6.
-
         .. code-block:: python
 
            # Lists all operations currently running on the server.
@@ -716,8 +714,7 @@ class Database(common.BaseObject):
             :class:`~pymongo.client_session.ClientSession`.
 
         .. note:: The :attr:`~pymongo.database.Database.write_concern` of
-           this database is automatically applied to this operation when using
-           MongoDB >= 3.4.
+           this database is automatically applied to this operation.
 
         .. versionchanged:: 3.6
            Added ``session`` parameter.

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -247,10 +247,9 @@ class MongoClient(common.BaseObject):
             between periodic server checks, or None to accept the default
             frequency of 10 seconds.
           - `appname`: (string or None) The name of the application that
-            created this MongoClient instance. MongoDB 3.4 and newer will
-            print this value in the server log upon establishing each
-            connection. It is also recorded in the slow query log and
-            profile collections.
+            created this MongoClient instance. The server will log this value
+            upon establishing each connection. It is also recorded in the slow
+            query log and profile collections.
           - `driver`: (pair or None) A driver implemented on top of PyMongo can
             pass a :class:`~pymongo.driver_info.DriverInfo` to add its name,
             version, and platform to the message printed in the server log when
@@ -259,7 +258,7 @@ class MongoClient(common.BaseObject):
             :mod:`~pymongo.monitoring` for details.
           - `retryWrites`: (boolean) Whether supported write operations
             executed within this MongoClient will be retried once after a
-            network error on MongoDB 3.6+. Defaults to ``True``.
+            network error. Defaults to ``True``.
             The supported write operations are:
 
               - :meth:`~pymongo.collection.Collection.bulk_write`, as long as
@@ -281,7 +280,7 @@ class MongoClient(common.BaseObject):
             https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst
           - `retryReads`: (boolean) Whether supported read operations
             executed within this MongoClient will be retried once after a
-            network error on MongoDB 3.6+. Defaults to ``True``.
+            network error. Defaults to ``True``.
             The supported read operations are:
             :meth:`~pymongo.collection.Collection.find`,
             :meth:`~pymongo.collection.Collection.find_one`,
@@ -315,9 +314,8 @@ class MongoClient(common.BaseObject):
             zlib support requires the Python standard library zlib module. zstd
             requires the `zstandard <https://pypi.org/project/zstandard/>`_
             package. By default no compression is used. Compression support
-            must also be enabled on the server. MongoDB 3.4+ supports snappy
-            compression. MongoDB 3.6 adds support for zlib. MongoDB 4.2 adds
-            support for zstd.
+            must also be enabled on the server. MongoDB 3.6+ supports snappy
+            and zlib compression. MongoDB 4.2+ adds support for zstd.
           - `zlibCompressionLevel`: (int) The zlib compression level to use
             when zlib is used as the wire protocol compressor. Supported values
             are -1 through 9. -1 tells the zlib library to use its default
@@ -355,10 +353,8 @@ class MongoClient(common.BaseObject):
             will cause **write operations to wait indefinitely**.
           - `journal`: If ``True`` block until write operations have been
             committed to the journal. Cannot be used in combination with
-            `fsync`. Prior to MongoDB 2.6 this option was ignored if the server
-            was running without journaling. Starting with MongoDB 2.6 write
-            operations will fail with an exception if this option is used when
-            the server is running without journaling.
+            `fsync`. Write operations will fail with an exception if this
+            option is used when the server is running without journaling.
           - `fsync`: If ``True`` and the server is running without journaling,
             blocks until the server has synced all data files to disk. If the
             server is running with journaling, this acts the same as the `j`
@@ -406,11 +402,9 @@ class MongoClient(common.BaseObject):
           - `authSource`: The database to authenticate on. Defaults to the
             database specified in the URI, if provided, or to "admin".
           - `authMechanism`: See :data:`~pymongo.auth.MECHANISMS` for options.
-            If no mechanism is specified, PyMongo automatically uses MONGODB-CR
-            when connected to a pre-3.0 version of MongoDB, SCRAM-SHA-1 when
-            connected to MongoDB 3.0 through 3.6, and negotiates the mechanism
-            to use (SCRAM-SHA-1 or SCRAM-SHA-256) when connected to MongoDB
-            4.0+.
+            If no mechanism is specified, PyMongo automatically SCRAM-SHA-1
+            when connected to MongoDB 3.6 and negotiates the mechanism to use
+            (SCRAM-SHA-1 or SCRAM-SHA-256) when connected to MongoDB 4.0+.
           - `authMechanismProperties`: Used to specify authentication mechanism
             specific options. To specify the service name for GSSAPI
             authentication pass authMechanismProperties='SERVICE_NAME:<service
@@ -1053,8 +1047,8 @@ class MongoClient(common.BaseObject):
     def close(self):
         """Cleanup client resources and disconnect from MongoDB.
 
-        On MongoDB >= 3.6, end all server sessions created by this client by
-        sending one or more endSessions commands.
+        End all server sessions created by this client by sending one or more
+        endSessions commands.
 
         Close all sockets in the connection pools and stop the monitor threads.
 
@@ -1565,8 +1559,6 @@ class MongoClient(common.BaseObject):
         :class:`~pymongo.client_session.SessionOptions`. See the
         :mod:`~pymongo.client_session` module for details and examples.
 
-        Requires MongoDB 3.6.
-
         A :class:`~pymongo.client_session.ClientSession` may only be used with
         the MongoClient that started it. :class:`ClientSession` instances are
         **not thread-safe or fork-safe**. They can only be used by one thread
@@ -1722,8 +1714,7 @@ class MongoClient(common.BaseObject):
            Added ``session`` parameter.
 
         .. note:: The :attr:`~pymongo.mongo_client.MongoClient.write_concern` of
-           this client is automatically applied to this operation when using
-           MongoDB >= 3.4.
+           this client is automatically applied to this operation.
 
         .. versionchanged:: 3.4
            Apply this client's write concern automatically to this operation

--- a/pymongo/operations.py
+++ b/pymongo/operations.py
@@ -65,8 +65,7 @@ class DeleteOne(object):
         :Parameters:
           - `filter`: A query that matches the document to delete.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only
-            supported on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -119,8 +118,7 @@ class DeleteMany(object):
         :Parameters:
           - `filter`: A query that matches the documents to delete.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only
-            supported on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -177,8 +175,7 @@ class ReplaceOne(object):
           - `upsert` (optional): If ``True``, perform an insert if no documents
             match the filter.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only
-            supported on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -287,10 +284,9 @@ class UpdateOne(_UpdateOp):
           - `upsert` (optional): If ``True``, perform an insert if no documents
             match the filter.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only
-            supported on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `array_filters` (optional): A list of filters specifying which
-            array elements an update should apply. Requires MongoDB 3.6+.
+            array elements an update should apply.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -335,10 +331,9 @@ class UpdateMany(_UpdateOp):
           - `upsert` (optional): If ``True``, perform an insert if no documents
             match the filter.
           - `collation` (optional): An instance of
-            :class:`~pymongo.collation.Collation`. This option is only
-            supported on MongoDB 3.4 and above.
+            :class:`~pymongo.collation.Collation`.
           - `array_filters` (optional): A list of filters specifying which
-            array elements an update should apply. Requires MongoDB 3.6+.
+            array elements an update should apply.
           - `hint` (optional): An index to use to support the query
             predicate specified either by its string name, or in the same
             format as passed to
@@ -404,9 +399,9 @@ class IndexModel(object):
             this collection after <int> seconds. The indexed field must
             be a UTC datetime or the data will not expire.
           - `partialFilterExpression`: A document that specifies a filter for
-            a partial index. Requires MongoDB >= 3.2.
+            a partial index.
           - `collation`: An instance of :class:`~pymongo.collation.Collation`
-            that specifies the collation to use in MongoDB >= 3.4.
+            that specifies the collation to use.
           - `wildcardProjection`: Allows users to include or exclude specific
             field paths from a `wildcard index`_ using the { "$**" : 1} key
             pattern. Requires MongoDB >= 4.2.

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -873,7 +873,7 @@ class SocketInfo(object):
         return self.socket_checker.socket_closed(self.sock)
 
     def send_cluster_time(self, command, session, client):
-        """Add cluster time for MongoDB >= 3.6."""
+        """Add $clusterTime."""
         if client:
             client._send_cluster_time(command, session)
 

--- a/pymongo/results.py
+++ b/pymongo/results.py
@@ -118,13 +118,7 @@ class UpdateResult(_WriteResult):
 
     @property
     def modified_count(self):
-        """The number of documents modified.
-
-        .. note:: modified_count is only reported by MongoDB 2.6 and later.
-          When connected to an earlier server version, or in certain mixed
-          version sharding configurations, this attribute will be set to
-          ``None``.
-        """
+        """The number of documents modified. """
         self._raise_if_unacknowledged("modified_count")
         return self.__raw_result.get("nModified")
 
@@ -195,13 +189,7 @@ class BulkWriteResult(_WriteResult):
 
     @property
     def modified_count(self):
-        """The number of documents modified.
-
-        .. note:: modified_count is only reported by MongoDB 2.6 and later.
-          When connected to an earlier server version, or in certain mixed
-          version sharding configurations, this attribute will be set to
-          ``None``.
-        """
+        """The number of documents modified."""
         self._raise_if_unacknowledged("modified_count")
         return self.__bulk_api_result.get("nModified")
 

--- a/pymongo/write_concern.py
+++ b/pymongo/write_concern.py
@@ -33,11 +33,9 @@ class WriteConcern(object):
           to complete. If replication does not complete in the given
           timeframe, a timeout exception is raised.
         - `j`: If ``True`` block until write operations have been committed
-          to the journal. Cannot be used in combination with `fsync`. Prior
-          to MongoDB 2.6 this option was ignored if the server was running
-          without journaling. Starting with MongoDB 2.6 write operations will
-          fail with an exception if this option is used when the server is
-          running without journaling.
+          to the journal. Cannot be used in combination with `fsync`. Write
+          operations will fail with an exception if this option is used when
+          the server is running without journaling.
         - `fsync`: If ``True`` and the server is running without journaling,
           blocks until the server has synced all data files to disk. If the
           server is running with journaling, this acts the same as the `j`

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -680,8 +680,6 @@ class TestCollection(IntegrationTest):
         db.drop_collection("test")
         db.create_collection("test", capped=True, size=4096)
         result = db.test.options()
-        # mongos 2.2.x adds an $auth field when auth is enabled.
-        result.pop('$auth', None)
         self.assertEqual(result, {"capped": True, 'size': 4096})
         db.drop_collection("test")
 

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -343,8 +343,7 @@ class TestCursor(IntegrationTest):
         for _ in a:
             break
         b = a.explain()
-        # "cursor" pre MongoDB 2.7.6, "executionStats" post
-        self.assertTrue("cursor" in b or "executionStats" in b)
+        self.assertIn("executionStats", b)
 
     def test_explain_with_read_concern(self):
         # Do not add readConcern level to explain.

--- a/test/utils.py
+++ b/test/utils.py
@@ -928,7 +928,7 @@ def is_greenthread_patched():
 
 
 def disable_replication(client):
-    """Disable replication on all secondaries, requires MongoDB 3.2."""
+    """Disable replication on all secondaries."""
     for host, port in client.secondaries:
         secondary = single_client(host, port)
         secondary.admin.command('configureFailPoint', 'stopReplProducer',
@@ -936,7 +936,7 @@ def disable_replication(client):
 
 
 def enable_replication(client):
-    """Enable replication on all secondaries, requires MongoDB 3.2."""
+    """Enable replication on all secondaries."""
     for host, port in client.secondaries:
         secondary = single_client(host, port)
         secondary.admin.command('configureFailPoint', 'stopReplProducer',


### PR DESCRIPTION
This was the command I used to look for lines to remove:
```
$ git grep 'ongo' -- ':(exclude)doc/changelog.rst' | grep -E '3\.[0123456789]|2\.[0123456789]'
```