### PR TITLE
PYTHON-3124 Remove overlapping slots from _WriteResult subclasses

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -91,3 +91,4 @@ The following is a list of people who have contributed to
 - Khanh Nguyen (KN99HN)
 - Henri Froese (henrifroese)
 - Ishmum Jawad Khan (ishmum123)
+- Arie Bovenberg (ariebovenberg)

--- a/pymongo/results.py
+++ b/pymongo/results.py
@@ -59,7 +59,7 @@ class _WriteResult(object):
 class InsertOneResult(_WriteResult):
     """The return type for :meth:`~pymongo.collection.Collection.insert_one`."""
 
-    __slots__ = ("__inserted_id", "__acknowledged")
+    __slots__ = ("__inserted_id",)
 
     def __init__(self, inserted_id: Any, acknowledged: bool) -> None:
         self.__inserted_id = inserted_id
@@ -74,7 +74,7 @@ class InsertOneResult(_WriteResult):
 class InsertManyResult(_WriteResult):
     """The return type for :meth:`~pymongo.collection.Collection.insert_many`."""
 
-    __slots__ = ("__inserted_ids", "__acknowledged")
+    __slots__ = ("__inserted_ids",)
 
     def __init__(self, inserted_ids: List[Any], acknowledged: bool) -> None:
         self.__inserted_ids = inserted_ids
@@ -98,7 +98,7 @@ class UpdateResult(_WriteResult):
     :meth:`~pymongo.collection.Collection.replace_one`.
     """
 
-    __slots__ = ("__raw_result", "__acknowledged")
+    __slots__ = ("__raw_result",)
 
     def __init__(self, raw_result: Dict[str, Any], acknowledged: bool) -> None:
         self.__raw_result = raw_result
@@ -136,7 +136,7 @@ class DeleteResult(_WriteResult):
     """The return type for :meth:`~pymongo.collection.Collection.delete_one`
     and :meth:`~pymongo.collection.Collection.delete_many`"""
 
-    __slots__ = ("__raw_result", "__acknowledged")
+    __slots__ = ("__raw_result",)
 
     def __init__(self, raw_result: Dict[str, Any], acknowledged: bool) -> None:
         self.__raw_result = raw_result
@@ -157,7 +157,7 @@ class DeleteResult(_WriteResult):
 class BulkWriteResult(_WriteResult):
     """An object wrapper for bulk API write results."""
 
-    __slots__ = ("__bulk_api_result", "__acknowledged")
+    __slots__ = ("__bulk_api_result",)
 
     def __init__(self, bulk_api_result: Dict[str, Any], acknowledged: bool) -> None:
         """Create a BulkWriteResult instance.


### PR DESCRIPTION
As described in [PYTHON-3124](https://jira.mongodb.org/projects/PYTHON/issues/PYTHON-3124), there were some overlapping slots in `_WriteResult` subclasses.

# Tests?

I see there have been several `__slots__`  issues in pymongo in the past. I discovered this slot issue with [slotscheck](https://github.com/ariebovenberg/slotscheck), a tool I maintain. If you like, I can add it to CI as I've done for [instagram/LibCST](https://github.com/Instagram/LibCST/pull/615), [sqlalchemy/sqlalchemy](https://github.com/sqlalchemy/sqlalchemy/pull/7670), and [aio-libs/aiohttp](https://github.com/aio-libs/aiohttp/pull/6547).