### PR TITLE
PYTHON-3138 copydb was removed in MongoDB 4.2

### DIFF
--- a/doc/examples/copydb.rst
+++ b/doc/examples/copydb.rst
@@ -4,18 +4,18 @@ Copying a Database
 MongoDB >= 4.2
 --------------
 
-Starting in MongoDB version 4.2, the server removes the deprecated copydb command.
-As an alternative, users can use mongodump and mongorestore (with the mongorestore
+Starting in MongoDB version 4.2, the server removes the deprecated ``copydb`` command.
+As an alternative, users can use ``mongodump`` and ``mongorestore`` (with the ``mongorestore``
 options ``--nsFrom`` and ``--nsTo``).
 
 For example, to copy the ``test`` database from a local instance running on the
 default port 27017 to the ``examples`` database on the same instance, you can:
 
-#. Use mongodump to dump the test database to an archive ``mongodump-test-db``::
+#. Use ``mongodump`` to dump the test database to an archive ``mongodump-test-db``::
 
     mongodump --archive="mongodump-test-db" --db=test
 
-#. Use mongorestore with ``--nsFrom`` and ``--nsTo`` to restore (with database name change)
+#. Use ``mongorestore`` with ``--nsFrom`` and ``--nsTo`` to restore (with database name change)
    from the archive::
 
     mongorestore --archive="mongodump-test-db" --nsFrom='test.*' --nsTo='examples.*'
@@ -23,15 +23,15 @@ default port 27017 to the ``examples`` database on the same instance, you can:
 Include additional options as necessary, such as to specify the uri or host, username,
 password and authentication database.
 
-For more info about using mongodump and mongorestore see the `Copy a Database`_ example
-in the official mongodump documentation.
+For more info about using ``mongodump`` and ``mongorestore`` see the `Copy a Database`_ example
+in the official ``mongodump`` documentation.
 
 MongoDB <= 4.0
 --------------
 
-When using MongoDB <= 4.0, it is possible to use the deprecated copydb command
-to copy a database. To copy a database within a single mongod process, or
-between mongod servers, connect to the target mongod and use the
+When using MongoDB <= 4.0, it is possible to use the deprecated ``copydb`` command
+to copy a database. To copy a database within a single ``mongod`` process, or
+between ``mongod`` servers, connect to the target ``mongod`` and use the
 :meth:`~pymongo.database.Database.command` method::
 
   >>> from pymongo import MongoClient

--- a/doc/examples/copydb.rst
+++ b/doc/examples/copydb.rst
@@ -1,8 +1,37 @@
 Copying a Database
 ==================
 
-To copy a database within a single mongod process, or between mongod
-servers, simply connect to the target mongod and use the
+MongoDB >= 4.2
+--------------
+
+Starting in MongoDB version 4.2, the server removes the deprecated copydb command.
+As an alternative, users can use mongodump and mongorestore (with the mongorestore
+options ``--nsFrom`` and ``--nsTo``).
+
+For example, to copy the ``test`` database from a local instance running on the
+default port 27017 to the ``examples`` database on the same instance, you can:
+
+#. Use mongodump to dump the test database to an archive ``mongodump-test-db``::
+
+    mongodump --archive="mongodump-test-db" --db=test
+
+#. Use mongorestore with ``--nsFrom`` and ``--nsTo`` to restore (with database name change)
+   from the archive::
+
+    mongorestore --archive="mongodump-test-db" --nsFrom='test.*' --nsTo='examples.*'
+
+Include additional options as necessary, such as to specify the uri or host, username,
+password and authentication database.
+
+For more info about using mongodump and mongorestore see the `Copy a Database`_ example
+in the official mongodump documentation.
+
+MongoDB <= 4.0
+--------------
+
+When using MongoDB <= 4.0, it is possible to use the deprecated copydb command
+to copy a database. To copy a database within a single mongod process, or
+between mongod servers, connect to the target mongod and use the
 :meth:`~pymongo.database.Database.command` method::
 
   >>> from pymongo import MongoClient
@@ -39,3 +68,6 @@ but it has been removed.
 
 .. _copyDatabase function in the mongo shell:
    http://docs.mongodb.org/manual/reference/method/db.copyDatabase/
+
+.. _Copy a Database:
+   https://www.mongodb.com/docs/database-tools/mongodump/#std-label-mongodump-example-copy-clone-database


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3138

I inlined part of the mongodump example for convenience.