### PR TITLE
PYTHON-3214 Fix typing markers not being included in the distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,3 @@ include tools/README.rst
 recursive-include test *.pem
 recursive-include test *.py
 recursive-include bson *.h
-include bson/py.typed
-include gridfs/py.typed
-include pymongo/py.typed

--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,14 @@ if sys.platform == "win32":
 else:
     extras_require["gssapi"] = ["pykerberos"]
 
-extra_opts = {"packages": ["bson", "pymongo", "gridfs"]}
+extra_opts = {
+    "packages": ["bson", "pymongo", "gridfs"],
+    "package_data": {
+        "bson": ["py.typed"],
+        "pymongo": ["py.typed"],
+        "gridfs": ["py.typed"],
+    },
+}
 
 if "--no_ext" in sys.argv:
     sys.argv.remove("--no_ext")


### PR DESCRIPTION
The typing markers should be declared in the `package_data` to get picked up and packaged into the distributed wheels.