### PR TITLE
PYTHON-3216 Include codec_options.pyi in release distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -295,14 +295,7 @@ if sys.platform == "win32":
 else:
     extras_require["gssapi"] = ["pykerberos"]
 
-extra_opts = {
-    "packages": ["bson", "pymongo", "gridfs"],
-    "package_data": {
-        "bson": ["py.typed"],
-        "pymongo": ["py.typed"],
-        "gridfs": ["py.typed"],
-    },
-}
+extra_opts = {}
 
 if "--no_ext" in sys.argv:
     sys.argv.remove("--no_ext")
@@ -350,5 +343,11 @@ setup(
     ],
     cmdclass={"build_ext": custom_build_ext, "doc": doc, "test": test},
     extras_require=extras_require,
+    packages=["bson", "pymongo", "gridfs"],
+    package_data={
+        "bson": ["py.typed", "*.pyi"],
+        "pymongo": ["py.typed", "*.pyi"],
+        "gridfs": ["py.typed", "*.pyi"],
+    },
     **extra_opts
 )


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3216

```
unzip -l dist/pymongo-4.2.0.dev0-cp37-cp37m-macosx_10_9_x86_64.whl | grep '.pyi'
     3331  04-05-2022 20:40   bson/codec_options.pyi
```