### PR TITLE
PYTHON-3250 Speed up majority writes in test suite

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1029,10 +1029,15 @@ class MockClientTest(unittest.TestCase):
         super(MockClientTest, self).tearDown()
 
 
+# Global knobs to speed up the test suite.
+global_knobs = client_knobs(events_queue_frequency=0.05)
+
+
 def setup():
     client_context.init()
     warnings.resetwarnings()
     warnings.simplefilter("always")
+    global_knobs.enable()
 
 
 def _get_executors(topology):
@@ -1086,6 +1091,7 @@ def print_running_clients():
 
 
 def teardown():
+    global_knobs.disable()
     garbage = []
     for g in gc.garbage:
         garbage.append("GARBAGE: %r" % (g,))

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -24,7 +24,7 @@ import sys
 import textwrap
 import traceback
 import uuid
-from typing import Any
+from typing import Any, Dict
 
 from pymongo.collection import Collection
 
@@ -634,7 +634,7 @@ class TestSpec(SpecRunner):
         coll = db[coll_name]
         coll.drop()
         wc = WriteConcern(w="majority")
-        kwargs = {}
+        kwargs: Dict[str, Any] = {}
         if json_schema:
             kwargs["validator"] = {"$jsonSchema": json_schema}
             kwargs["codec_options"] = OPTS

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -717,22 +717,24 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         return False
 
     def insert_initial_data(self, initial_data):
-        for collection_data in initial_data:
+        for i, collection_data in enumerate(initial_data):
             coll_name = collection_data["collectionName"]
             db_name = collection_data["databaseName"]
             documents = collection_data["documents"]
 
-            coll = self.client.get_database(db_name).get_collection(
-                coll_name, write_concern=WriteConcern(w="majority")
-            )
-            coll.drop()
-
-            if len(documents) > 0:
-                coll.insert_many(documents)
+            # Setup the collection with as few majority writes as possible.
+            db = self.client[db_name]
+            db.drop_collection(coll_name)
+            # Only use majority wc only on the final write.
+            if i == len(initial_data) - 1:
+                wc = WriteConcern(w="majority")
             else:
-                # ensure collection exists
-                result = coll.insert_one({})
-                coll.delete_one({"_id": result.inserted_id})
+                wc = WriteConcern(w=1)
+            if documents:
+                db.get_collection(coll_name, write_concern=wc).insert_many(documents)
+            else:
+                # Ensure collection exists
+                db.create_collection(coll_name, write_concern=wc)
 
     @classmethod
     def setUpClass(cls):

--- a/test/utils_spec_runner.py
+++ b/test/utils_spec_runner.py
@@ -469,10 +469,6 @@ class SpecRunner(IntegrationTest):
             db.create_collection(coll_name, write_concern=wc)
 
     def run_scenario(self, scenario_def, test):
-        """----------------------------------------------------------------------
-        Ran 363 tests in 251.381s
-
-        OK (skipped=89)"""
         self.maybe_skip_scenario(test)
 
         # Kill all sessions before and after each test to prevent an open

--- a/test/utils_spec_runner.py
+++ b/test/utils_spec_runner.py
@@ -453,15 +453,26 @@ class SpecRunner(IntegrationTest):
         """Allow specs to override a test's setup."""
         db_name = self.get_scenario_db_name(scenario_def)
         coll_name = self.get_scenario_coll_name(scenario_def)
-        db = client_context.client.get_database(db_name, write_concern=WriteConcern(w="majority"))
-        coll = db[coll_name]
-        coll.drop()
-        db.create_collection(coll_name)
-        if scenario_def["data"]:
-            # Load data.
-            coll.insert_many(scenario_def["data"])
+        documents = scenario_def["data"]
+
+        # Setup the collection with as few majority writes as possible.
+        db = client_context.client.get_database(db_name)
+        coll_exists = bool(db.list_collection_names(filter={"name": coll_name}))
+        if coll_exists:
+            db[coll_name].delete_many({})
+        # Only use majority wc only on the final write.
+        wc = WriteConcern(w="majority")
+        if documents:
+            db.get_collection(coll_name, write_concern=wc).insert_many(documents)
+        elif not coll_exists:
+            # Ensure collection exists.
+            db.create_collection(coll_name, write_concern=wc)
 
     def run_scenario(self, scenario_def, test):
+        """----------------------------------------------------------------------
+        Ran 363 tests in 251.381s
+
+        OK (skipped=89)"""
         self.maybe_skip_scenario(test)
 
         # Kill all sessions before and after each test to prevent an open


### PR DESCRIPTION
This shaves off anywhere from 1 minute to **16 minutes** from the test suite on macos depending of the server version and topology: https://spruce.mongodb.com/task/mongo_python_driver_test_macos__platform~macos_1014_auth~auth_ssl~ssl_test_4.2_replica_set_patch_05b55e88dfa1636511eeeac56d4a75593a76fbeb_6270a5ab5623434c42b90339_22_05_03_03_46_53/tests?execution=0&sortBy=STATUS&sortDir=ASC

On "macOS 10.14 Auth SSL" alone this change saves 67 minutes of execution time (Time Spent 3h 32m vs 4h 25m).
