### PR TITLE
PYTHON-3433 [v3.13] Failure: test.test_encryption.TestSpec.test_legacy_maxWireVersion_operation_fails_with_maxWireVersion___8 (#1052)

### DIFF
--- a/test/client-side-encryption/spec/maxWireVersion.json
+++ b/test/client-side-encryption/spec/maxWireVersion.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "maxServerVersion": "4.0"
+      "maxServerVersion": "4.0.99"
     }
   ],
   "database_name": "default",

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -537,6 +537,9 @@ class TestSpec(SpecRunner):
                 self.skipTest("GCP environment credentials are not set")
         if "key_vault_namespace" not in opts:
             opts["key_vault_namespace"] = "keyvault.datakeys"
+        if "extra_options" in opts:
+            opts.update(camel_to_snake_args(opts.pop("extra_options")))
+
         opts = dict(opts)
         return AutoEncryptionOpts(**opts)
 


### PR DESCRIPTION
(cherry picked from commit e3ff041b474835f007faaead470bb12dcc9dc22c)