### PR TITLE
PYTHON-3257 Fix "connection pool paused" errors in child after fork

### DIFF
--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -1420,7 +1420,7 @@ class Pool:
         # See test.test_client:TestClient.test_fork for an example of
         # what could go wrong otherwise
         if self.pid != os.getpid():
-            self.reset()
+            self.reset_without_pause()
 
         if self.closed:
             if self.enabled_for_cmap:
@@ -1526,7 +1526,7 @@ class Pool:
         if self.enabled_for_cmap:
             listeners.publish_connection_checked_in(self.address, sock_info.id)
         if self.pid != os.getpid():
-            self.reset()
+            self.reset_without_pause()
         else:
             if self.closed:
                 sock_info.close_socket(ConnectionClosedReason.POOL_CLOSED)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3257

This change fixes a regression in pymongo 4.0.
```python
$ cat fork_test.py 
from os import fork
from pymongo import MongoClient, errors

# Create client in parent (before fork).
client = MongoClient()
client.admin.command('ping')
pid = fork()
if pid:
    print('parent exiting')
else:
    print('ping in child:')
    for i in range(1, 50):
        try:
            print(client.admin.command('ping'))
            break
        except errors.AutoReconnect as exc:
            print(f'failure {i}: {exc}')
```

Output before this change:
```
$ python fork_test.py
parent exiting
ping in child:
/Users/shane/git/mongo-python-driver/pymongo/topology.py:177: UserWarning: MongoClient opened before fork. Create MongoClient only after forking. See PyMongo's documentation for details: https://pymongo.readthedocs.io/en/stable/faq.html#is-pymongo-fork-safe
  "MongoClient opened before fork. Create MongoClient only "
failure 1: localhost:27017: connection pool paused
failure 2: localhost:27017: connection pool paused
{'ok': 1.0, '$clusterTime': {'clusterTime': Timestamp(1652133036, 1), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1652133036, 1)}
```

After this change:
```
$ python fork_test.py
parent exiting
ping in child:
/Users/shane/git/mongo-python-driver/pymongo/topology.py:178: UserWarning: MongoClient opened before fork. Create MongoClient only after forking. See PyMongo's documentation for details: https://pymongo.readthedocs.io/en/stable/faq.html#is-pymongo-fork-safe
  "MongoClient opened before fork. Create MongoClient only "
{'ok': 1.0, '$clusterTime': {'clusterTime': Timestamp(1652133136, 1), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1652133136, 1)}
```