### PR TITLE
PYTHON-3579 Test Failure - Amazon Linux 2018 fails downloading crypt_shared when it is not even needed

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2137,6 +2137,7 @@ axes:
         run_on: amazon1-2018-test
         batchtime: 10080  # 7 days
         variables:
+          skip_crypt_shared: true
           python3_binary: "/opt/python/3.8/bin/python3"
           libmongocrypt_url: https://s3.amazonaws.com/mciuploads/libmongocrypt/linux-64-amazon-ami/master/latest/libmongocrypt.tar.gz
       - id: archlinux-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -283,8 +283,8 @@ functions:
               fi
           fi
 
-          if [ -n "${test_crypt_shared}" ]; then
-            export TEST_CRYPT_SHARED=1
+          if [ -n "${skip_crypt_shared}" ]; then
+            export SKIP_CRYPT_SHARED=1
           fi
 
           ${PREPARE_SHELL}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -282,8 +282,11 @@ functions:
                 ulimit -c unlimited
               fi
           fi
-
+          if [ -n "${test_crypt_shared}" ]; then
+            export TEST_CRYPT_SHARED=1
+          fi
           ${PREPARE_SHELL}
+
           MONGODB_VERSION=${VERSION} \
             TOPOLOGY=${TOPOLOGY} \
             AUTH=${AUTH} \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -282,11 +282,12 @@ functions:
                 ulimit -c unlimited
               fi
           fi
+
           if [ -n "${test_crypt_shared}" ]; then
             export TEST_CRYPT_SHARED=1
           fi
-          ${PREPARE_SHELL}
 
+          ${PREPARE_SHELL}
           MONGODB_VERSION=${VERSION} \
             TOPOLOGY=${TOPOLOGY} \
             AUTH=${AUTH} \


### PR DESCRIPTION
Depends on https://github.com/mongodb-labs/drivers-evergreen-tools/pull/266