### PR TITLE
PYTHON-2110 Refactored some C to avoid symbol conflicts

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -153,7 +153,7 @@ static PyObject* datetime_from_millis(long long millis) {
     int microseconds = diff * 1000;
     Time64_T seconds = (millis - diff) / 1000;
     struct TM timeinfo;
-    gmtime64_r(&seconds, &timeinfo);
+    cbson_gmtime64_r(&seconds, &timeinfo);
 
     return PyDateTime_FromDateAndTime(timeinfo.tm_year + 1900,
                                       timeinfo.tm_mon + 1,
@@ -175,14 +175,14 @@ static long long millis_from_datetime(PyObject* datetime) {
     timeinfo.tm_min = PyDateTime_DATE_GET_MINUTE(datetime);
     timeinfo.tm_sec = PyDateTime_DATE_GET_SECOND(datetime);
 
-    millis = timegm64(&timeinfo) * 1000;
+    millis = cbson_timegm64(&timeinfo) * 1000;
     millis += PyDateTime_DATE_GET_MICROSECOND(datetime) / 1000;
     return millis;
 }
 
 /* Just make this compatible w/ the old API. */
 int buffer_write_bytes(buffer_t buffer, const char* data, int size) {
-    if (buffer_write(buffer, data, size)) {
+    if (pymongo_buffer_write(buffer, data, size)) {
         return 0;
     }
     return 1;
@@ -207,7 +207,7 @@ void buffer_write_int32_at_position(buffer_t buffer,
                                     int position,
                                     int32_t data) {
     uint32_t data_le = BSON_UINT32_TO_LE(data);
-    memcpy(buffer_get_buffer(buffer) + position, &data_le, 4);
+    memcpy(pymongo_buffer_get_buffer(buffer) + position, &data_le, 4);
 }
 
 static int write_unicode(buffer_t buffer, PyObject* py_string) {
@@ -419,7 +419,7 @@ static long _type_marker(PyObject* object) {
  * Return 1 on success. options->document_class is a new reference.
  * Return 0 on failure.
  */
-int convert_type_registry(PyObject* registry_obj, type_registry_t* registry) {
+int cbson_convert_type_registry(PyObject* registry_obj, type_registry_t* registry) {
     registry->encoder_map = NULL;
     registry->decoder_map = NULL;
     registry->fallback_encoder = NULL;
@@ -481,7 +481,7 @@ int convert_codec_options(PyObject* options_obj, void* p) {
         return 0;
     }
 
-    if (!convert_type_registry(type_registry_obj,
+    if (!cbson_convert_type_registry(type_registry_obj,
                                &options->type_registry)) {
         return 0;
     }
@@ -597,7 +597,7 @@ static int _write_regex_to_buffer(
         Py_DECREF(encoded_pattern);
         return 0;
     }
-    status = check_string((const unsigned char*)pattern_data,
+    status = cbson_check_string((const unsigned char*)pattern_data,
                           pattern_length, check_utf8, 1);
     if (status == NOT_UTF_8) {
         PyObject* InvalidStringData = _error("InvalidStringData");
@@ -649,7 +649,7 @@ static int _write_regex_to_buffer(
     if (!buffer_write_bytes(buffer, flags, flags_length)) {
         return 0;
     }
-    *(buffer_get_buffer(buffer) + type_byte) = 0x0B;
+    *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x0B;
     return 1;
 }
 
@@ -687,7 +687,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
             const char* data;
             int size;
 
-            *(buffer_get_buffer(buffer) + type_byte) = 0x05;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x05;
             subtype_object = PyObject_GetAttrString(value, "subtype");
             if (!subtype_object) {
                 return 0;
@@ -750,7 +750,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
                 return 0;
             }
             Py_DECREF(pystring);
-            *(buffer_get_buffer(buffer) + type_byte) = 0x07;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x07;
             return 1;
         }
     case 11:
@@ -772,15 +772,15 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
 
             if (scope == Py_None) {
                 Py_DECREF(scope);
-                *(buffer_get_buffer(buffer) + type_byte) = 0x0D;
+                *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x0D;
                 return write_string(buffer, value);
             }
 
-            *(buffer_get_buffer(buffer) + type_byte) = 0x0F;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x0F;
 
-            start_position = buffer_get_position(buffer);
+            start_position = pymongo_buffer_get_position(buffer);
             /* save space for length */
-            length_location = buffer_save_space(buffer, 4);
+            length_location = pymongo_buffer_save_space(buffer, 4);
             if (length_location == -1) {
                 Py_DECREF(scope);
                 return 0;
@@ -797,7 +797,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
             }
             Py_DECREF(scope);
 
-            length = buffer_get_position(buffer) - start_position;
+            length = pymongo_buffer_get_position(buffer) - start_position;
             buffer_write_int32_at_position(
                 buffer, length_location, (int32_t)length);
             return 1;
@@ -834,7 +834,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
                 return 0;
             }
 
-            *(buffer_get_buffer(buffer) + type_byte) = 0x11;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x11;
             return 1;
         }
     case 18:
@@ -849,7 +849,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
             if (!buffer_write_int64(buffer, (int64_t)ll)) {
                 return 0;
             }
-            *(buffer_get_buffer(buffer) + type_byte) = 0x12;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x12;
             return 1;
         }
     case 19:
@@ -870,7 +870,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
                 return 0;
             }
             Py_DECREF(pystring);
-            *(buffer_get_buffer(buffer) + type_byte) = 0x13;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x13;
             return 1;
         }
     case 100:
@@ -885,7 +885,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
                 return 0;
             }
             Py_DECREF(as_doc);
-            *(buffer_get_buffer(buffer) + type_byte) = 0x03;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x03;
             return 1;
         }
     case 101:
@@ -894,19 +894,19 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
             if (!write_raw_doc(buffer, value)) {
                 return 0;
             }
-            *(buffer_get_buffer(buffer) + type_byte) = 0x03;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x03;
             return 1;
         }
     case 255:
         {
             /* MinKey */
-            *(buffer_get_buffer(buffer) + type_byte) = 0xFF;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0xFF;
             return 1;
         }
     case 127:
         {
             /* MaxKey */
-            *(buffer_get_buffer(buffer) + type_byte) = 0x7F;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x7F;
             return 1;
         }
     }
@@ -915,7 +915,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
 
     if (PyBool_Check(value)) {
         const char c = (value == Py_True) ? 0x01 : 0x00;
-        *(buffer_get_buffer(buffer) + type_byte) = 0x08;
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x08;
         return buffer_write_bytes(buffer, &c, 1);
     }
     else if (PyLong_Check(value)) {
@@ -931,20 +931,20 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
                                 "MongoDB can only handle up to 8-byte ints");
                 return 0;
             }
-            *(buffer_get_buffer(buffer) + type_byte) = 0x12;
+            *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x12;
             return buffer_write_int64(buffer, (int64_t)long_long_value);
         }
-        *(buffer_get_buffer(buffer) + type_byte) = 0x10;
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x10;
         return buffer_write_int32(buffer, (int32_t)int_value);
     } else if (PyFloat_Check(value)) {
         const double d = PyFloat_AsDouble(value);
-        *(buffer_get_buffer(buffer) + type_byte) = 0x01;
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x01;
         return buffer_write_double(buffer, d);
     } else if (value == Py_None) {
-        *(buffer_get_buffer(buffer) + type_byte) = 0x0A;
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x0A;
         return 1;
     } else if (PyDict_Check(value)) {
-        *(buffer_get_buffer(buffer) + type_byte) = 0x03;
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x03;
         return write_dict(self, buffer, value, check_keys, options, 0);
     } else if (PyList_Check(value) || PyTuple_Check(value)) {
         Py_ssize_t items, i;
@@ -953,11 +953,11 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
             length;
         char zero = 0;
 
-        *(buffer_get_buffer(buffer) + type_byte) = 0x04;
-        start_position = buffer_get_position(buffer);
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x04;
+        start_position = pymongo_buffer_get_position(buffer);
 
         /* save space for length */
-        length_location = buffer_save_space(buffer, 4);
+        length_location = pymongo_buffer_save_space(buffer, 4);
         if (length_location == -1) {
             return 0;
         }
@@ -972,7 +972,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
             return 0;
         }
         for(i = 0; i < items; i++) {
-            int list_type_byte = buffer_save_space(buffer, 1);
+            int list_type_byte = pymongo_buffer_save_space(buffer, 1);
             char name[16];
             PyObject* item_value;
 
@@ -999,7 +999,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
         if (!buffer_write_bytes(buffer, &zero, 1)) {
             return 0;
         }
-        length = buffer_get_position(buffer) - start_position;
+        length = pymongo_buffer_get_position(buffer) - start_position;
         buffer_write_int32_at_position(
             buffer, length_location, (int32_t)length);
         return 1;
@@ -1012,7 +1012,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
             return 0;
         if ((size = _downcast_and_check(PyBytes_GET_SIZE(value), 0)) == -1)
             return 0;
-        *(buffer_get_buffer(buffer) + type_byte) = 0x05;
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x05;
         if (!buffer_write_int32(buffer, (int32_t)size)) {
             return 0;
         }
@@ -1024,7 +1024,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
         }
         return 1;
     } else if (PyUnicode_Check(value)) {
-        *(buffer_get_buffer(buffer) + type_byte) = 0x02;
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x02;
         return write_unicode(buffer, value);
     } else if (PyDateTime_Check(value)) {
         long long millis;
@@ -1042,7 +1042,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
         } else {
             millis = millis_from_datetime(value);
         }
-        *(buffer_get_buffer(buffer) + type_byte) = 0x09;
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x09;
         return buffer_write_int64(buffer, (int64_t)millis);
     } else if (PyObject_TypeCheck(value, state->REType)) {
         return _write_regex_to_buffer(buffer, type_byte, value);
@@ -1059,7 +1059,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
         if (PyErr_Occurred()) {
             return 0;
         }
-        *(buffer_get_buffer(buffer) + type_byte) = 0x03;
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x03;
         return write_dict(self, buffer, value, check_keys, options, 0);
     }
 
@@ -1189,7 +1189,7 @@ int write_pair(PyObject* self, buffer_t buffer, const char* name, int name_lengt
         return 1;
     }
 
-    type_byte = buffer_save_space(buffer, 1);
+    type_byte = pymongo_buffer_save_space(buffer, 1);
     if (type_byte == -1) {
         return 0;
     }
@@ -1362,7 +1362,7 @@ int write_dict(PyObject* self, buffer_t buffer,
         }
     }
 
-    length_location = buffer_save_space(buffer, 4);
+    length_location = pymongo_buffer_save_space(buffer, 4);
     if (length_location == -1) {
         return 0;
     }
@@ -1429,7 +1429,7 @@ int write_dict(PyObject* self, buffer_t buffer,
     if (!buffer_write_bytes(buffer, &zero, 1)) {
         return 0;
     }
-    length = buffer_get_position(buffer) - length_location;
+    length = pymongo_buffer_get_position(buffer) - length_location;
     buffer_write_int32_at_position(
         buffer, length_location, (int32_t)length);
     return length;
@@ -1464,7 +1464,7 @@ static PyObject* _cbson_dict_to_bson(PyObject* self, PyObject* args) {
         return raw_bson_document_bytes_obj;
     }
 
-    buffer = buffer_new();
+    buffer = pymongo_buffer_new();
     if (!buffer) {
         destroy_codec_options(&options);
         return NULL;
@@ -1472,15 +1472,15 @@ static PyObject* _cbson_dict_to_bson(PyObject* self, PyObject* args) {
 
     if (!write_dict(self, buffer, dict, check_keys, &options, top_level)) {
         destroy_codec_options(&options);
-        buffer_free(buffer);
+        pymongo_buffer_free(buffer);
         return NULL;
     }
 
     /* objectify buffer */
-    result = Py_BuildValue("y#", buffer_get_buffer(buffer),
-                           (Py_ssize_t)buffer_get_position(buffer));
+    result = Py_BuildValue("y#", pymongo_buffer_get_buffer(buffer),
+                           (Py_ssize_t)pymongo_buffer_get_position(buffer));
     destroy_codec_options(&options);
-    buffer_free(buffer);
+    pymongo_buffer_free(buffer);
     return result;
 }
 

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2718,7 +2718,7 @@ static struct PyModuleDef moduledef = {
 };
 
 PyMODINIT_FUNC
-PyInit__cbson(void)
+cbson_PyInit__cbson(void)
 {
     PyObject *m;
     PyObject *c_api_object;

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2718,7 +2718,7 @@ static struct PyModuleDef moduledef = {
 };
 
 PyMODINIT_FUNC
-cbson_PyInit__cbson(void)
+PyInit__cbson(void)
 {
     PyObject *m;
     PyObject *c_api_object;

--- a/bson/buffer.c
+++ b/bson/buffer.c
@@ -39,7 +39,7 @@ static void set_memory_error(void) {
 
 /* Allocate and return a new buffer.
  * Return NULL and sets MemoryError on allocation failure. */
-buffer_t buffer_new(void) {
+buffer_t pymongo_buffer_new(void) {
     buffer_t buffer;
     buffer = (buffer_t)malloc(sizeof(struct buffer));
     if (buffer == NULL) {
@@ -61,7 +61,7 @@ buffer_t buffer_new(void) {
 
 /* Free the memory allocated for `buffer`.
  * Return non-zero on failure. */
-int buffer_free(buffer_t buffer) {
+int pymongo_buffer_free(buffer_t buffer) {
     if (buffer == NULL) {
         return 1;
     }
@@ -122,7 +122,7 @@ static int buffer_assure_space(buffer_t buffer, int size) {
 /* Save `size` bytes from the current position in `buffer` (and grow if needed).
  * Return offset for writing, or -1 on failure.
  * Sets MemoryError or ValueError on failure. */
-buffer_position buffer_save_space(buffer_t buffer, int size) {
+buffer_position pymongo_buffer_save_space(buffer_t buffer, int size) {
     int position = buffer->position;
     if (buffer_assure_space(buffer, size) != 0) {
         return -1;
@@ -134,7 +134,7 @@ buffer_position buffer_save_space(buffer_t buffer, int size) {
 /* Write `size` bytes from `data` to `buffer` (and grow if needed).
  * Return non-zero on failure.
  * Sets MemoryError or ValueError on failure. */
-int buffer_write(buffer_t buffer, const char* data, int size) {
+int pymongo_buffer_write(buffer_t buffer, const char* data, int size) {
     if (buffer_assure_space(buffer, size) != 0) {
         return 1;
     }
@@ -144,14 +144,14 @@ int buffer_write(buffer_t buffer, const char* data, int size) {
     return 0;
 }
 
-int buffer_get_position(buffer_t buffer) {
+int pymongo_buffer_get_position(buffer_t buffer) {
     return buffer->position;
 }
 
-char* buffer_get_buffer(buffer_t buffer) {
+char* pymongo_buffer_get_buffer(buffer_t buffer) {
     return buffer->buffer;
 }
 
-void buffer_update_position(buffer_t buffer, buffer_position new_position) {
+void pymongo_buffer_update_position(buffer_t buffer, buffer_position new_position) {
     buffer->position = new_position;
 }

--- a/bson/buffer.h
+++ b/bson/buffer.h
@@ -27,25 +27,25 @@ typedef int buffer_position;
 
 /* Allocate and return a new buffer.
  * Return NULL on allocation failure. */
-buffer_t buffer_new(void);
+buffer_t pymongo_buffer_new(void);
 
 /* Free the memory allocated for `buffer`.
  * Return non-zero on failure. */
-int buffer_free(buffer_t buffer);
+int pymongo_buffer_free(buffer_t buffer);
 
 /* Save `size` bytes from the current position in `buffer` (and grow if needed).
  * Return offset for writing, or -1 on allocation failure. */
-buffer_position buffer_save_space(buffer_t buffer, int size);
+buffer_position pymongo_buffer_save_space(buffer_t buffer, int size);
 
 /* Write `size` bytes from `data` to `buffer` (and grow if needed).
  * Return non-zero on allocation failure. */
-int buffer_write(buffer_t buffer, const char* data, int size);
+int pymongo_buffer_write(buffer_t buffer, const char* data, int size);
 
 /* Getters for the internals of a buffer_t.
  * Should try to avoid using these as much as possible
  * since they break the abstraction. */
-buffer_position buffer_get_position(buffer_t buffer);
-char* buffer_get_buffer(buffer_t buffer);
-void buffer_update_position(buffer_t buffer, buffer_position new_position);
+buffer_position pymongo_buffer_get_position(buffer_t buffer);
+char* pymongo_buffer_get_buffer(buffer_t buffer);
+void pymongo_buffer_update_position(buffer_t buffer, buffer_position new_position);
 
 #endif

--- a/bson/encoding_helpers.c
+++ b/bson/encoding_helpers.c
@@ -87,7 +87,7 @@ static unsigned char isLegalUTF8(const unsigned char* source, int length) {
     return 1;
 }
 
-result_t check_string(const unsigned char* string, const int length,
+result_t cbson_check_string(const unsigned char* string, const int length,
                       const char check_utf8, const char check_null) {
     int position = 0;
     /* By default we go character by character. Will be different for checking

--- a/bson/encoding_helpers.h
+++ b/bson/encoding_helpers.h
@@ -23,7 +23,7 @@ typedef enum {
     HAS_NULL
 } result_t;
 
-result_t check_string(const unsigned char* string, const int length,
+result_t cbson_check_string(const unsigned char* string, const int length,
                       const char check_utf8, const char check_null);
 
 #endif

--- a/bson/time64.c
+++ b/bson/time64.c
@@ -458,7 +458,7 @@ struct tm * cbson_fake_localtime_r(const time_t *time, struct tm *result) {
 
 
 /* Simulate gmtime_r() to the best of our ability */
-struct tm * fake_gmtime_r(const time_t *time, struct tm *result) {
+struct tm * cbson_fake_gmtime_r(const time_t *time, struct tm *result) {
     const struct tm *static_result = gmtime(time);
 
     assert(result != NULL);

--- a/bson/time64.h
+++ b/bson/time64.h
@@ -60,7 +60,7 @@ Time64_T   timelocal64   (const struct TM *);
 #ifdef HAS_GMTIME_R
 #    define GMTIME_R(clock, result)    gmtime_r(clock, result)
 #else
-#    define GMTIME_R(clock, result)    fake_gmtime_r(clock, result)
+#    define GMTIME_R(clock, result)    cbson_fake_gmtime_r(clock, result)
 #endif
 
 

--- a/bson/time64.h
+++ b/bson/time64.h
@@ -41,13 +41,13 @@ struct TM64 {
 
 
 /* Declare public functions */
-struct TM *gmtime64_r    (const Time64_T *, struct TM *);
-struct TM *localtime64_r (const Time64_T *, struct TM *);
-struct TM *gmtime64      (const Time64_T *);
-struct TM *localtime64   (const Time64_T *);
+struct TM *cbson_gmtime64_r    (const Time64_T *, struct TM *);
+struct TM *cbson_localtime64_r (const Time64_T *, struct TM *);
+struct TM *cbson_gmtime64      (const Time64_T *);
+struct TM *cbson_localtime64   (const Time64_T *);
 
-Time64_T   timegm64      (const struct TM *);
-Time64_T   mktime64      (const struct TM *);
+Time64_T   cbson_timegm64      (const struct TM *);
+Time64_T   cbson_mktime64      (const struct TM *);
 Time64_T   timelocal64   (const struct TM *);
 
 
@@ -55,7 +55,7 @@ Time64_T   timelocal64   (const struct TM *);
 #ifdef HAS_LOCALTIME_R
 #    define LOCALTIME_R(clock, result) localtime_r(clock, result)
 #else
-#    define LOCALTIME_R(clock, result) fake_localtime_r(clock, result)
+#    define LOCALTIME_R(clock, result) cbson_fake_localtime_r(clock, result)
 #endif
 #ifdef HAS_GMTIME_R
 #    define GMTIME_R(clock, result)    gmtime_r(clock, result)

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -92,3 +92,4 @@ The following is a list of people who have contributed to
 - Henri Froese (henrifroese)
 - Ishmum Jawad Khan (ishmum123)
 - Arie Bovenberg (ariebovenberg)
+- Ben Warner (bcwarner)

--- a/pymongo/_cmessagemodule.c
+++ b/pymongo/_cmessagemodule.c
@@ -935,7 +935,7 @@ static struct PyModuleDef moduledef = {
 };
 
 PyMODINIT_FUNC
-pymongo_PyInit__cmessage(void)
+PyInit__cmessage(void)
 {
     PyObject *_cbson = NULL;
     PyObject *c_api_object = NULL;


### PR DESCRIPTION


Refactored some of the C symbols so that they avoid conflicts as mentioned in [PYTHON-2110](https://jira.mongodb.org/browse/PYTHON-2110). The following symbols should be refactored as:

```
PyInit__cmessage        => pymongo_PyInit__cmessage
buffer_free             => pymongo_buffer_free
buffer_get_buffer       => pymongo_buffer_get_buffer
buffer_get_position     => pymongo_buffer_get_position
buffer_new              => pymongo_buffer_new
buffer_save_space       => pymongo_buffer_save_space
buffer_update_position  => pymongo_buffer_update_position
buffer_write            => pymongo_buffer_write

PyInit__cmessage        => pymongo_PyInit__cmessage
buffer_free             => pymongo_buffer_free
buffer_get_buffer       => pymongo_buffer_get_buffer
buffer_get_position     => pymongo_buffer_get_position
buffer_new              => pymongo_buffer_new
buffer_save_space       => pymongo_buffer_save_space
buffer_update_position  => pymongo_buffer_update_position
buffer_write            => pymongo_buffer_write
check_string            => cbson_check_string
cmp_date                => cbson_cmp_date
convert_type_registry   => cbson_convert_type_registry
copy_TM64_to_tm         => cbson_copy_TM64_to_tm
copy_tm_to_TM64         => cbson_copy_tm_to_TM64
date_in_safe_range      => cbson_date_in_safe_range
fake_localtime_r        => cbson_fake_localtime_r
gmtime64                => cbson_gmtime64
gmtime64_r              => cbson_gmtime64_r
localtime64             => cbson_localtime64 
localtime64_r           => cbson_localtime64_r
mktime64                => cbson_mktime64
timegm64                => cbson_timegm64
timelocal64             => cbson_timelocal64
valid_tm_mon            => cbson_valid_tm_mon
valid_tm_wday           => cbson_valid_tm_wday
```