### PR TITLE
PYTHON-3187 Avoid tight poll() loop on pyopenssl connections

### DIFF
--- a/pymongo/pyopenssl_context.py
+++ b/pymongo/pyopenssl_context.py
@@ -70,6 +70,8 @@ _VERIFY_MAP = {
 _REVERSE_VERIFY_MAP = dict((value, key) for key, value in _VERIFY_MAP.items())
 
 
+# For SNI support. According to RFC6066, section 3, IPv4 and IPv6 literals are
+# not permitted for SNI hostname.
 def _is_ip_address(address):
     try:
         _ip_address(address)
@@ -104,8 +106,17 @@ class _sslConn(_SSL.Connection):
         while True:
             try:
                 return call(*args, **kwargs)
-            except _RETRY_ERRORS:
-                self.socket_checker.select(self, True, True, timeout)
+            except _RETRY_ERRORS as exc:
+                if isinstance(exc, _SSL.WantReadError):
+                    want_read = True
+                    want_write = False
+                elif isinstance(exc, _SSL.WantWriteError):
+                    want_read = False
+                    want_write = True
+                else:
+                    want_read = True
+                    want_write = True
+                self.socket_checker.select(self, want_read, want_write, timeout)
                 if timeout and _time.monotonic() - start > timeout:
                     raise _socket.timeout("timed out")
                 continue

--- a/pymongo/ssl_support.py
+++ b/pymongo/ssl_support.py
@@ -14,8 +14,6 @@
 
 """Support for SSL in PyMongo."""
 
-import sys
-
 from pymongo.errors import ConfigurationError
 
 HAVE_SSL = True
@@ -38,7 +36,7 @@ if HAVE_SSL:
     from ssl import CERT_NONE, CERT_REQUIRED
 
     HAS_SNI = _ssl.HAS_SNI
-    IPADDR_SAFE = _ssl.IS_PYOPENSSL or sys.version_info[:2] >= (3, 7)
+    IPADDR_SAFE = True
     SSLError = _ssl.SSLError
 
     def get_ssl_context(
@@ -53,12 +51,10 @@ if HAVE_SSL:
         """Create and return an SSLContext object."""
         verify_mode = CERT_NONE if allow_invalid_certificates else CERT_REQUIRED
         ctx = _ssl.SSLContext(_ssl.PROTOCOL_SSLv23)
-        # SSLContext.check_hostname was added in CPython 3.4.
-        if hasattr(ctx, "check_hostname"):
-            if verify_mode != CERT_NONE:
-                ctx.check_hostname = not allow_invalid_hostnames
-            else:
-                ctx.check_hostname = False
+        if verify_mode != CERT_NONE:
+            ctx.check_hostname = not allow_invalid_hostnames
+        else:
+            ctx.check_hostname = False
         if hasattr(ctx, "check_ocsp_endpoint"):
             ctx.check_ocsp_endpoint = not disable_ocsp_endpoint_check
         if hasattr(ctx, "options"):

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -145,13 +145,10 @@ class TestAutoEncryptionOpts(PyMongoTestCase):
             self.assertEqual(opts._kms_ssl_contexts, {})
         opts = AutoEncryptionOpts({}, "k.d", kms_tls_options={"kmip": {"tls": True}, "aws": {}})
         ctx = opts._kms_ssl_contexts["kmip"]
-        # On < 3.7 we check hostnames manually.
-        if sys.version_info[:2] >= (3, 7):
-            self.assertEqual(ctx.check_hostname, True)
+        self.assertEqual(ctx.check_hostname, True)
         self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
         ctx = opts._kms_ssl_contexts["aws"]
-        if sys.version_info[:2] >= (3, 7):
-            self.assertEqual(ctx.check_hostname, True)
+        self.assertEqual(ctx.check_hostname, True)
         self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
         opts = AutoEncryptionOpts(
             {},
@@ -159,8 +156,7 @@ class TestAutoEncryptionOpts(PyMongoTestCase):
             kms_tls_options={"kmip": {"tlsCAFile": CA_PEM, "tlsCertificateKeyFile": CLIENT_PEM}},
         )
         ctx = opts._kms_ssl_contexts["kmip"]
-        if sys.version_info[:2] >= (3, 7):
-            self.assertEqual(ctx.check_hostname, True)
+        self.assertEqual(ctx.check_hostname, True)
         self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
 
 

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -65,8 +65,6 @@ CA_BUNDLE_PEM = os.path.join(CERT_PATH, "trusted-ca.pem")
 CRL_PEM = os.path.join(CERT_PATH, "crl.pem")
 MONGODB_X509_USERNAME = "C=US,ST=New York,L=New York City,O=MDB,OU=Drivers,CN=client"
 
-_PY37PLUS = sys.version_info[:2] >= (3, 7)
-
 # To fully test this start a mongod instance (built with SSL support) like so:
 # mongod --dbpath /path/to/data/directory --sslOnNormalPorts \
 # --sslPEMKeyFile /path/to/pymongo/test/certificates/server.pem \
@@ -306,10 +304,7 @@ class TestSSL(IntegrationTest):
         ctx = get_ssl_context(None, None, None, None, False, True, False)
         self.assertFalse(ctx.check_hostname)
         ctx = get_ssl_context(None, None, None, None, False, False, False)
-        if _PY37PLUS or _HAVE_PYOPENSSL:
-            self.assertTrue(ctx.check_hostname)
-        else:
-            self.assertFalse(ctx.check_hostname)
+        self.assertTrue(ctx.check_hostname)
 
         response = self.client.admin.command(HelloCompat.LEGACY_CMD)
 


### PR DESCRIPTION
This is tangentially related to some work I did on CSOT so I figured I would knock it out. 

This change fixes the issue described in PYTHON-3187 and also cleans up the Python <3.7 ssl support code for check_hostname and SNI.