### PR TITLE
PYTHON-2970 SDAM should give priority to electionId over setVersion to detect a stale primary

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,6 +26,21 @@ PyMongo 4.1 brings a number of improvements including:
 - :meth:`gridfs.GridOut.seek` now returns the new position in the file, to
   conform to the behavior of :meth:`io.IOBase.seek`.
 
+Bug fixes
+.........
+
+- Fixed a bug where the client could be unable to discover the new primary
+  after a simultaneous replica set election and reconfig (`PYTHON-2970`_).
+
+.. _PYTHON-2970: https://jira.mongodb.org/browse/PYTHON-2970
+
+Issues Resolved
+...............
+
+See the `PyMongo 4.1 release notes in JIRA`_ for the list of resolved issues
+in this release.
+
+.. _PyMongo 4.1 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=30619
 
 Changes in Version 4.0
 ----------------------

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -17,6 +17,7 @@
 from random import sample
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
+from bson.min_key import MinKey
 from bson.objectid import ObjectId
 from pymongo import common
 from pymongo.errors import ConfigurationError
@@ -531,30 +532,16 @@ def _update_rs_from_primary(
         sds.pop(server_description.address)
         return (_check_has_primary(sds), replica_set_name, max_set_version, max_election_id)
 
+    new_election_tuple = server_description.election_id, server_description.set_version
     max_election_tuple = max_election_id, max_set_version
-    new_election_tuple = tuple(reversed(server_description.election_tuple))
-    new_election_id = server_description.election_id
-    new_set_version = server_description.set_version
-    if None not in new_election_tuple and (
-        None not in max_election_tuple
-        and (
-            max_election_id > new_election_id
-            or (max_election_id == new_election_id and max_set_version > new_set_version)
-        )
-    ):
+    new_election_safe = tuple(MinKey() if i is None else i for i in new_election_tuple)
+    max_election_safe = tuple(MinKey() if i is None else i for i in max_election_tuple)
+    if new_election_safe >= max_election_safe:
+        max_election_id, max_set_version = new_election_tuple
+    else:
         # Stale primary, set to type Unknown.
         sds[server_description.address] = server_description.to_unknown()
         return _check_has_primary(sds), replica_set_name, max_set_version, max_election_id
-
-    if new_election_id is not None and (
-        max_election_id is None or new_election_id > max_election_id
-    ):
-        max_election_id = server_description.election_id
-
-    if new_set_version is not None and (
-        max_set_version is None or new_set_version > max_set_version
-    ):
-        max_set_version = server_description.set_version
 
     # We've heard from the primary. Is it the same primary as before?
     for server in sds.values():

--- a/test/discovery_and_monitoring/rs/electionId_precedence_setVersion.json
+++ b/test/discovery_and_monitoring/rs/electionId_precedence_setVersion.json
@@ -1,5 +1,5 @@
 {
-  "description": "Record max setVersion, even from primary without electionId",
+  "description": "ElectionId is considered higher precedence than setVersion",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -22,35 +22,7 @@
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            }
-          },
-          "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 1,
-        "maxElectionId": {
-          "$oid": "000000000000000000000001"
-        }
-      }
-    },
-    {
-      "responses": [
+        ],
         [
           "b:27017",
           {
@@ -63,38 +35,13 @@
             ],
             "setName": "rs",
             "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            }
-          },
-          "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 1,
-        "maxElectionId": {
-          "$oid": "000000000000000000000001"
-        }
-      }
-    },
-    {
-      "responses": [
+        ],
         [
           "a:27017",
           {
@@ -128,6 +75,7 @@
           "b:27017": {
             "type": "Unknown",
             "setName": null,
+            "setVersion": null,
             "electionId": null
           }
         },

--- a/test/discovery_and_monitoring/rs/electionId_setVersion.json
+++ b/test/discovery_and_monitoring/rs/electionId_setVersion.json
@@ -1,5 +1,5 @@
 {
-  "description": "Record max setVersion, even from primary without electionId",
+  "description": "ElectionId is considered higher precedence than setVersion",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -22,35 +22,7 @@
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            }
-          },
-          "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 1,
-        "maxElectionId": {
-          "$oid": "000000000000000000000001"
-        }
-      }
-    },
-    {
-      "responses": [
+        ],
         [
           "b:27017",
           {
@@ -63,35 +35,13 @@
             ],
             "setName": "rs",
             "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
-          },
-          "b:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 2
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 2,
-        "maxElectionId": {
-          "$oid": "000000000000000000000001"
-        }
-      }
-    },
-    {
-      "responses": [
+        ],
         [
           "a:27017",
           {
@@ -125,6 +75,7 @@
           "b:27017": {
             "type": "Unknown",
             "setName": null,
+            "setVersion": null,
             "electionId": null
           }
         },

--- a/test/discovery_and_monitoring/rs/null_election_id.json
+++ b/test/discovery_and_monitoring/rs/null_election_id.json
@@ -123,15 +123,18 @@
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
+            "type": "Unknown",
+            "setName": null,
+            "setVersion": null,
             "electionId": null
           },
           "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
           },
           "c:27017": {
             "type": "Unknown",
@@ -174,15 +177,18 @@
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
+            "type": "Unknown",
+            "setName": null,
+            "setVersion": null,
             "electionId": null
           },
           "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
           },
           "c:27017": {
             "type": "Unknown",

--- a/test/discovery_and_monitoring/rs/set_version_can_rollback.json
+++ b/test/discovery_and_monitoring/rs/set_version_can_rollback.json
@@ -1,5 +1,5 @@
 {
-  "description": "Record max setVersion, even from primary without electionId",
+  "description": "Set version rolls back after new primary with higher election Id",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -8,54 +8,7 @@
           "a:27017",
           {
             "ok": 1,
-            "helloOk": true,
-            "isWritablePrimary": true,
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            },
-            "minWireVersion": 0,
-            "maxWireVersion": 6
-          }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            }
-          },
-          "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 1,
-        "maxElectionId": {
-          "$oid": "000000000000000000000001"
-        }
-      }
-    },
-    {
-      "responses": [
-        [
-          "b:27017",
-          {
-            "ok": 1,
-            "helloOk": true,
+            "hello": true,
             "isWritablePrimary": true,
             "hosts": [
               "a:27017",
@@ -63,6 +16,9 @@
             ],
             "setName": "rs",
             "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
@@ -73,7 +29,7 @@
           "a:27017": {
             "type": "RSPrimary",
             "setName": "rs",
-            "setVersion": 1,
+            "setVersion": 2,
             "electionId": {
               "$oid": "000000000000000000000001"
             }
@@ -87,19 +43,20 @@
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
         "setName": "rs",
-        "maxSetVersion": 1,
+        "maxSetVersion": 2,
         "maxElectionId": {
           "$oid": "000000000000000000000001"
         }
       }
     },
     {
+      "_comment": "Response from new primary with newer election Id",
       "responses": [
         [
-          "a:27017",
+          "b:27017",
           {
             "ok": 1,
-            "helloOk": true,
+            "hello": true,
             "isWritablePrimary": true,
             "hosts": [
               "a:27017",
@@ -118,17 +75,65 @@
       "outcome": {
         "servers": {
           "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
             "type": "RSPrimary",
             "setName": "rs",
             "setVersion": 1,
             "electionId": {
               "$oid": "000000000000000000000002"
             }
-          },
-          "b:27017": {
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
+      }
+    },
+    {
+      "_comment": "Response from stale primary",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "hello": true,
+            "isWritablePrimary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
             "type": "Unknown",
             "setName": null,
             "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
           }
         },
         "topologyType": "ReplicaSetWithPrimary",

--- a/test/discovery_and_monitoring/rs/setversion_equal_max_without_electionid.json
+++ b/test/discovery_and_monitoring/rs/setversion_equal_max_without_electionid.json
@@ -1,5 +1,5 @@
 {
-  "description": "ElectionId is considered higher precedence than setVersion",
+  "description": "setVersion version that is equal is treated the same as greater than if there is no electionId",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -16,47 +16,6 @@
             ],
             "setName": "rs",
             "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            },
-            "minWireVersion": 0,
-            "maxWireVersion": 6
-          }
-        ],
-        [
-          "b:27017",
-          {
-            "ok": 1,
-            "helloOk": true,
-            "isWritablePrimary": true,
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
-            "setName": "rs",
-            "setVersion": 2,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            },
-            "minWireVersion": 0,
-            "maxWireVersion": 6
-          }
-        ],
-        [
-          "a:27017",
-          {
-            "ok": 1,
-            "helloOk": true,
-            "isWritablePrimary": true,
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000002"
-            },
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
@@ -68,24 +27,57 @@
             "type": "RSPrimary",
             "setName": "rs",
             "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000002"
-            }
+            "electionId": null
           },
           "b:27017": {
             "type": "Unknown",
             "setName": null,
-            "setVersion": null,
             "electionId": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
         "setName": "rs",
-        "maxSetVersion": 2,
-        "maxElectionId": {
-          "$oid": "000000000000000000000002"
-        }
+        "maxSetVersion": 1
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs",
+        "maxSetVersion": 1
       }
     }
   ]

--- a/test/discovery_and_monitoring/rs/setversion_greaterthan_max_without_electionid.json
+++ b/test/discovery_and_monitoring/rs/setversion_greaterthan_max_without_electionid.json
@@ -1,6 +1,6 @@
 {
-  "description": "Secondary ignored when ok is zero",
-  "uri": "mongodb://a,b/?replicaSet=rs",
+  "description": "setVersion that is greater than maxSetVersion is used if there is no electionId",
+  "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
       "responses": [
@@ -10,27 +10,12 @@
             "ok": 1,
             "helloOk": true,
             "isWritablePrimary": true,
-            "setName": "rs",
             "hosts": [
               "a:27017",
               "b:27017"
             ],
-            "minWireVersion": 0,
-            "maxWireVersion": 6
-          }
-        ],
-        [
-          "b:27017",
-          {
-            "ok": 1,
-            "helloOk": true,
-            "isWritablePrimary": false,
-            "secondary": true,
             "setName": "rs",
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
+            "setVersion": 1,
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
@@ -40,16 +25,20 @@
         "servers": {
           "a:27017": {
             "type": "RSPrimary",
-            "setName": "rs"
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
           },
           "b:27017": {
-            "type": "RSSecondary",
-            "setName": "rs"
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1
       }
     },
     {
@@ -57,7 +46,15 @@
         [
           "b:27017",
           {
-            "ok": 0,
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 2,
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
@@ -66,17 +63,21 @@
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs"
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
           },
           "b:27017": {
-            "type": "Unknown",
-            "setName": null
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2
       }
     }
   ]

--- a/test/discovery_and_monitoring/rs/setversion_without_electionid.json
+++ b/test/discovery_and_monitoring/rs/setversion_without_electionid.json
@@ -1,5 +1,5 @@
 {
-  "description": "setVersion is ignored if there is no electionId",
+  "description": "setVersion that is less than maxSetVersion is ignored if there is no electionId",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -63,14 +63,14 @@
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "Unknown",
-            "setName": null,
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
             "electionId": null
           },
           "b:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
+            "type": "Unknown",
+            "setName": null,
             "electionId": null
           }
         },

--- a/test/test_discovery_and_monitoring.py
+++ b/test/test_discovery_and_monitoring.py
@@ -220,6 +220,8 @@ def create_tests():
         dirname = os.path.split(dirpath)[-1]
 
         for filename in filenames:
+            if os.path.splitext(filename)[1] != ".json":
+                continue
             with open(os.path.join(dirpath, filename)) as scenario_stream:
                 scenario_def = json_util.loads(scenario_stream.read())
 


### PR DESCRIPTION
Draft implementation of DRIVERS-1954: https://github.com/mongodb/specifications/pull/1122

TODO:
- [X] ServerDescription.election_tuple is now incorrect. Ideally we'd reverse it but doing so would be a breaking change. Perhaps we should just deprecate it? Edit: I opened https://jira.mongodb.org/browse/PYTHON-3162 to deprecation this.