### PR TITLE
PYTHON-3084 MongoClient/Database/Collection should not implement Iterable

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -3146,8 +3146,8 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
             **kwargs,
         )
 
-    def __iter__(self) -> "Collection[_DocumentType]":
-        return self
+    # See PYTHON-3084.
+    __iter__ = None
 
     def __next__(self) -> NoReturn:
         raise TypeError("'Collection' object is not iterable")

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -1009,9 +1009,6 @@ class Database(common.BaseObject, Generic[_DocumentType]):
 
         return result
 
-    # See PYTHON-3084.
-    __iter__ = None
-
     def __next__(self) -> NoReturn:
         raise TypeError("'Database' object is not iterable")
 

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -1009,6 +1009,9 @@ class Database(common.BaseObject, Generic[_DocumentType]):
 
         return result
 
+    # See PYTHON-3084.
+    __iter__ = None
+
     def __next__(self) -> NoReturn:
         raise TypeError("'Database' object is not iterable")
 

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -1009,8 +1009,8 @@ class Database(common.BaseObject, Generic[_DocumentType]):
 
         return result
 
-    def __iter__(self) -> "Database[_DocumentType]":
-        return self
+    # See PYTHON-3084.
+    __iter__ = None
 
     def __next__(self) -> NoReturn:
         raise TypeError("'Database' object is not iterable")

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1973,8 +1973,8 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self.close()
 
-    def __iter__(self) -> "MongoClient[_DocumentType]":
-        return self
+    # See PYTHON-3084.
+    __iter__ = None
 
     def __next__(self) -> NoReturn:
         raise TypeError("'MongoClient' object is not iterable")

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1973,9 +1973,6 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self.close()
 
-    # See PYTHON-3084.
-    __iter__ = None
-
     def __next__(self) -> NoReturn:
         raise TypeError("'MongoClient' object is not iterable")
 

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1973,6 +1973,9 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self.close()
 
+    # See PYTHON-3084.
+    __iter__ = None
+
     def __next__(self) -> NoReturn:
         raise TypeError("'MongoClient' object is not iterable")
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -211,8 +211,12 @@ class ClientUnitTest(unittest.TestCase):
 
     def test_iteration(self):
         client = self.client
+        if "PyPy" in sys.version:
+            msg = "'NoneType' object is not callable"
+        else:
+            msg = "'MongoClient' object is not iterable"
         # Iteration fails
-        with self.assertRaisesRegex(TypeError, "'MongoClient' object is not iterable"):
+        with self.assertRaisesRegex(TypeError, msg):
             for _ in client:  # type: ignore[misc] # error: "None" not callable  [misc]
                 break
         # Index fails

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -26,7 +26,7 @@ import struct
 import sys
 import threading
 import time
-from typing import Type, no_type_check
+from typing import Iterable, Type, no_type_check
 
 sys.path[0:0] = [""]
 
@@ -210,10 +210,22 @@ class ClientUnitTest(unittest.TestCase):
         self.assertIn("has no attribute '_does_not_exist'", str(context.exception))
 
     def test_iteration(self):
-        def iterate():
-            [a for a in self.client]  # type: ignore[misc] # error: "None" not callable  [misc]
-
-        self.assertRaises(TypeError, iterate)
+        client = self.client
+        # Iteration fails
+        with self.assertRaises(TypeError):
+            for _ in client:
+                break
+        # Index fails
+        with self.assertRaises(TypeError):
+            _ = client[0]
+        # next fails
+        with self.assertRaises(TypeError):
+            _ = next(client)
+        # .next() fails
+        with self.assertRaises(TypeError):
+            _ = client.next()
+        # Do not implement typing.Iterable.
+        self.assertNotIsInstance(client, Iterable)
 
     def test_get_default_database(self):
         c = rs_or_single_client(

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -211,7 +211,7 @@ class ClientUnitTest(unittest.TestCase):
 
     def test_iteration(self):
         def iterate():
-            [a for a in self.client]
+            [a for a in self.client]  # type: ignore[misc] # error: "None" not callable  [misc]
 
         self.assertRaises(TypeError, iterate)
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -212,17 +212,17 @@ class ClientUnitTest(unittest.TestCase):
     def test_iteration(self):
         client = self.client
         # Iteration fails
-        with self.assertRaises(TypeError):
-            for _ in client:
+        with self.assertRaisesRegex(TypeError, "'MongoClient' object is not iterable"):
+            for _ in client:  # type: ignore[misc] # error: "None" not callable  [misc]
                 break
         # Index fails
         with self.assertRaises(TypeError):
             _ = client[0]
         # next fails
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "'MongoClient' object is not iterable"):
             _ = next(client)
         # .next() fails
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "'MongoClient' object is not iterable"):
             _ = client.next()
         # Do not implement typing.Iterable.
         self.assertNotIsInstance(client, Iterable)

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -126,17 +126,17 @@ class TestCollectionNoConnect(unittest.TestCase):
     def test_iteration(self):
         coll = self.db.coll
         # Iteration fails
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "'Collection' object is not iterable"):
             for _ in coll:  # type: ignore[misc] # error: "None" not callable  [misc]
                 break
         # Non-string indices will start failing in PyMongo 5.
         self.assertEqual(coll[0].name, "coll.0")
         self.assertEqual(coll[{}].name, "coll.{}")
         # next fails
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "'Collection' object is not iterable"):
             _ = next(coll)
         # .next() fails
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "'Collection' object is not iterable"):
             _ = coll.next()
         # Do not implement typing.Iterable.
         self.assertNotIsInstance(coll, Iterable)

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -125,8 +125,12 @@ class TestCollectionNoConnect(unittest.TestCase):
 
     def test_iteration(self):
         coll = self.db.coll
+        if "PyPy" in sys.version:
+            msg = "'NoneType' object is not callable"
+        else:
+            msg = "'Collection' object is not iterable"
         # Iteration fails
-        with self.assertRaisesRegex(TypeError, "'Collection' object is not iterable"):
+        with self.assertRaisesRegex(TypeError, msg):
             for _ in coll:  # type: ignore[misc] # error: "None" not callable  [misc]
                 break
         # Non-string indices will start failing in PyMongo 5.

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -96,17 +96,17 @@ class TestDatabaseNoConnect(unittest.TestCase):
     def test_iteration(self):
         db = self.client.pymongo_test
         # Iteration fails
-        with self.assertRaises(TypeError):
-            for _ in db:
+        with self.assertRaisesRegex(TypeError, "'Database' object is not iterable"):
+            for _ in db:  # type: ignore[misc] # error: "None" not callable  [misc]
                 break
         # Index fails
         with self.assertRaises(TypeError):
             _ = db[0]
         # next fails
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "'Database' object is not iterable"):
             _ = next(db)
         # .next() fails
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "'Database' object is not iterable"):
             _ = db.next()
         # Do not implement typing.Iterable.
         self.assertNotIsInstance(db, Iterable)

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -16,7 +16,7 @@
 
 import re
 import sys
-from typing import Any, List, Mapping
+from typing import Any, Iterable, List, Mapping
 
 sys.path[0:0] = [""]
 
@@ -94,7 +94,22 @@ class TestDatabaseNoConnect(unittest.TestCase):
         self.assertIn("has no attribute '_does_not_exist'", str(context.exception))
 
     def test_iteration(self):
-        self.assertRaises(TypeError, next, self.client.pymongo_test)
+        db = self.client.pymongo_test
+        # Iteration fails
+        with self.assertRaises(TypeError):
+            for _ in db:
+                break
+        # Index fails
+        with self.assertRaises(TypeError):
+            _ = db[0]
+        # next fails
+        with self.assertRaises(TypeError):
+            _ = next(db)
+        # .next() fails
+        with self.assertRaises(TypeError):
+            _ = db.next()
+        # Do not implement typing.Iterable.
+        self.assertNotIsInstance(db, Iterable)
 
 
 class TestDatabase(IntegrationTest):

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -95,8 +95,12 @@ class TestDatabaseNoConnect(unittest.TestCase):
 
     def test_iteration(self):
         db = self.client.pymongo_test
+        if "PyPy" in sys.version:
+            msg = "'NoneType' object is not callable"
+        else:
+            msg = "'Database' object is not iterable"
         # Iteration fails
-        with self.assertRaisesRegex(TypeError, "'Database' object is not iterable"):
+        with self.assertRaisesRegex(TypeError, msg):
             for _ in db:  # type: ignore[misc] # error: "None" not callable  [misc]
                 break
         # Index fails


### PR DESCRIPTION
As noted in PYTHON-3084, this was the only way to get the typing.Iterable instance check to fail. We could also remove `__next__`+`next` (from client/Database only) but I kept them around so that users get better error messages `TypeError: 'MongoClient' object is not iterable` vs `TypeError: name must be an instance of str`.