### PR TITLE
Add string equality and non-equality to ObjectId

### DIFF
--- a/bson/objectid.py
+++ b/bson/objectid.py
@@ -255,11 +255,15 @@ class ObjectId(object):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ObjectId):
             return self.__id == other.binary
+        elif isinstance(other, str):
+            return str(self) == other
         return NotImplemented
 
     def __ne__(self, other: Any) -> bool:
         if isinstance(other, ObjectId):
             return self.__id != other.binary
+        elif isinstance(other, str):
+            return str(self) != other
         return NotImplemented
 
     def __lt__(self, other: Any) -> bool:

--- a/test/test_objectid.py
+++ b/test/test_objectid.py
@@ -85,6 +85,14 @@ class TestObjectId(unittest.TestCase):
         self.assertEqual(a, ObjectId(a.binary))
         self.assertEqual(a, ObjectId(str(a)))
 
+    def test_str_equality(self):
+        a = ObjectId()
+        self.assertEqual(a, str(a))
+        self.assertEqual(str(a), a)
+
+        self.assertNotEqual("123456789012", a)
+        self.assertNotEqual(a, "123456789012")
+
     def test_generation_time(self):
         d1 = datetime.datetime.utcnow()
         d2 = ObjectId().generation_time


### PR DESCRIPTION
Hello,

As we are using MongoDB and Pymongo in a HTTP API, we got a lot of strings coming in as query parameters, json body, ...
We were quite surprised that a comparison between a `string` and its `ObjectId` equivalent would not return `True`.

We don't really know what this change would imply, but we would like to propose it if it can help someone else. If it is something that you have thought of and is not desired upstream, feel free to close ;)

Thanks a lot !