### PR TITLE
PYTHON-3251 Make extra whitespace visible in invalid port exception

### DIFF
--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -134,7 +134,7 @@ def parse_host(entity: str, default_port: Optional[int] = DEFAULT_PORT) -> _Addr
         host, port = host.split(":", 1)
     if isinstance(port, str):
         if not port.isdigit() or int(port) > 65535 or int(port) <= 0:
-            raise ValueError("Port must be an integer between 0 and 65535: %s" % (port,))
+            raise ValueError("Port must be an integer between 0 and 65535: %r" % (port,))
         port = int(port)
 
     # Normalize hostname to lowercase, since DNS is case-insensitive:

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -147,6 +147,10 @@ class TestURI(unittest.TestCase):
         self.assertRaises(InvalidURI, parse_uri, "http://foo@foobar.com")
         self.assertRaises(ValueError, parse_uri, "mongodb://::1", 27017)
 
+        # Extra whitespace should be visible is error message.
+        with self.assertRaisesRegex(ValueError, "'27017 '"):
+            parse_uri("mongodb://localhost:27017 ")
+
         orig: dict = {
             "nodelist": [("localhost", 27017)],
             "username": None,

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -147,7 +147,7 @@ class TestURI(unittest.TestCase):
         self.assertRaises(InvalidURI, parse_uri, "http://foo@foobar.com")
         self.assertRaises(ValueError, parse_uri, "mongodb://::1", 27017)
 
-        # Extra whitespace should be visible is error message.
+        # Extra whitespace should be visible in error message.
         with self.assertRaisesRegex(ValueError, "'27017 '"):
             parse_uri("mongodb://localhost:27017 ")
 


### PR DESCRIPTION
Minor change to improve the error behavior in https://jira.mongodb.org/browse/PYTHON-3251. 

Before this change:
```
>>> uri_parser.parse_uri('mongodb://mongo-service:27017 ')
...
ValueError: Port must be an integer between 0 and 65535: 27017 
```

After this change:
```
>>> uri_parser.parse_uri('mongodb://mongo-service:27017 ')
...
ValueError: Port must be an integer between 0 and 65535: '27017 '
```