### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -772,7 +772,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
 
         .. note:: If this client has been configured to use MongoDB Stable
            API (see :ref:`versioned-api-ref`), then :meth:`command` will
-           automactically add API versioning options to the given command.
+           automatically add API versioning options to the given command.
            Explicitly adding API versioning options in the command and
            declaring an API version on the client is not supported.
 

--- a/pymongo/ocsp_support.py
+++ b/pymongo/ocsp_support.py
@@ -217,7 +217,7 @@ def _verify_response(issuer, response):
     if not res:
         return 0
 
-    # Note that we are not using a "tolerence period" as discussed in
+    # Note that we are not using a "tolerance period" as discussed in
     # https://tools.ietf.org/rfc/rfc5019.txt?
     now = _datetime.utcnow()
     # RFC6960, Section 3.2, Number 5


### PR DESCRIPTION
There are small typos in:
- pymongo/database.py
- pymongo/ocsp_support.py

Fixes:
- Should read `tolerance` rather than `tolerence`.
- Should read `automatically` rather than `automactically`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md