### PR TITLE
PYTHON-3371 Remove DatetimeConversionOpts.__repr__

### DIFF
--- a/bson/codec_options.py
+++ b/bson/codec_options.py
@@ -205,9 +205,6 @@ class DatetimeConversionOpts(enum.IntEnum):
     DATETIME_MS = 3
     DATETIME_AUTO = 4
 
-    def __repr__(self):
-        return f"{self.value}"
-
 
 class _BaseCodecOptions(NamedTuple):
     document_class: Type[Mapping[str, Any]]

--- a/bson/codec_options.py
+++ b/bson/codec_options.py
@@ -367,7 +367,7 @@ class CodecOptions(_BaseCodecOptions):
         return (
             "document_class=%s, tz_aware=%r, uuid_representation=%s, "
             "unicode_decode_error_handler=%r, tzinfo=%r, "
-            "type_registry=%r, datetime_conversion=%r"
+            "type_registry=%r, datetime_conversion=%s"
             % (
                 document_class_repr,
                 self.tz_aware,

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -980,7 +980,8 @@ class TestCodecOptions(unittest.TestCase):
             "uuid_representation=UuidRepresentation.UNSPECIFIED, "
             "unicode_decode_error_handler='strict', "
             "tzinfo=None, type_registry=TypeRegistry(type_codecs=[], "
-            "fallback_encoder=None), datetime_conversion=1)"
+            "fallback_encoder=None), "
+            "datetime_conversion=<DatetimeConversionOpts.DATETIME: 1>)"
         )
         self.assertEqual(r, repr(CodecOptions()))
 

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -981,7 +981,7 @@ class TestCodecOptions(unittest.TestCase):
             "unicode_decode_error_handler='strict', "
             "tzinfo=None, type_registry=TypeRegistry(type_codecs=[], "
             "fallback_encoder=None), "
-            "datetime_conversion=<DatetimeConversionOpts.DATETIME: 1>)"
+            "datetime_conversion=DatetimeConversionOpts.DATETIME)"
         )
         self.assertEqual(r, repr(CodecOptions()))
 


### PR DESCRIPTION
Removed `__repr__` so that the default behavior is used, and changed test to match.