### PR TITLE
PYTHON-3577 Fix test_aggregate_out on 4.0 replica set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -312,13 +312,6 @@ by this python implementation.\n
 else:
     extra_opts["ext_modules"] = ext_modules
 
-import logging
-
-# Enable logs in this format:
-# 2022-03-30 12:40:55,582 INFO <ServerHeartbeatStartedEvent ('localhost', 27017)>
-FORMAT = "%(asctime)s %(levelname)s %(message)s"
-logging.basicConfig(format=FORMAT, level=logging.INFO)
-
 setup(
     name="pymongo",
     version=version,

--- a/setup.py
+++ b/setup.py
@@ -312,6 +312,13 @@ by this python implementation.\n
 else:
     extra_opts["ext_modules"] = ext_modules
 
+import logging
+
+# Enable logs in this format:
+# 2022-03-30 12:40:55,582 INFO <ServerHeartbeatStartedEvent ('localhost', 27017)>
+FORMAT = "%(asctime)s %(levelname)s %(message)s"
+logging.basicConfig(format=FORMAT, level=logging.INFO)
+
 setup(
     name="pymongo",
     version=version,

--- a/test/test_load_balancer.py
+++ b/test/test_load_balancer.py
@@ -123,12 +123,7 @@ class TestLB(IntegrationTest):
         session.start_transaction()
         client.test_session_gc.test.find_one({}, session=session)
         # Cleanup the transaction left open on the server.
-        session_id = session.session_id
-
-        def kill_session():
-            self.client.admin.command("killSessions", [session_id])
-
-        self.addCleanup(kill_session)
+        self.addCleanup(self.client.admin.command, "killSessions", [session.session_id])
         if client_context.load_balancer:
             self.assertEqual(pool.active_sockets, 1)  # Pinned.
 

--- a/test/test_load_balancer.py
+++ b/test/test_load_balancer.py
@@ -122,6 +122,13 @@ class TestLB(IntegrationTest):
         session = client.start_session()
         session.start_transaction()
         client.test_session_gc.test.find_one({}, session=session)
+        # Cleanup the transaction left open on the server.
+        session_id = session.session_id
+
+        def kill_session():
+            self.client.admin.command("killSessions", [session_id])
+
+        self.addCleanup(kill_session)
         if client_context.load_balancer:
             self.assertEqual(pool.active_sockets, 1)  # Pinned.
 

--- a/test/test_read_concern.py
+++ b/test/test_read_concern.py
@@ -24,7 +24,6 @@ from test.utils import OvertCommandListener, rs_or_single_client
 
 from bson.son import SON
 from pymongo.errors import OperationFailure
-from pymongo.event_loggers import *
 from pymongo.read_concern import ReadConcern
 
 
@@ -36,16 +35,7 @@ class TestReadConcern(IntegrationTest):
     def setUpClass(cls):
         super(TestReadConcern, cls).setUpClass()
         cls.listener = OvertCommandListener()
-        cls.client = rs_or_single_client(
-            event_listeners=[
-                cls.listener,
-                CommandLogger(),
-                HeartbeatLogger(),
-                ConnectionPoolLogger(),
-                ServerLogger(),
-                TopologyLogger(),
-            ]
-        )
+        cls.client = rs_or_single_client(event_listeners=[cls.listener])
         cls.db = cls.client.pymongo_test
         client_context.client.pymongo_test.create_collection("coll")
 

--- a/test/test_read_concern.py
+++ b/test/test_read_concern.py
@@ -20,10 +20,11 @@ import unittest
 sys.path[0:0] = [""]
 
 from test import IntegrationTest, client_context
-from test.utils import OvertCommandListener, rs_or_single_client, single_client
+from test.utils import OvertCommandListener, rs_or_single_client
 
 from bson.son import SON
 from pymongo.errors import OperationFailure
+from pymongo.event_loggers import *
 from pymongo.read_concern import ReadConcern
 
 
@@ -35,7 +36,16 @@ class TestReadConcern(IntegrationTest):
     def setUpClass(cls):
         super(TestReadConcern, cls).setUpClass()
         cls.listener = OvertCommandListener()
-        cls.client = single_client(event_listeners=[cls.listener])
+        cls.client = rs_or_single_client(
+            event_listeners=[
+                cls.listener,
+                CommandLogger(),
+                HeartbeatLogger(),
+                ConnectionPoolLogger(),
+                ServerLogger(),
+                TopologyLogger(),
+            ]
+        )
         cls.db = cls.client.pymongo_test
         client_context.client.pymongo_test.create_collection("coll")
 


### PR DESCRIPTION
By looking at the server logs I discovered that the 4.0 primary was blocked from running the agg $out operation because a previous test intentionally left a transaction open. I've updated the test to close the transaction on the server so the test runs in a few milliseconds instead of 1 minute now.