### PR TITLE
PYTHON-3508 Improve the performance of GridOut.readline and GridOut.read

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,10 +4,23 @@ Changelog
 Changes in Version 4.3.3
 ------------------------
 
-- Fixed a performance regression in :meth:`~gridfs.GridOut.download_to_stream`
-  and :meth:`~gridfs.GridOut.download_to_stream_by_name` by reading in chunks
-  instead of line by line.
+Version 4.3.3 fixes a number of bugs:
 
+- Fixed a performance regression in :meth:`~gridfs.GridFSBucket.download_to_stream`
+  and :meth:`~gridfs.GridFSBucket.download_to_stream_by_name` by reading in chunks
+  instead of line by line (`PYTHON-3502`_).
+- Improved performance of :meth:`gridfs.grid_file.GridOut.read` and
+  :meth:`gridfs.grid_file.GridOut.readline` (`PYTHON-3508`_).
+
+Issues Resolved
+...............
+
+See the `PyMongo 4.3.3 release notes in JIRA`_ for the list of resolved issues
+in this release.
+
+.. _PYTHON-3502: https://jira.mongodb.org/browse/PYTHON-3502
+.. _PYTHON-3508: https://jira.mongodb.org/browse/PYTHON-3508
+.. _PyMongo 4.3.3 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=34709
 
 Changes in Version 4.3 (4.3.2)
 ------------------------------

--- a/gridfs/grid_file.py
+++ b/gridfs/grid_file.py
@@ -560,8 +560,9 @@ class GridOut(io.IOBase):
                 self.__buffer_pos = 0
                 self.__position += len(chunk_data)
             else:
-                buf = chunk_data = self.readchunk()
+                buf = self.readchunk()
                 chunk_start = 0
+                chunk_data = memoryview(buf)
             if line:
                 pos = buf.find(NEWLN, chunk_start, chunk_start + needed) - chunk_start
                 if pos >= 0:


### PR DESCRIPTION
Benchmark results for iterating a randomly generated file with readline() before this change:
```
client.server_info()['version']='5.0.13' pymongo.__version__='4.4.0.dev0'
object_size_mb= 1, chunk_size_kb= 128, 0.030s
object_size_mb= 1, chunk_size_kb= 256, 0.036s
object_size_mb= 1, chunk_size_kb= 512, 0.056s
object_size_mb= 1, chunk_size_kb=1024, 0.122s
object_size_mb= 1, chunk_size_kb=8192, 0.116s
object_size_mb= 5, chunk_size_kb= 128, 0.179s
object_size_mb= 5, chunk_size_kb= 256, 0.185s
object_size_mb= 5, chunk_size_kb= 512, 0.338s
object_size_mb= 5, chunk_size_kb=1024, 0.652s
object_size_mb= 5, chunk_size_kb=8192, 8.401s
object_size_mb=20, chunk_size_kb= 128, 0.869s
object_size_mb=20, chunk_size_kb= 256, 1.131s
object_size_mb=20, chunk_size_kb= 512, 1.694s
object_size_mb=20, chunk_size_kb=1024, 3.029s
object_size_mb=20, chunk_size_kb=8192, 51.000s
(cut off after 20MB because the 80MB benchmark took too long)
```
And after:
```
client.server_info()['version']='5.0.13' pymongo.__version__='4.4.0.dev0'
object_size_mb= 1, chunk_size_kb= 128, 0.012s
object_size_mb= 1, chunk_size_kb= 256, 0.020s
object_size_mb= 1, chunk_size_kb= 512, 0.012s
object_size_mb= 1, chunk_size_kb=1024, 0.012s
object_size_mb= 1, chunk_size_kb=8192, 0.014s
object_size_mb= 5, chunk_size_kb= 128, 0.070s
object_size_mb= 5, chunk_size_kb= 256, 0.080s
object_size_mb= 5, chunk_size_kb= 512, 0.075s
object_size_mb= 5, chunk_size_kb=1024, 0.050s
object_size_mb= 5, chunk_size_kb=8192, 0.043s
object_size_mb=20, chunk_size_kb= 128, 0.191s
object_size_mb=20, chunk_size_kb= 256, 0.191s
object_size_mb=20, chunk_size_kb= 512, 0.189s
object_size_mb=20, chunk_size_kb=1024, 0.189s
object_size_mb=20, chunk_size_kb=8192, 0.150s
object_size_mb=80, chunk_size_kb= 128, 0.625s
object_size_mb=80, chunk_size_kb= 256, 0.572s
object_size_mb=80, chunk_size_kb= 512, 0.638s
object_size_mb=80, chunk_size_kb=1024, 0.584s
object_size_mb=80, chunk_size_kb=8192, 0.610s
```

This is a huge perf gain anywhere from 2x to 100x (and more) depending on the file size and chunk_size.