### PR TITLE
PYTHON-2160 Stop using Google Groups email address

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -4,7 +4,7 @@ be distributed under licenses different than the PyMongo software.
 In the event that we accidentally failed to list a required notice,
 please bring it to our attention through any of the ways detailed here:
 
-           mongodb-dev@googlegroups.com
+           https://jira.mongodb.org/projects/PYTHON
 
 The attached notices are provided for information only.
 

--- a/setup.py
+++ b/setup.py
@@ -315,7 +315,6 @@ setup(
     description="Python driver for MongoDB <http://www.mongodb.org>",
     long_description=readme_content,
     author="The MongoDB Python Team",
-    author_email="mongodb-user@googlegroups.com",
     url="http://github.com/mongodb/mongo-python-driver",
     keywords=["mongo", "mongodb", "pymongo", "gridfs", "bson"],
     install_requires=[],


### PR DESCRIPTION
This has one side effect that a warning is printed when running setup.py check or sdist:
```
$ python3.10 setup.py check
running check
warning: check: missing meta-data: if 'author' supplied, 'author_email' should be supplied too
``` 
And:
```
 python3.10 setup.py sdist
running sdist
running egg_info
writing pymongo.egg-info/PKG-INFO
writing dependency_links to pymongo.egg-info/dependency_links.txt
writing requirements to pymongo.egg-info/requires.txt
writing top-level names to pymongo.egg-info/top_level.txt
reading manifest file 'pymongo.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'pymongo.egg-info/SOURCES.txt'
running check
warning: check: missing meta-data: if 'author' supplied, 'author_email' should be supplied too

...
Writing pymongo-4.1.0.dev0/setup.cfg
Creating tar archive
removing 'pymongo-4.1.0.dev0' (and everything under it)
```

We can just ignore this warning. See https://discuss.python.org/t/which-fields-are-required-for-a-setup-py-especially-is-author-required/2705