### PR TITLE
PYTHON-2970 Prioritize electionId over setVersion for stale primary check on 6.0+

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -33,6 +33,8 @@ Bug fixes
 - Fixed a bug where  :class:`~pymongo.change_stream.ChangeStream`
   would allow an app to retry calling ``next()`` or ``try_next()`` even
   after non-resumable errors (`PYTHON-3389`_).
+- Fixed a bug where the client could be unable to discover the new primary
+  after a simultaneous replica set election and reconfig (`PYTHON-2970`_).
 
 Issues Resolved
 ...............
@@ -42,6 +44,7 @@ in this release.
 
 .. _PYTHON-1824: https://jira.mongodb.org/browse/PYTHON-1824
 .. _PYTHON-2484: https://jira.mongodb.org/browse/PYTHON-2484
+.. _PYTHON-2970: https://jira.mongodb.org/browse/PYTHON-2970
 .. _PYTHON-3389: https://jira.mongodb.org/browse/PYTHON-3389
 .. _PyMongo 4.3 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=33425
 

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -17,6 +17,7 @@
 from random import sample
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
+from bson.min_key import MinKey
 from bson.objectid import ObjectId
 from pymongo import common
 from pymongo.errors import ConfigurationError
@@ -532,24 +533,16 @@ def _update_rs_from_primary(
         sds.pop(server_description.address)
         return (_check_has_primary(sds), replica_set_name, max_set_version, max_election_id)
 
-    max_election_tuple = max_set_version, max_election_id
-    if None not in server_description.election_tuple:
-        if (
-            None not in max_election_tuple
-            and max_election_tuple > server_description.election_tuple
-        ):
-
-            # Stale primary, set to type Unknown.
-            sds[server_description.address] = server_description.to_unknown()
-            return (_check_has_primary(sds), replica_set_name, max_set_version, max_election_id)
-
-        max_election_id = server_description.election_id
-
-    if server_description.set_version is not None and (
-        max_set_version is None or server_description.set_version > max_set_version
-    ):
-
-        max_set_version = server_description.set_version
+    new_election_tuple = server_description.election_id, server_description.set_version
+    max_election_tuple = max_election_id, max_set_version
+    new_election_safe = tuple(MinKey() if i is None else i for i in new_election_tuple)
+    max_election_safe = tuple(MinKey() if i is None else i for i in max_election_tuple)
+    if new_election_safe >= max_election_safe:
+        max_election_id, max_set_version = new_election_tuple
+    else:
+        # Stale primary, set to type Unknown.
+        sds[server_description.address] = server_description.to_unknown()
+        return _check_has_primary(sds), replica_set_name, max_set_version, max_election_id
 
     # We've heard from the primary. Is it the same primary as before?
     for server in sds.values():

--- a/test/discovery_and_monitoring/rs/electionId_precedence_setVersion.json
+++ b/test/discovery_and_monitoring/rs/electionId_precedence_setVersion.json
@@ -1,5 +1,5 @@
 {
-  "description": "Record max setVersion, even from primary without electionId",
+  "description": "ElectionId is considered higher precedence than setVersion",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -22,35 +22,7 @@
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            }
-          },
-          "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 1,
-        "maxElectionId": {
-          "$oid": "000000000000000000000001"
-        }
-      }
-    },
-    {
-      "responses": [
+        ],
         [
           "b:27017",
           {
@@ -63,38 +35,13 @@
             ],
             "setName": "rs",
             "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            }
-          },
-          "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 1,
-        "maxElectionId": {
-          "$oid": "000000000000000000000001"
-        }
-      }
-    },
-    {
-      "responses": [
+        ],
         [
           "a:27017",
           {
@@ -128,6 +75,7 @@
           "b:27017": {
             "type": "Unknown",
             "setName": null,
+            "setVersion": null,
             "electionId": null
           }
         },

--- a/test/discovery_and_monitoring/rs/electionId_precedence_setVersion.json
+++ b/test/discovery_and_monitoring/rs/electionId_precedence_setVersion.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ],
         [
@@ -39,7 +39,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ],
         [
@@ -58,7 +58,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/null_election_id-pre-6.0.json
+++ b/test/discovery_and_monitoring/rs/null_election_id-pre-6.0.json
@@ -1,5 +1,5 @@
 {
-  "description": "Set version rolls back after new primary with higher election Id",
+  "description": "Pre 6.0 Primaries with and without electionIds",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -12,15 +12,13 @@
             "isWritablePrimary": true,
             "hosts": [
               "a:27017",
-              "b:27017"
+              "b:27017",
+              "c:27017"
             ],
+            "setVersion": 1,
             "setName": "rs",
-            "setVersion": 2,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            },
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
           }
         ]
       ],
@@ -29,12 +27,15 @@
           "a:27017": {
             "type": "RSPrimary",
             "setName": "rs",
-            "setVersion": 2,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            }
+            "setVersion": 1,
+            "electionId": null
           },
           "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "c:27017": {
             "type": "Unknown",
             "setName": null,
             "electionId": null
@@ -43,10 +44,7 @@
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
         "setName": "rs",
-        "maxSetVersion": 2,
-        "maxElectionId": {
-          "$oid": "000000000000000000000001"
-        }
+        "maxSetVersion": 1
       }
     },
     {
@@ -59,7 +57,8 @@
             "isWritablePrimary": true,
             "hosts": [
               "a:27017",
-              "b:27017"
+              "b:27017",
+              "c:27017"
             ],
             "setName": "rs",
             "setVersion": 1,
@@ -67,7 +66,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
           }
         ]
       ],
@@ -85,6 +84,11 @@
             "electionId": {
               "$oid": "000000000000000000000002"
             }
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
@@ -106,32 +110,84 @@
             "isWritablePrimary": true,
             "hosts": [
               "a:27017",
-              "b:27017"
+              "b:27017",
+              "c:27017"
             ],
+            "setVersion": 1,
             "setName": "rs",
-            "setVersion": 2,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            },
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
           }
         ]
       ],
       "outcome": {
         "servers": {
           "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
+          },
+          "b:27017": {
             "type": "Unknown",
             "setName": null,
             "electionId": null
           },
-          "b:27017": {
-            "type": "RSPrimary",
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017"
+            ],
             "setName": "rs",
             "setVersion": 1,
             "electionId": {
-              "$oid": "000000000000000000000002"
-            }
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",

--- a/test/discovery_and_monitoring/rs/null_election_id.json
+++ b/test/discovery_and_monitoring/rs/null_election_id.json
@@ -123,15 +123,18 @@
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
+            "type": "Unknown",
+            "setName": null,
+            "setVersion": null,
             "electionId": null
           },
           "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
           },
           "c:27017": {
             "type": "Unknown",
@@ -174,15 +177,18 @@
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
+            "type": "Unknown",
+            "setName": null,
+            "setVersion": null,
             "electionId": null
           },
           "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
           },
           "c:27017": {
             "type": "Unknown",

--- a/test/discovery_and_monitoring/rs/null_election_id.json
+++ b/test/discovery_and_monitoring/rs/null_election_id.json
@@ -18,7 +18,7 @@
             "setVersion": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],
@@ -66,7 +66,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],
@@ -116,7 +116,7 @@
             "setVersion": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],
@@ -170,7 +170,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/secondary_ignore_ok_0-pre-6.0.json
+++ b/test/discovery_and_monitoring/rs/secondary_ignore_ok_0-pre-6.0.json
@@ -1,6 +1,6 @@
 {
-  "description": "setVersion that is less than maxSetVersion is ignored if there is no electionId",
-  "uri": "mongodb://a/?replicaSet=rs",
+  "description": "Pre 6.0 New primary",
+  "uri": "mongodb://a,b/?replicaSet=rs",
   "phases": [
     {
       "responses": [
@@ -10,14 +10,29 @@
             "ok": 1,
             "helloOk": true,
             "isWritablePrimary": true,
+            "setName": "rs",
             "hosts": [
               "a:27017",
               "b:27017"
             ],
-            "setName": "rs",
-            "setVersion": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
           }
         ]
       ],
@@ -25,20 +40,16 @@
         "servers": {
           "a:27017": {
             "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 2,
-            "electionId": null
+            "setName": "rs"
           },
           "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
+            "type": "RSSecondary",
+            "setName": "rs"
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 2
+        "setName": "rs"
       }
     },
     {
@@ -46,17 +57,9 @@
         [
           "b:27017",
           {
-            "ok": 1,
-            "helloOk": true,
-            "isWritablePrimary": true,
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
-            "setName": "rs",
-            "setVersion": 1,
+            "ok": 0,
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
           }
         ]
       ],
@@ -64,20 +67,16 @@
         "servers": {
           "a:27017": {
             "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 2,
-            "electionId": null
+            "setName": "rs"
           },
           "b:27017": {
             "type": "Unknown",
-            "setName": null,
-            "electionId": null
+            "setName": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 2
+        "setName": "rs"
       }
     }
   ]

--- a/test/discovery_and_monitoring/rs/set_version_can_rollback.json
+++ b/test/discovery_and_monitoring/rs/set_version_can_rollback.json
@@ -1,5 +1,5 @@
 {
-  "description": "Record max setVersion, even from primary without electionId",
+  "description": "Set version rolls back after new primary with higher election Id",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -8,54 +8,7 @@
           "a:27017",
           {
             "ok": 1,
-            "helloOk": true,
-            "isWritablePrimary": true,
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            },
-            "minWireVersion": 0,
-            "maxWireVersion": 6
-          }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000001"
-            }
-          },
-          "b:27017": {
-            "type": "Unknown",
-            "setName": null,
-            "electionId": null
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs",
-        "maxSetVersion": 1,
-        "maxElectionId": {
-          "$oid": "000000000000000000000001"
-        }
-      }
-    },
-    {
-      "responses": [
-        [
-          "b:27017",
-          {
-            "ok": 1,
-            "helloOk": true,
+            "hello": true,
             "isWritablePrimary": true,
             "hosts": [
               "a:27017",
@@ -63,6 +16,9 @@
             ],
             "setName": "rs",
             "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
@@ -73,7 +29,7 @@
           "a:27017": {
             "type": "RSPrimary",
             "setName": "rs",
-            "setVersion": 1,
+            "setVersion": 2,
             "electionId": {
               "$oid": "000000000000000000000001"
             }
@@ -87,19 +43,20 @@
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
         "setName": "rs",
-        "maxSetVersion": 1,
+        "maxSetVersion": 2,
         "maxElectionId": {
           "$oid": "000000000000000000000001"
         }
       }
     },
     {
+      "_comment": "Response from new primary with newer election Id",
       "responses": [
         [
-          "a:27017",
+          "b:27017",
           {
             "ok": 1,
-            "helloOk": true,
+            "hello": true,
             "isWritablePrimary": true,
             "hosts": [
               "a:27017",
@@ -118,17 +75,65 @@
       "outcome": {
         "servers": {
           "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
             "type": "RSPrimary",
             "setName": "rs",
             "setVersion": 1,
             "electionId": {
               "$oid": "000000000000000000000002"
             }
-          },
-          "b:27017": {
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
+      }
+    },
+    {
+      "_comment": "Response from stale primary",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "hello": true,
+            "isWritablePrimary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
             "type": "Unknown",
             "setName": null,
             "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
           }
         },
         "topologyType": "ReplicaSetWithPrimary",

--- a/test/discovery_and_monitoring/rs/setversion_equal_max_without_electionid.json
+++ b/test/discovery_and_monitoring/rs/setversion_equal_max_without_electionid.json
@@ -1,6 +1,6 @@
 {
-  "description": "Secondary ignored when ok is zero",
-  "uri": "mongodb://a,b/?replicaSet=rs",
+  "description": "setVersion version that is equal is treated the same as greater than if there is no electionId",
+  "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
       "responses": [
@@ -10,27 +10,12 @@
             "ok": 1,
             "helloOk": true,
             "isWritablePrimary": true,
-            "setName": "rs",
             "hosts": [
               "a:27017",
               "b:27017"
             ],
-            "minWireVersion": 0,
-            "maxWireVersion": 6
-          }
-        ],
-        [
-          "b:27017",
-          {
-            "ok": 1,
-            "helloOk": true,
-            "isWritablePrimary": false,
-            "secondary": true,
             "setName": "rs",
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
+            "setVersion": 1,
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
@@ -40,16 +25,20 @@
         "servers": {
           "a:27017": {
             "type": "RSPrimary",
-            "setName": "rs"
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
           },
           "b:27017": {
-            "type": "RSSecondary",
-            "setName": "rs"
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1
       }
     },
     {
@@ -57,7 +46,15 @@
         [
           "b:27017",
           {
-            "ok": 0,
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
@@ -66,17 +63,21 @@
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs"
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
           },
           "b:27017": {
-            "type": "Unknown",
-            "setName": null
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1
       }
     }
   ]

--- a/test/discovery_and_monitoring/rs/setversion_equal_max_without_electionid.json
+++ b/test/discovery_and_monitoring/rs/setversion_equal_max_without_electionid.json
@@ -17,7 +17,7 @@
             "setName": "rs",
             "setVersion": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],
@@ -56,7 +56,7 @@
             "setName": "rs",
             "setVersion": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/setversion_greaterthan_max_without_electionid.json
+++ b/test/discovery_and_monitoring/rs/setversion_greaterthan_max_without_electionid.json
@@ -1,6 +1,6 @@
 {
-  "description": "Secondary ignored when ok is zero",
-  "uri": "mongodb://a,b/?replicaSet=rs",
+  "description": "setVersion that is greater than maxSetVersion is used if there is no electionId",
+  "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
       "responses": [
@@ -10,27 +10,12 @@
             "ok": 1,
             "helloOk": true,
             "isWritablePrimary": true,
-            "setName": "rs",
             "hosts": [
               "a:27017",
               "b:27017"
             ],
-            "minWireVersion": 0,
-            "maxWireVersion": 6
-          }
-        ],
-        [
-          "b:27017",
-          {
-            "ok": 1,
-            "helloOk": true,
-            "isWritablePrimary": false,
-            "secondary": true,
             "setName": "rs",
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
+            "setVersion": 1,
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
@@ -40,16 +25,20 @@
         "servers": {
           "a:27017": {
             "type": "RSPrimary",
-            "setName": "rs"
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
           },
           "b:27017": {
-            "type": "RSSecondary",
-            "setName": "rs"
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1
       }
     },
     {
@@ -57,7 +46,15 @@
         [
           "b:27017",
           {
-            "ok": 0,
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 2,
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
@@ -66,17 +63,21 @@
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs"
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
           },
           "b:27017": {
-            "type": "Unknown",
-            "setName": null
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2
       }
     }
   ]

--- a/test/discovery_and_monitoring/rs/setversion_greaterthan_max_without_electionid.json
+++ b/test/discovery_and_monitoring/rs/setversion_greaterthan_max_without_electionid.json
@@ -17,7 +17,7 @@
             "setName": "rs",
             "setVersion": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],
@@ -56,7 +56,7 @@
             "setName": "rs",
             "setVersion": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/setversion_without_electionid-pre-6.0.json
+++ b/test/discovery_and_monitoring/rs/setversion_without_electionid-pre-6.0.json
@@ -1,5 +1,5 @@
 {
-  "description": "setVersion that is less than maxSetVersion is ignored if there is no electionId",
+  "description": "Pre 6.0 setVersion is ignored if there is no electionId",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -17,7 +17,7 @@
             "setName": "rs",
             "setVersion": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
           }
         ]
       ],
@@ -56,21 +56,21 @@
             "setName": "rs",
             "setVersion": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
           }
         ]
       ],
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 2,
+            "type": "Unknown",
+            "setName": null,
             "electionId": null
           },
           "b:27017": {
-            "type": "Unknown",
-            "setName": null,
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
             "electionId": null
           }
         },

--- a/test/discovery_and_monitoring/rs/setversion_without_electionid.json
+++ b/test/discovery_and_monitoring/rs/setversion_without_electionid.json
@@ -1,5 +1,5 @@
 {
-  "description": "setVersion is ignored if there is no electionId",
+  "description": "setVersion that is less than maxSetVersion is ignored if there is no electionId",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -63,14 +63,14 @@
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "Unknown",
-            "setName": null,
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
             "electionId": null
           },
           "b:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "setVersion": 1,
+            "type": "Unknown",
+            "setName": null,
             "electionId": null
           }
         },

--- a/test/discovery_and_monitoring/rs/use_setversion_without_electionid-pre-6.0.json
+++ b/test/discovery_and_monitoring/rs/use_setversion_without_electionid-pre-6.0.json
@@ -1,5 +1,5 @@
 {
-  "description": "Set version rolls back after new primary with higher election Id",
+  "description": "Pre 6.0 Record max setVersion, even from primary without electionId",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -15,12 +15,12 @@
               "b:27017"
             ],
             "setName": "rs",
-            "setVersion": 2,
+            "setVersion": 1,
             "electionId": {
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
           }
         ]
       ],
@@ -29,7 +29,7 @@
           "a:27017": {
             "type": "RSPrimary",
             "setName": "rs",
-            "setVersion": 2,
+            "setVersion": 1,
             "electionId": {
               "$oid": "000000000000000000000001"
             }
@@ -43,7 +43,7 @@
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
         "setName": "rs",
-        "maxSetVersion": 2,
+        "maxSetVersion": 1,
         "maxElectionId": {
           "$oid": "000000000000000000000001"
         }
@@ -62,12 +62,9 @@
               "b:27017"
             ],
             "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000002"
-            },
+            "setVersion": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
           }
         ]
       ],
@@ -81,18 +78,15 @@
           "b:27017": {
             "type": "RSPrimary",
             "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000002"
-            }
+            "setVersion": 2
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
         "setName": "rs",
-        "maxSetVersion": 1,
+        "maxSetVersion": 2,
         "maxElectionId": {
-          "$oid": "000000000000000000000002"
+          "$oid": "000000000000000000000001"
         }
       }
     },
@@ -109,12 +103,12 @@
               "b:27017"
             ],
             "setName": "rs",
-            "setVersion": 2,
+            "setVersion": 1,
             "electionId": {
-              "$oid": "000000000000000000000001"
+              "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 17
+            "maxWireVersion": 6
           }
         ]
       ],
@@ -128,18 +122,15 @@
           "b:27017": {
             "type": "RSPrimary",
             "setName": "rs",
-            "setVersion": 1,
-            "electionId": {
-              "$oid": "000000000000000000000002"
-            }
+            "setVersion": 2
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
         "setName": "rs",
-        "maxSetVersion": 1,
+        "maxSetVersion": 2,
         "maxElectionId": {
-          "$oid": "000000000000000000000002"
+          "$oid": "000000000000000000000001"
         }
       }
     }

--- a/test/discovery_and_monitoring/rs/use_setversion_without_electionid.json
+++ b/test/discovery_and_monitoring/rs/use_setversion_without_electionid.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],
@@ -64,7 +64,7 @@
             "setName": "rs",
             "setVersion": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],
@@ -111,7 +111,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 17
           }
         ]
       ],

--- a/test/discovery_and_monitoring/unified/rediscover-quickly-after-step-down.json
+++ b/test/discovery_and_monitoring/unified/rediscover-quickly-after-step-down.json
@@ -117,7 +117,7 @@
               "replSetFreeze": 0
             },
             "readPreference": {
-              "mode": "Secondary"
+              "mode": "secondary"
             },
             "commandName": "replSetFreeze"
           }

--- a/test/utils.py
+++ b/test/utils.py
@@ -1004,10 +1004,7 @@ def assertion_context(msg):
     try:
         yield
     except AssertionError as exc:
-        msg = "%s (%s)" % (exc, msg)
-        exc_type, exc_val, exc_tb = sys.exc_info()
-        assert exc_type is not None
-        raise exc_type(exc_val).with_traceback(exc_tb)
+        raise AssertionError(f"{msg}: {exc}")
 
 
 def parse_spec_options(opts):


### PR DESCRIPTION
This PR:
- Implements [PYTHON-2970](https://jira.mongodb.org/browse/PYTHON-2970) by reapplying the original change from #845. 
- Implements [PYTHON-3400](https://jira.mongodb.org/browse/PYTHON-3400) to only use the new logic on MongoDB 6.0+