### PR TITLE
PYTHON-3174 Don't reinit client_context.client

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -316,7 +316,6 @@ class ClientContext(object):
             if "dataLake" in build_info:
                 self.is_data_lake = True
                 self.auth_enabled = True
-                self.client.close()
                 self.client = self._connect(host, port, username=db_user, password=db_pwd)
                 self.connected = True
                 return
@@ -354,14 +353,13 @@ class ClientContext(object):
                     if not self._check_user_provided():
                         _create_user(self.client.admin, db_user, db_pwd)
 
-                self.client.close()
                 self.client = self._connect(
                     host,
                     port,
                     username=db_user,
                     password=db_pwd,
                     replicaSet=self.replica_set_name,
-                    **self.default_client_options,
+                    **self.default_client_options
                 )
 
                 # May not have this if OperationFailure was raised earlier.
@@ -381,7 +379,6 @@ class ClientContext(object):
             if "setName" in hello:
                 self.replica_set_name = str(hello["setName"])
                 self.is_rs = True
-                self.client.close()
                 if self.auth_enabled:
                     # It doesn't matter which member we use as the seed here.
                     self.client = pymongo.MongoClient(
@@ -390,7 +387,7 @@ class ClientContext(object):
                         username=db_user,
                         password=db_pwd,
                         replicaSet=self.replica_set_name,
-                        **self.default_client_options,
+                        **self.default_client_options
                     )
                 else:
                     self.client = pymongo.MongoClient(
@@ -493,7 +490,7 @@ class ClientContext(object):
             username=db_user,
             password=db_pwd,
             serverSelectionTimeoutMS=100,
-            **self.default_client_options,
+            **self.default_client_options
         )
 
         try:
@@ -1054,7 +1051,6 @@ def print_running_clients():
     # XXX: Can be removed after PYTHON-1634 or PYTHON-1896.
     c = client_context.client
     if c:
-        print(f"client_context.client._topology._topology_id: {c._topology._topology_id}")
         processed.add(c._topology._topology_id)
     # Call collect to manually cleanup any would-be gc'd clients to avoid
     # false positives.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -361,7 +361,7 @@ class ClientContext(object):
                     username=db_user,
                     password=db_pwd,
                     replicaSet=self.replica_set_name,
-                    **self.default_client_options
+                    **self.default_client_options,
                 )
 
                 # May not have this if OperationFailure was raised earlier.
@@ -390,7 +390,7 @@ class ClientContext(object):
                         username=db_user,
                         password=db_pwd,
                         replicaSet=self.replica_set_name,
-                        **self.default_client_options
+                        **self.default_client_options,
                     )
                 else:
                     self.client = pymongo.MongoClient(
@@ -493,7 +493,7 @@ class ClientContext(object):
             username=db_user,
             password=db_pwd,
             serverSelectionTimeoutMS=100,
-            **self.default_client_options
+            **self.default_client_options,
         )
 
         try:
@@ -1054,6 +1054,7 @@ def print_running_clients():
     # XXX: Can be removed after PYTHON-1634 or PYTHON-1896.
     c = client_context.client
     if c:
+        print(f"client_context.client._topology._topology_id: {c._topology._topology_id}")
         processed.add(c._topology._topology_id)
     # Call collect to manually cleanup any would-be gc'd clients to avoid
     # false positives.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -316,6 +316,7 @@ class ClientContext(object):
             if "dataLake" in build_info:
                 self.is_data_lake = True
                 self.auth_enabled = True
+                self.client.close()
                 self.client = self._connect(host, port, username=db_user, password=db_pwd)
                 self.connected = True
                 return
@@ -353,6 +354,7 @@ class ClientContext(object):
                     if not self._check_user_provided():
                         _create_user(self.client.admin, db_user, db_pwd)
 
+                self.client.close()
                 self.client = self._connect(
                     host,
                     port,
@@ -379,6 +381,7 @@ class ClientContext(object):
             if "setName" in hello:
                 self.replica_set_name = str(hello["setName"])
                 self.is_rs = True
+                self.client.close()
                 if self.auth_enabled:
                     # It doesn't matter which member we use as the seed here.
                     self.client = pymongo.MongoClient(

--- a/test/test_raw_bson.py
+++ b/test/test_raw_bson.py
@@ -20,7 +20,6 @@ sys.path[0:0] = [""]
 
 from test import client_context, unittest
 from test.test_client import IntegrationTest
-from test.utils import rs_or_single_client
 
 from bson import decode, encode
 from bson.binary import JAVA_LEGACY, Binary, UuidRepresentation
@@ -41,12 +40,6 @@ class TestRawBSONDocument(IntegrationTest):
         b"\x00\x00\x00\x02street\x00\r\x00\x00\x00Baker Street\x00\x00\x00\x00"
     )
     document = RawBSONDocument(bson_string)
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestRawBSONDocument, cls).setUpClass()
-        client_context.client = rs_or_single_client()
-        cls.client = client_context.client
 
     def tearDown(self):
         if client_context.connected:


### PR DESCRIPTION
This code was mistakenly added in PYTHON-2463 (#737).