### PR TITLE
PYTHON-3294 Depend on PyMongoCrypt 1.3.0b0 tag for beta

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,9 @@ if sys.platform in ("win32", "darwin"):
     pyopenssl_reqs.append("certifi")
 
 extras_require = {
-    "encryption": ["pymongocrypt>=1.2.0,<2.0.0"],
+    "encryption": [
+        "pymongocrypt@git+https://github.com/mongodb/libmongocrypt.git@1.5.0-rc1#subdirectory=bindings/python"
+    ],
     "ocsp": pyopenssl_reqs,
     "snappy": ["python-snappy"],
     "zstd": ["zstandard"],

--- a/setup.py
+++ b/setup.py
@@ -282,7 +282,7 @@ if sys.platform in ("win32", "darwin"):
 
 extras_require = {
     "encryption": [
-        "pymongocrypt@git+https://github.com/mongodb/libmongocrypt.git@1.5.0-rc1#subdirectory=bindings/python"
+        "pymongocrypt@git+ssh://git@github.com/mongodb/libmongocrypt.git@pymongocrypt-1.3.0b0#subdirectory=bindings/python"
     ],
     "ocsp": pyopenssl_reqs,
     "snappy": ["python-snappy"],


### PR DESCRIPTION
I will update this once we create a tag for https://github.com/mongodb/libmongocrypt/pull/366.