### PR TITLE
PYTHON-3222 Fix memory leak in cbson decode_all

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2583,7 +2583,8 @@ done:
     return result;
 }
 
-static PyObject* _cbson_decode_all(PyObject* self, PyObject* args) {
+static PyObject* _cbson_decode_all(PyObject* self, PyObject* args,
+                                   PyObject* kwargs) {
     int32_t size;
     Py_ssize_t total_size;
     const char* string;
@@ -2591,13 +2592,14 @@ static PyObject* _cbson_decode_all(PyObject* self, PyObject* args) {
     PyObject* dict;
     PyObject* result = NULL;
     codec_options_t options;
-    PyObject* options_obj;
+    PyObject* options_obj = NULL;
     Py_buffer view = {0};
+    static char *kwlist[] =  {"data", "codec_options", NULL};
 
-    if (!PyArg_ParseTuple(args, "O|O", &bson, &options_obj)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O", kwlist, &bson, &options_obj)) {
         return NULL;
     }
-    if ((PyTuple_GET_SIZE(args) < 2) ||  (options_obj == Py_None)) {
+    if ((options_obj == NULL) || (options_obj == Py_None)) {
         if (!default_codec_options(GETSTATE(self), &options)) {
             return NULL;
         }
@@ -2695,7 +2697,7 @@ static PyMethodDef _CBSONMethods[] = {
      "convert a dictionary to a string containing its BSON representation."},
     {"_bson_to_dict", _cbson_bson_to_dict, METH_VARARGS,
      "convert a BSON string to a SON object."},
-    {"decode_all", _cbson_decode_all, METH_VARARGS,
+    {"decode_all", (PyCFunction)_cbson_decode_all, METH_VARARGS | METH_KEYWORDS,
      "convert binary data to a sequence of documents."},
     {"_element_to_dict", _cbson_element_to_dict, METH_VARARGS,
      "Decode a single key, value pair."},

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,32 @@
 Changelog
 =========
 
+Changes in Version 4.1.1
+-------------------------
+
+Issues Resolved
+...............
+
+Version 4.1.1 fixes a number of bugs:
+
+- Fixed a memory leak bug when calling :func:`~bson.decode_all` without a
+  ``codec_options`` argument (`PYTHON-3222`_).
+- Fixed a bug where :func:`~bson.decode_all` did not accept ``codec_options``
+  as a keyword argument (`PYTHON-3222`_).
+- Fixed an oversight where type markers (py.typed files) were not included
+  in our release distributions (`PYTHON-3214`_).
+- Fixed a bug where pymongo would raise a "NameError: name sys is not defined"
+  exception when attempting to parse a "mongodb+srv://" URI when the dnspython
+  dependency was not installed (`PYTHON-3198`_).
+
+See the `PyMongo 4.1.1 release notes in JIRA`_ for the list of resolved issues
+in this release.
+
+.. _PYTHON-3198: https://jira.mongodb.org/browse/PYTHON-3198
+.. _PYTHON-3214: https://jira.mongodb.org/browse/PYTHON-3214
+.. _PYTHON-3222: https://jira.mongodb.org/browse/PYTHON-3222
+.. _PyMongo 4.1.1 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=33290
+
 Changes in Version 4.1
 ----------------------
 

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -1006,6 +1006,15 @@ class TestCodecOptions(unittest.TestCase):
         decoded = bson.decode_all(bson.encode(doc2), None)[0]
         self.assertIsInstance(decoded["id"], Binary)
 
+    def test_decode_all_kwarg(self):
+        doc = {"a": uuid.uuid4()}
+        opts = CodecOptions(uuid_representation=UuidRepresentation.STANDARD)
+        encoded = encode(doc, codec_options=opts)
+        # Positional codec_options
+        self.assertEqual([doc], decode_all(encoded, opts))
+        # Keyword codec_options
+        self.assertEqual([doc], decode_all(encoded, codec_options=opts))
+
     def test_unicode_decode_error_handler(self):
         enc = encode({"keystr": "foobar"})
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3222

This change fixes a number of issues:

1. Fixes a memory leak of CodecOptions() in C extension's default_codec_options function. The leak occurs when not passing a CodecOptions to decode_all, (ie `decode_all(data)` or  `decode_all(data, None)`).
1. Fixes support for keyword argument codec_options for bson.decode_all.
1. Fixes a documentation issue where bson.decode_all was not showing up in the docs page.
1. Adds the changelog for 4.1.1