### PR TITLE
PYTHON-3406 Log traceback when fork() test encounters a deadlock

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -17,7 +17,9 @@
 
 import base64
 import gc
+import multiprocessing
 import os
+import signal
 import socket
 import sys
 import threading
@@ -43,7 +45,7 @@ except ImportError:
 from contextlib import contextmanager
 from functools import wraps
 from test.version import Version
-from typing import Dict, Generator, no_type_check
+from typing import Callable, Dict, Generator, no_type_check
 from unittest import SkipTest
 from urllib.parse import quote_plus
 
@@ -999,40 +1001,35 @@ class PyMongoTestCase(unittest.TestCase):
             )
 
     @contextmanager
-    def fork(self, target=None) -> Generator[int, None, None]:
+    def fork(self, target: Callable) -> Generator[int, None, None]:
         """Helper for tests that use os.fork()
 
         Use in a with statement:
 
-            with self.fork() as pid:
-                if pid == 0:  # Child
-                    pass
-                else:  # Parent
-                    pass
+            with self.fork(target=lambda: print('in child')) as proc:
+                self.assertTrue(proc.pid)  # Child process was started
         """
-        import multiprocessing
-
         ctx = multiprocessing.get_context("fork")
         proc = ctx.Process(target=target)
         proc.start()
-        yield proc
-
-        # Wait 60s.
-        proc.join(60)
-        pid = proc.pid or -1  # mypy
-        if proc.exitcode is None:
-            # If it failed, SIGINT to get traceback and wait
-            # 10s.
-            import signal
-
-            os.kill(pid, signal.SIGINT)
-            proc.join(10)
+        try:
+            yield proc
+        finally:
+            # Wait 60s.
+            proc.join(60)
+            pid = proc.pid
+            assert pid
             if proc.exitcode is None:
-                # If that also failed, SIGKILL and resume after.
-                os.kill(pid, signal.SIGKILL)
-            proc.join(10)
-            self.fail("deadlock")
-        self.assertEqual(proc.exitcode, 0)
+                # If it failed, SIGINT to get traceback and wait
+                # 10s.
+                os.kill(pid, signal.SIGINT)
+                proc.join(10)
+                if proc.exitcode is None:
+                    # If that also failed, SIGKILL and resume after.
+                    os.kill(pid, signal.SIGKILL)
+                proc.join(10)
+                self.fail("deadlock")
+            self.assertEqual(proc.exitcode, 0)
 
 
 class IntegrationTest(PyMongoTestCase):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1011,7 +1011,6 @@ class PyMongoTestCase(unittest.TestCase):
                     pass
         """
         import multiprocessing
-        import signal
 
         ctx = multiprocessing.get_context("fork")
         proc = ctx.Process(target=target)
@@ -1024,6 +1023,8 @@ class PyMongoTestCase(unittest.TestCase):
         if proc.exitcode is None:
             # If it failed, SIGINT to get traceback and wait
             # 10s.
+            import signal
+
             os.kill(pid, signal.SIGINT)
             proc.join(10)
             if proc.exitcode is None:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1001,7 +1001,7 @@ class PyMongoTestCase(unittest.TestCase):
             )
 
     @contextmanager
-    def fork(self, target: Callable) -> Generator[int, None, None]:
+    def fork(self, target: Callable) -> Generator[multiprocessing.Process, None, None]:
         """Helper for tests that use os.fork()
 
         Use in a with statement:
@@ -1013,7 +1013,7 @@ class PyMongoTestCase(unittest.TestCase):
         proc = ctx.Process(target=target)
         proc.start()
         try:
-            yield proc
+            yield proc  # type: ignore
         finally:
             # Wait 60s.
             proc.join(60)

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -341,9 +341,13 @@ class TestClientSimple(EncryptionIntegrationTest):
     def test_fork(self):
         opts = AutoEncryptionOpts(KMS_PROVIDERS, "keyvault.datakeys")
         client = rs_or_single_client(auto_encryption_opts=opts)
-        with self.fork():
+        self.addCleanup(client.close)
+
+        def target():
             client.admin.command("ping")
-            client.close()
+
+        with self.fork(target):
+            target()
 
 
 class TestEncryptedBulkWrite(BulkTestBase, EncryptionIntegrationTest):

--- a/test/test_fork.py
+++ b/test/test_fork.py
@@ -118,14 +118,15 @@ class TestFork(IntegrationTest):
                         proc.start()
                         # Wait 60s.
                         proc.join(60)
+                        pid = proc.pid or -1  # mypy
                         if proc.exitcode is None:
                             # If it failed, SIGINT to get traceback and wait
                             # 10s.
-                            os.kill(proc.pid, signal.SIGINT)
+                            os.kill(pid, signal.SIGINT)
                             proc.join(10)
                             if proc.exitcode is None:
                                 # If that also failed, SIGKILL and resume after.
-                                os.kill(proc.pid, signal.SIGKILL)
+                                os.kill(ipid, signal.SIGKILL)
                             self.runner.fail("deadlock")
                         self.runner.assertEqual(proc.exitcode, 0)
                     action(rc)

--- a/test/test_fork.py
+++ b/test/test_fork.py
@@ -121,12 +121,11 @@ class TestFork(IntegrationTest):
                         if proc.exitcode is None:
                             # If it failed, SIGINT to get traceback and wait
                             # 10s.
-                            signal.pidfd_send_signal(proc.pid, signal.SIGINT)
+                            os.kill(proc.pid, signal.SIGINT)
                             proc.join(10)
                             if proc.exitcode is None:
                                 # If that also failed, SIGKILL and resume after.
-                                signal.pidfd_send_signal(proc.pid, signal.SIGKILL)
-                        if proc.exitcode is None:
+                                os.kill(proc.pid, signal.SIGKILL)
                             self.runner.fail("deadlock")
                         self.runner.assertEqual(proc.exitcode, 0)
                     action(rc)

--- a/test/test_fork.py
+++ b/test/test_fork.py
@@ -126,7 +126,7 @@ class TestFork(IntegrationTest):
                             proc.join(10)
                             if proc.exitcode is None:
                                 # If that also failed, SIGKILL and resume after.
-                                os.kill(ipid, signal.SIGKILL)
+                                os.kill(pid, signal.SIGKILL)
                             self.runner.fail("deadlock")
                         self.runner.assertEqual(proc.exitcode, 0)
                     action(rc)


### PR DESCRIPTION
This PR improves the tests by logging a traceback when a fork() test encounters a deadlock. For example, when I remove the lock sanitation code here is the new output:
```
$ python test/test_fork.py -v -k test_lock_client
test_lock_client (__main__.TestFork) ... Process ForkProcess-1:
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/process.py", line 297, in _bootstrap
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/process.py", line 99, in run
    self._target(*self._args, **self._kwargs)
  File "test/test_fork.py", line 49, in target
    self.client.admin.command("ping")
  File "/Users/shane/git/mongo-python-driver/pymongo/_csot.py", line 105, in csot_wrapper
    return func(self, *args, **kwargs)
  File "/Users/shane/git/mongo-python-driver/pymongo/database.py", line 799, in command
    with self.__client._socket_for_reads(read_preference, session) as (
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1288, in _socket_for_reads
    _ = self._get_topology()
  File "/Users/shane/git/mongo-python-driver/pymongo/mongo_client.py", line 1197, in _get_topology
    with self.__lock:
KeyboardInterrupt
FAIL

======================================================================
FAIL: test_lock_client (__main__.TestFork)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_fork.py", line 52, in test_lock_client
    pass
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 119, in __exit__
    next(self.gen)
  File "/Users/shane/git/mongo-python-driver/test/__init__.py", line 1029, in fork
    self.fail(f"child timed out after {timeout}s (see traceback in logs): deadlock?")
AssertionError: child timed out after 60s (see traceback in logs): deadlock?
```

https://jira.mongodb.org/browse/PYTHON-3406