### PR TITLE
PYTHON-3363 Allow change stream to be resumed after a timeout

### DIFF
--- a/pymongo/change_stream.py
+++ b/pymongo/change_stream.py
@@ -360,7 +360,7 @@ class ChangeStream(Generic[_DocumentType]):
 
         # Check if the cursor was invalidated.
         if not self._cursor.alive:
-            self.close()
+            self._closed = True
 
         # If no changes are available.
         if change is None:

--- a/pymongo/change_stream.py
+++ b/pymongo/change_stream.py
@@ -302,7 +302,7 @@ class ChangeStream(Generic[_DocumentType]):
 
         .. versionadded:: 3.8
         """
-        return self._cursor.alive
+        return not self._closed
 
     @_csot.apply
     def try_next(self) -> Optional[_DocumentType]:
@@ -357,6 +357,10 @@ class ChangeStream(Generic[_DocumentType]):
                 raise
             self._resume()
             change = self._cursor._try_next(False)
+
+        # Check if the cursor was invalidated.
+        if not self._cursor.alive:
+            self.close()
 
         # If no changes are available.
         if change is None:

--- a/pymongo/change_stream.py
+++ b/pymongo/change_stream.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, Mapping, Optional, Union
 from bson import _bson_to_dict
 from bson.raw_bson import RawBSONDocument
 from bson.timestamp import Timestamp
-from pymongo import common
+from pymongo import _csot, common
 from pymongo.aggregation import (
     _CollectionAggregationCommand,
     _DatabaseAggregationCommand,
@@ -128,6 +128,8 @@ class ChangeStream(Generic[_DocumentType]):
         self._start_at_operation_time = start_at_operation_time
         self._session = session
         self._comment = comment
+        self._closed = False
+        self._timeout = self._target._timeout
         # Initialize cursor.
         self._cursor = self._create_cursor()
 
@@ -234,6 +236,7 @@ class ChangeStream(Generic[_DocumentType]):
 
     def close(self) -> None:
         """Close this ChangeStream."""
+        self._closed = True
         self._cursor.close()
 
     def __iter__(self) -> "ChangeStream[_DocumentType]":
@@ -248,6 +251,7 @@ class ChangeStream(Generic[_DocumentType]):
         """
         return copy.deepcopy(self._resume_token)
 
+    @_csot.apply
     def next(self) -> _DocumentType:
         """Advance the cursor.
 
@@ -300,6 +304,7 @@ class ChangeStream(Generic[_DocumentType]):
         """
         return self._cursor.alive
 
+    @_csot.apply
     def try_next(self) -> Optional[_DocumentType]:
         """Advance the cursor without blocking indefinitely.
 
@@ -332,6 +337,9 @@ class ChangeStream(Generic[_DocumentType]):
 
         .. versionadded:: 3.8
         """
+        if not self._closed and not self._cursor.alive:
+            self._resume()
+
         # Attempt to get the next change with at most one getMore and at most
         # one resume attempt.
         try:

--- a/test/test_csot.py
+++ b/test/test_csot.py
@@ -83,17 +83,22 @@ class TestCSOT(IntegrationTest):
                 with self.assertRaises(PyMongoError) as ctx:
                     stream.try_next()
                 self.assertTrue(ctx.exception.timeout)
+                self.assertTrue(stream.alive)
                 with self.assertRaises(PyMongoError) as ctx:
                     stream.try_next()
                 self.assertTrue(ctx.exception.timeout)
+                self.assertTrue(stream.alive)
             coll.insert_one({})
-            with pymongo.timeout(0.5):
-                self.assertTrue(stream.try_next())
+            with pymongo.timeout(2):
+                self.assertTrue(stream.next())
+            self.assertTrue(stream.alive)
             # Timeout applies to entire next() call, not only individual commands.
             with pymongo.timeout(0.5):
                 with self.assertRaises(PyMongoError) as ctx:
                     stream.next()
                 self.assertTrue(ctx.exception.timeout)
+            self.assertTrue(stream.alive)
+        self.assertFalse(stream.alive)
 
 
 if __name__ == "__main__":

--- a/test/test_csot.py
+++ b/test/test_csot.py
@@ -19,11 +19,12 @@ import sys
 
 sys.path[0:0] = [""]
 
-from test import IntegrationTest, unittest
+from test import IntegrationTest, client_context, unittest
 from test.unified_format import generate_test_classes
 
 import pymongo
 from pymongo import _csot
+from pymongo.errors import PyMongoError
 
 # Location of JSON test specifications.
 TEST_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "csot")
@@ -71,6 +72,28 @@ class TestCSOT(IntegrationTest):
         self.assertEqual(_csot.get_timeout(), None)
         self.assertEqual(_csot.get_deadline(), float("inf"))
         self.assertEqual(_csot.get_rtt(), 0.0)
+
+    @client_context.require_version_min(3, 6)
+    @client_context.require_no_mmap
+    @client_context.require_no_standalone
+    def test_change_stream_can_resume_after_timeouts(self):
+        coll = self.db.coll
+        with coll.watch(max_await_time_ms=150) as stream:
+            with pymongo.timeout(0.1):
+                with self.assertRaises(PyMongoError) as ctx:
+                    stream.try_next()
+                self.assertTrue(ctx.exception.timeout)
+                with self.assertRaises(PyMongoError) as ctx:
+                    stream.try_next()
+                self.assertTrue(ctx.exception.timeout)
+            coll.insert_one({})
+            with pymongo.timeout(0.5):
+                self.assertTrue(stream.try_next())
+            # Timeout applies to entire next() call, not only individual commands.
+            with pymongo.timeout(0.5):
+                with self.assertRaises(PyMongoError) as ctx:
+                    stream.next()
+                self.assertTrue(ctx.exception.timeout)
 
 
 if __name__ == "__main__":

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1076,10 +1076,6 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         self.__raise_if_unsupported("startTransaction", target, ClientSession)
         return target.start_transaction(*args, **kwargs)
 
-    def _cursor_iterateOnce(self, target, *args, **kwargs):
-        self.__raise_if_unsupported("iterateOnce", target, NonLazyCursor, ChangeStream)
-        return target.try_next()
-
     def _changeStreamOperation_iterateUntilDocumentOrError(self, target, *args, **kwargs):
         self.__raise_if_unsupported("iterateUntilDocumentOrError", target, ChangeStream)
         return next(target)
@@ -1202,8 +1198,11 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         try:
             method = getattr(self, method_name)
         except AttributeError:
+            target_opname = camel_to_snake(opname)
+            if target_opname == "iterate_once":
+                target_opname = "try_next"
             try:
-                cmd = getattr(target, camel_to_snake(opname))
+                cmd = getattr(target, target_opname)
             except AttributeError:
                 self.fail("Unsupported operation %s on entity %s" % (opname, target))
         else:


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3363