### PR TITLE
PYTHON-2763 Fix check_keys removal in encryption

### DIFF
--- a/pymongo/message.py
+++ b/pymongo/message.py
@@ -309,10 +309,8 @@ class _Query(object):
         sock_info.send_cluster_time(cmd, session, self.client)
         # Support auto encryption
         client = self.client
-        if (client._encrypter and
-                not client._encrypter._bypass_auto_encryption):
-            cmd = client._encrypter.encrypt(
-                self.db, cmd, False, self.codec_options)
+        if client._encrypter and not client._encrypter._bypass_auto_encryption:
+            cmd = client._encrypter.encrypt(self.db, cmd, self.codec_options)
         self._as_command = cmd, self.db
         return self._as_command
 
@@ -409,10 +407,8 @@ class _GetMore(object):
         sock_info.send_cluster_time(cmd, self.session, self.client)
         # Support auto encryption
         client = self.client
-        if (client._encrypter and
-                not client._encrypter._bypass_auto_encryption):
-            cmd = client._encrypter.encrypt(
-                self.db, cmd, False, self.codec_options)
+        if client._encrypter and not client._encrypter._bypass_auto_encryption:
+            cmd = client._encrypter.encrypt(self.db, cmd, self.codec_options)
         self._as_command = cmd, self.db
         return self._as_command
 


### PR DESCRIPTION
Fix this bug in PYTHON-2763:
```python
 [2021/12/13 23:49:53.657] ERROR: test_automatic (test_encryption.TestAzureEncryption)
 [2021/12/13 23:49:53.657] ----------------------------------------------------------------------
 [2021/12/13 23:49:53.657] Traceback (most recent call last):
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/test/test_encryption.py", line 1441, in test_automatic
 [2021/12/13 23:49:53.657]     return self._test_automatic(
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/test/test_encryption.py", line 1414, in _test_automatic
 [2021/12/13 23:49:53.657]     output_doc = coll.find_one({})
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/collection.py", line 1133, in find_one
 [2021/12/13 23:49:53.657]     for result in cursor.limit(-1):
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/cursor.py", line 1163, in next
 [2021/12/13 23:49:53.657]     if len(self.__data) or self._refresh():
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/cursor.py", line 1084, in _refresh
 [2021/12/13 23:49:53.657]     self.__send_message(q)
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/cursor.py", line 975, in __send_message
 [2021/12/13 23:49:53.657]     response = client._run_operation(
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/mongo_client.py", line 1203, in _run_operation
 [2021/12/13 23:49:53.657]     return self._retryable_read(
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/mongo_client.py", line 1301, in _retryable_read
 [2021/12/13 23:49:53.657]     return func(session, server, sock_info, secondary_ok)
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/mongo_client.py", line 1199, in _cmd
 [2021/12/13 23:49:53.657]     return server.run_operation(
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/server.py", line 97, in run_operation
 [2021/12/13 23:49:53.657]     message = operation.get_message(
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/message.py", line 331, in get_message
 [2021/12/13 23:49:53.657]     spec = self.as_command(sock_info)[0]
 [2021/12/13 23:49:53.657]   File "/data/mci/a675b9166889c90001e88dd30fc0da34/src/pymongo/message.py", line 314, in as_command
 [2021/12/13 23:49:53.657]     cmd = client._encrypter.encrypt(
 [2021/12/13 23:49:53.657] TypeError: encrypt() takes 4 positional arguments but 5 were given
```
https://evergreen.mongodb.com/task/mongo_python_driver_test_macos_encryption__platform~macos_1014_auth~auth_ssl~nossl_encryption~encryption_test_4.2_standalone_797197e73bd18fc7c4076408e68aa745f8070c49_21_12_10_18_22_49