### PR TITLE
PYTHON-2473 Add basic Github Actions testing

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,0 +1,28 @@
+name: Python Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    # supercharge/mongodb-github-action requires containers so we don't test other platforms
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: ["3.6", "3.10", "pypy-3.8"]
+    name: CPython ${{ matrix.python-version }}-${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.7.0
+        with:
+          mongodb-version: 4.4
+      - name: Run tests
+        run: |
+          python setup.py test


### PR DESCRIPTION
Passing tests here: https://github.com/ShaneHarvey/mongo-python-driver/actions/runs/1560579660

Note that our main testing is done on Evergreen (https://evergreen.mongodb.com/waterfall/mongo-python-driver) but actions is useful to get quicker feedback and help external contributors.