### PR TITLE
PYTHON-3065 Ignore SRV polling update when topology is discovered to be a replica set

### DIFF
--- a/pymongo/topology.py
+++ b/pymongo/topology.py
@@ -358,6 +358,8 @@ class Topology(object):
         Hold the lock when calling this.
         """
         td_old = self._description
+        if td_old.topology_type not in SRV_POLLING_TOPOLOGIES:
+            return
         self._description = _updated_topology_description_srv_polling(self._description, seedlist)
 
         self._update_servers()

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -477,6 +477,7 @@ def _updated_topology_description_srv_polling(topology_description, seedlist):
       - `seedlist`: a list of new seeds new ServerDescription that resulted from
         a hello call
     """
+    assert topology_description.topology_type in SRV_POLLING_TOPOLOGIES
     # Create a copy of the server descriptions.
     sds = topology_description.server_descriptions()
 


### PR DESCRIPTION
Fixes https://jira.mongodb.org/browse/PYTHON-3065.

Explanation:

PYTHON-3065 looked like a flakey test but is actually a real bug. With some extra logging the test failure looks like this:
```
test_direct-connection-false (test.test_dns.TestDNSRepl) ... _ensure_opened: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: Unknown, servers: [<ServerDescription ('localhost.test.build.10gen.cc', 27017) server_type: Unknown, rtt: None>]>

MongoClient(mongodb+srv://test3.test.build.10gen.cc/?directConnection=false, **{'tlsCertificateKeyFile': '/Users/shane/git/mongo-python-driver/test/certificates/client.pem', 'tlsCAFile': '/Users/shane/git/mongo-python-driver/test/certificates/ca.pem', 'tlsAllowInvalidHostnames': True, 'appname': 'test_direct-connection-false'})
_process_change: <ServerDescription ('localhost.test.build.10gen.cc', 27017) server_type: RSSecondary, rtt: 0.001449183000000076>
_process_change, new: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: ReplicaSetNoPrimary, servers: [<ServerDescription ('localhost', 27017) server_type: Unknown, rtt: None>, <ServerDescription ('localhost', 27018) server_type: Unknown, rtt: None>, <ServerDescription ('localhost', 27019) server_type: Unknown, rtt: None>]>
_process_change: <ServerDescription ('localhost', 27017) server_type: RSSecondary, rtt: 0.0010720439999998277>
_process_change, new: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: ReplicaSetNoPrimary, servers: [<ServerDescription ('localhost', 27017) server_type: RSSecondary, rtt: 0.0010720439999998277>, <ServerDescription ('localhost', 27018) server_type: Unknown, rtt: None>, <ServerDescription ('localhost', 27019) server_type: Unknown, rtt: None>]>
_process_change: <ServerDescription ('localhost', 27019) server_type: RSSecondary, rtt: 0.001547292999999783>
_process_change, new: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: ReplicaSetNoPrimary, servers: [<ServerDescription ('localhost', 27017) server_type: RSSecondary, rtt: 0.0010720439999998277>, <ServerDescription ('localhost', 27018) server_type: Unknown, rtt: None>, <ServerDescription ('localhost', 27019) server_type: RSSecondary, rtt: 0.001547292999999783>]>
_process_change: <ServerDescription ('localhost', 27018) server_type: RSPrimary, rtt: 0.0009001800000003612>
_process_change, new: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: ReplicaSetWithPrimary, servers: [<ServerDescription ('localhost', 27017) server_type: RSSecondary, rtt: 0.0010720439999998277>, <ServerDescription ('localhost', 27018) server_type: RSPrimary, rtt: 0.0009001800000003612>, <ServerDescription ('localhost', 27019) server_type: RSSecondary, rtt: 0.001547292999999783>]>
_process_srv_update: [('localhost.test.build.10gen.cc', 27017)]
_process_srv_update, new: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: ReplicaSetWithPrimary, servers: [<ServerDescription ('localhost.test.build.10gen.cc', 27017) server_type: Unknown, rtt: None>]>
_process_change: <ServerDescription ('localhost.test.build.10gen.cc', 27017) server_type: RSSecondary, rtt: 0.0012669780000003072>
_process_change, new: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: ReplicaSetNoPrimary, servers: []>
FAIL
...
FAIL: test_direct-connection-false (test.test_dns.TestDNSRepl)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/test/test_dns.py", line 134, in run_test
    wait_until(lambda: hosts == client.nodes, "match test hosts to client nodes")
AssertionError: Didn't ever match test hosts to client nodes

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/test/test_dns.py", line 136, in run_test
    self.assertEqual(hosts, client.nodes)
AssertionError: Items in the first set but not the second:
('localhost', 27019)
('localhost', 27017)
('localhost', 27018)
```

The key bits are these lines:
```
_process_change, new: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: ReplicaSetWithPrimary, servers: [<ServerDescription ('localhost', 27017) server_type: RSSecondary, rtt: 0.0010720439999998277>, <ServerDescription ('localhost', 27018) server_type: RSPrimary, rtt: 0.0009001800000003612>, <ServerDescription ('localhost', 27019) server_type: RSSecondary, rtt: 0.001547292999999783>]>
_process_srv_update: [('localhost.test.build.10gen.cc', 27017)]
_process_srv_update, new: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: ReplicaSetWithPrimary, servers: [<ServerDescription ('localhost.test.build.10gen.cc', 27017) server_type: Unknown, rtt: None>]>
_process_change: <ServerDescription ('localhost.test.build.10gen.cc', 27017) server_type: RSSecondary, rtt: 0.0012669780000003072>
_process_change, new: <TopologyDescription id: 6275bd337ad1d299c0eefa54, topology_type: ReplicaSetNoPrimary, servers: []>
```

The topology has already been discovered to be ReplicaSetWithPrimary and then the delayed SrvMonitor update comes in. _process_srv_update mistakenly updates the topology to ReplicaSetWithPrimary with an unknown server causing the next response to remove the server.

The fix is to ignore the srv update when we know the topology is not Unknown and not Sharded.