### PR TITLE
PYTHON-3441 docs: add missed method in monitoring logger example

### DIFF
--- a/pymongo/monitoring.py
+++ b/pymongo/monitoring.py
@@ -125,6 +125,9 @@ Connection monitoring and pooling events are also available. For example::
         def pool_created(self, event):
             logging.info("[pool {0.address}] pool created".format(event))
 
+        def pool_ready(self, event):
+            logging.info("[pool {0.address}] pool is ready".format(event))
+
         def pool_cleared(self, event):
             logging.info("[pool {0.address}] pool cleared".format(event))
 


### PR DESCRIPTION
I was researching how to log queries.
Found the `monitoring` module with great examples.
And found out that the example of [ConnectionPoolLogger](https://pymongo.readthedocs.io/en/stable/api/pymongo/monitoring.html#:~:text=Connection%20monitoring%20and%20pooling%20events%20are%20also%20available.%20For%20example%3A) is [missing one new method](https://pymongo.readthedocs.io/en/stable/api/pymongo/monitoring.html#pymongo.monitoring.ConnectionPoolListener.pool_ready).
As a result of this - `NotImplementedError` on invocation of the method.

So, I made a single commit to fix it.