### PR TITLE
PYTHON-3527 + PYTHON-3528 Fix no-server tests

### DIFF
--- a/test/test_create_entities.py
+++ b/test/test_create_entities.py
@@ -62,7 +62,7 @@ class TestCreateEntities(IntegrationTest):
                 {
                     "client": {
                         "id": "client0",
-                        "uriOptions": {"retryReads": True, "serverSelectionTimeoutMS": 500},
+                        "uriOptions": {"retryReads": True},
                     }
                 },
                 {"database": {"id": "database0", "client": "client0", "databaseName": "dat"}},

--- a/test/test_mypy.py
+++ b/test/test_mypy.py
@@ -15,6 +15,7 @@
 """Test that each file in mypy_fails/ actually fails mypy, and test some
 sample client code that uses PyMongo typings."""
 import os
+import sys
 import tempfile
 import unittest
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Union
@@ -51,7 +52,9 @@ try:
 except ImportError:
     api = None  # type: ignore[assignment]
 
-from test import IntegrationTest
+sys.path[0:0] = [""]
+
+from test import IntegrationTest, client_context
 from test.utils import rs_or_single_client
 
 from bson import CodecOptions, decode, decode_all, decode_file_iter, decode_iter, encode
@@ -430,6 +433,7 @@ class TestDocumentType(unittest.TestCase):
         # This should fail because _id is not included in our TypedDict definition.
         assert out["_id"]  # type:ignore[typeddict-item]
 
+    @client_context.require_connection
     def test_typeddict_find_notrequired(self):
         if NotRequired is None or ImplicitMovie is None:
             raise unittest.SkipTest("Python 3.11+ is required to use NotRequired.")


### PR DESCRIPTION
PYTHON-3528 Skip TestCreateEntities when no server is running.
PYTHON-3527 Skip test_typeddict_find_notrequired when no server is running.

Also fixes the 150s TestCreateEntities issue. 