### PR TITLE
PYTHON-2888 Migrate from json.send to perf.send

### DIFF
--- a/.evergreen/perf.yml
+++ b/.evergreen/perf.yml
@@ -133,9 +133,8 @@ functions:
         file_location: src/report.json
 
   "send dashboard data":
-    - command: json.send
+    - command: perf.send
       params:
-        name: perf
         file: src/results.json
 
   "cleanup":

--- a/test/performance/perf_test.py
+++ b/test/performance/perf_test.py
@@ -47,9 +47,7 @@ OUTPUT_FILE = os.environ.get('OUTPUT_FILE')
 result_data = []
 
 def tearDownModule():
-    output = json.dumps({
-        'results': result_data
-        }, indent=4)
+    output = json.dumps(result_data, indent=4)
     if OUTPUT_FILE:
         with open(OUTPUT_FILE, 'w') as opf:
             opf.write(output)

--- a/test/performance/perf_test.py
+++ b/test/performance/perf_test.py
@@ -77,7 +77,7 @@ class PerformanceTest(object):
     def tearDown(self):
         name = self.__class__.__name__
         median = self.percentile(50)
-        result = self.data_size / median
+        bytes_per_sec = self.data_size / median
         print('Running %s. MEDIAN=%s' % (self.__class__.__name__,
                                          self.percentile(50)))
         result_data.append({
@@ -89,8 +89,8 @@ class PerformanceTest(object):
             },
             'metrics': [
                 {
-                    'name': 'ops_per_sec',
-                    'value': result
+                    'name': 'bytes_per_sec',
+                    'value': bytes_per_sec
                 },
             ]
         })

--- a/test/performance/perf_test.py
+++ b/test/performance/perf_test.py
@@ -83,12 +83,18 @@ class PerformanceTest(object):
         print('Running %s. MEDIAN=%s' % (self.__class__.__name__,
                                          self.percentile(50)))
         result_data.append({
-            'name': name,
-            'results': {
-                '1': {
-                    'ops_per_sec': result
-                }
-            }
+            'info': {
+                'test_name': name,
+                'args': {
+                   'threads': 1,
+                },
+            },
+            'metrics': [
+                {
+                    'name': 'ops_per_sec',
+                    'value': result
+                },
+            ]
         })
 
     def before(self):


### PR DESCRIPTION
Followed the migration guide here: https://github.com/10gen/performance-tooling-docs/blob/main/getting_started/performance_monitoring_setup.md#legacy-data-migration

Testing here: https://spruce.mongodb.com/version/61b2a9a5562343496412629b