### PR TITLE
PYTHON-3577 Fix test_session_gc on serverless

### DIFF
--- a/test/test_load_balancer.py
+++ b/test/test_load_balancer.py
@@ -122,8 +122,10 @@ class TestLB(IntegrationTest):
         session = client.start_session()
         session.start_transaction()
         client.test_session_gc.test.find_one({}, session=session)
-        # Cleanup the transaction left open on the server.
-        self.addCleanup(self.client.admin.command, "killSessions", [session.session_id])
+        # Cleanup the transaction left open on the server unless we're
+        # testing serverless which does not support killSessions.
+        if not client_context.serverless:
+            self.addCleanup(self.client.admin.command, "killSessions", [session.session_id])
         if client_context.load_balancer:
             self.assertEqual(pool.active_sockets, 1)  # Pinned.
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3577 

Fixes this error on serverless:
```
 [2023/02/02 20:32:46.535] ERROR [1.071s]: test_session_gc (test_load_balancer.TestLB)
 [2023/02/02 20:32:46.535] ----------------------------------------------------------------------
 [2023/02/02 20:32:46.535] Traceback (most recent call last):
 [2023/02/02 20:32:46.535]   File "/data/mci/4cac7e2c9fe9236da7246fb89bbb0d46/src/pymongo/_csot.py", line 105, in csot_wrapper
 [2023/02/02 20:32:46.535]     return func(self, *args, **kwargs)
 [2023/02/02 20:32:46.536]   File "/data/mci/4cac7e2c9fe9236da7246fb89bbb0d46/src/pymongo/database.py", line 824, in command
 [2023/02/02 20:32:46.536]     return self._command(
 [2023/02/02 20:32:46.536]   File "/data/mci/4cac7e2c9fe9236da7246fb89bbb0d46/src/pymongo/database.py", line 703, in _command
 [2023/02/02 20:32:46.536]     return sock_info.command(
 [2023/02/02 20:32:46.536]   File "/data/mci/4cac7e2c9fe9236da7246fb89bbb0d46/src/pymongo/pool.py", line 767, in command
 [2023/02/02 20:32:46.536]     return command(
 [2023/02/02 20:32:46.536]   File "/data/mci/4cac7e2c9fe9236da7246fb89bbb0d46/src/pymongo/network.py", line 166, in command
 [2023/02/02 20:32:46.536]     helpers._check_command_response(
 [2023/02/02 20:32:46.536]   File "/data/mci/4cac7e2c9fe9236da7246fb89bbb0d46/src/pymongo/helpers.py", line 191, in _check_command_response
 [2023/02/02 20:32:46.536]     raise OperationFailure(errmsg, code, response, max_wire_version)
 [2023/02/02 20:32:46.536] pymongo.errors.OperationFailure: (Unauthorized) not authorized on admin to execute command { killSessions: [[{id {4 [190 134...
```
https://evergreen.mongodb.com/task/mongo_python_driver_serverless__platform~ubuntu_18.04_auth_ssl~auth_ssl_python_version~3.10_serverless~enabled_test_serverless_540562a60630a57d3eb0c06358b19d3882a5de18_23_01_31_23_22_28