### PR TITLE
PYTHON-3345 CSOT use connection handshake RTT for load balanced mode

### DIFF
--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1336,6 +1336,10 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
                 bulk.started_retryable_write = True
 
         while True:
+            if is_retrying():
+                remaining = _csot.remaining()
+                if remaining is not None and remaining <= 0:
+                    raise last_error
             try:
                 server = self._select_server(writable_server_selector, session)
                 supports_session = (
@@ -1394,6 +1398,10 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
         multiple_retries = _csot.get_timeout() is not None
 
         while True:
+            if retrying:
+                remaining = _csot.remaining()
+                if remaining is not None and remaining <= 0:
+                    raise last_error
             try:
                 server = self._select_server(read_pref, session, address=address)
                 with self._socket_from_server(read_pref, server, session) as (sock_info, read_pref):

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -1339,6 +1339,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
             if is_retrying():
                 remaining = _csot.remaining()
                 if remaining is not None and remaining <= 0:
+                    assert last_error is not None
                     raise last_error
             try:
                 server = self._select_server(writable_server_selector, session)
@@ -1401,6 +1402,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
             if retrying:
                 remaining = _csot.remaining()
                 if remaining is not None and remaining <= 0:
+                    assert last_error is not None
                     raise last_error
             try:
                 server = self._select_server(read_pref, session, address=address)

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -559,7 +559,7 @@ class SocketInfo(object):
         self.pinned_cursor = False
         self.active = False
         self.last_timeout = self.opts.socket_timeout
-        self.connect_rtt = 0
+        self.connect_rtt = 0.0
 
     def set_socket_timeout(self, timeout):
         """Cache last timeout to avoid duplicate calls to sock.settimeout."""

--- a/test/test_csot.py
+++ b/test/test_csot.py
@@ -33,6 +33,9 @@ globals().update(generate_test_classes(TEST_PATH, module=__name__))
 
 
 class TestCSOT(IntegrationTest):
+    RUN_ON_SERVERLESS = True
+    RUN_ON_LOAD_BALANCER = True
+
     def test_timeout_nested(self):
         coll = self.db.coll
         self.assertEqual(_csot.get_timeout(), None)


### PR DESCRIPTION
Explanation: 

1.  In load balanced mode the driver skips SDAM so we need to fallback to using the connection's rtt calculated from the connection handshake.
1.  In load balanced mode the driver also skips server selection so we cannot rely on a ServerSelectionTimeoutError to abort the retry loop. Instead we need to explicitly check the CSOT timeout has not expired. 