### PR TITLE
PYTHON-3337 Fix capped collection test on MMAPv1

### DIFF
--- a/test/unified-test-format/valid-pass/collectionData-createOptions.json
+++ b/test/unified-test-format/valid-pass/collectionData-createOptions.json
@@ -34,7 +34,7 @@
       "databaseName": "database0",
       "createOptions": {
         "capped": true,
-        "size": 512
+        "size": 4096
       },
       "documents": [
         {
@@ -60,7 +60,7 @@
           },
           "expectResult": {
             "capped": true,
-            "maxSize": 512
+            "maxSize": 4096
           }
         }
       ]

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -882,7 +882,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         if "csot" in class_name:
             if client_context.storage_engine == "mmapv1":
                 self.skipTest(
-                    "MMAPv1 does not support retryable writes which is required for " "CSOT tests"
+                    "MMAPv1 does not support retryable writes which is required for CSOT tests"
                 )
             if "change" in description or "change" in class_name:
                 self.skipTest("CSOT not implemented for watch()")

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -880,6 +880,10 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         class_name = self.__class__.__name__.lower()
         description = spec["description"].lower()
         if "csot" in class_name:
+            if client_context.storage_engine == "mmapv1":
+                self.skipTest(
+                    "MMAPv1 does not support retryable writes which is required for " "CSOT tests"
+                )
             if "change" in description or "change" in class_name:
                 self.skipTest("CSOT not implemented for watch()")
             if "cursors" in class_name:


### PR DESCRIPTION
Explanation:
> If the size field is less than or equal to 4096, then the collection will have a cap of 4096 bytes.

https://www.mongodb.com/docs/manual/core/capped-collections/#create-a-capped-collection