### PR TITLE
PYTHON-3088 [4.0] Test rapid releases with load balancers

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2639,7 +2639,7 @@ buildvariants:
 
 - matrix_name: "load-balancer"
   matrix_spec:
-    platform: awslinux
+    platform: ubuntu-18.04
     mongodb-version: ["rapid", "latest"]
     auth-ssl: "*"
     python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3.6", "pypy3.7"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1920,6 +1920,10 @@ axes:
         display_name: "MongoDB latest"
         variables:
           VERSION: "latest"
+      - id: "rapid"
+        display_name: "MongoDB rapid"
+        variables:
+          VERSION: "rapid"
 
   # Choice of Python runtime version
   - id: python-version
@@ -2635,8 +2639,8 @@ buildvariants:
 
 - matrix_name: "load-balancer"
   matrix_spec:
-    platform: ubuntu-18.04
-    mongodb-version: ["5.0", "latest"]
+    platform: awslinux
+    mongodb-version: ["rapid", "latest"]
     auth-ssl: "*"
     python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3.6", "pypy3.7"]
     loadbalancer: "*"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1718,8 +1718,6 @@ tasks:
             TOPOLOGY: "sharded_cluster"
             LOAD_BALANCER: true
         - func: "run load-balancer"
-          vars:
-            LOAD_BALANCER: true
         - func: "run tests"
 # }}}
     - name: "coverage-report"


### PR DESCRIPTION
PYTHON-3088 [v3.13] Update load balancer tests to support dedicated load balancer port (#870)
(cherry picked from commit 1443d7687edb9f6f62a182c0d3b5e9386b4a568c)
