### PR TITLE
PYTHON-3616 Use minimum RTT for CSOT maxTimeMS calculation

### DIFF
--- a/pymongo/_csot.py
+++ b/pymongo/_csot.py
@@ -123,7 +123,7 @@ _MAX_RTT_SAMPLES: int = 10
 _MIN_RTT_SAMPLES: int = 2
 
 
-class MovingMinimum(object):
+class MovingMinimum:
     """Tracks a minimum RTT within the last 10 RTT samples."""
 
     samples: Deque[float]

--- a/pymongo/_csot.py
+++ b/pymongo/_csot.py
@@ -16,8 +16,9 @@
 
 import functools
 import time
+from collections import deque
 from contextvars import ContextVar, Token
-from typing import Any, Callable, MutableMapping, Optional, Tuple, TypeVar, cast
+from typing import Any, Callable, Deque, MutableMapping, Optional, Tuple, TypeVar, cast
 
 from pymongo.write_concern import WriteConcern
 
@@ -116,3 +117,33 @@ def apply_write_concern(cmd: MutableMapping, write_concern: Optional[WriteConcer
         wc.pop("wtimeout", None)
     if wc:
         cmd["writeConcern"] = wc
+
+
+_MAX_RTT_SAMPLES: int = 10
+_MIN_RTT_SAMPLES: int = 2
+
+
+class MovingMinimum(object):
+    """Tracks a minimum RTT within the last 10 RTT samples."""
+
+    samples: Deque[float]
+
+    def __init__(self) -> None:
+        self.samples = deque(maxlen=_MAX_RTT_SAMPLES)
+
+    def add_sample(self, sample: float) -> None:
+        if sample < 0:
+            # Likely system time change while waiting for hello response
+            # and not using time.monotonic. Ignore it, the next one will
+            # probably be valid.
+            return
+        self.samples.append(sample)
+
+    def get(self) -> float:
+        """Get the min, or 0.0 if there aren't enough samples yet."""
+        if len(self.samples) >= _MIN_RTT_SAMPLES:
+            return min(self.samples)
+        return 0.0
+
+    def reset(self) -> None:
+        self.samples.clear()

--- a/pymongo/server_description.py
+++ b/pymongo/server_description.py
@@ -32,6 +32,7 @@ class ServerDescription(object):
       - `hello`: Optional Hello instance
       - `round_trip_time`: Optional float
       - `error`: Optional, the last error attempting to connect to the server
+      - `round_trip_time`: Optional float, the min latency from the most recent samples
     """
 
     __slots__ = (
@@ -47,6 +48,7 @@ class ServerDescription(object):
         "_min_wire_version",
         "_max_wire_version",
         "_round_trip_time",
+        "_min_round_trip_time",
         "_me",
         "_is_writable",
         "_is_readable",
@@ -66,6 +68,7 @@ class ServerDescription(object):
         hello: Optional[Hello] = None,
         round_trip_time: Optional[float] = None,
         error: Optional[Exception] = None,
+        min_round_trip_time: float = 0.0,
     ) -> None:
         self._address = address
         if not hello:
@@ -88,6 +91,7 @@ class ServerDescription(object):
         self._is_readable = hello.is_readable
         self._ls_timeout_minutes = hello.logical_session_timeout_minutes
         self._round_trip_time = round_trip_time
+        self._min_round_trip_time = min_round_trip_time
         self._me = hello.me
         self._last_update_time = time.monotonic()
         self._error = error
@@ -202,6 +206,11 @@ class ServerDescription(object):
             return self._host_to_round_trip_time[self._address]
 
         return self._round_trip_time
+
+    @property
+    def min_round_trip_time(self) -> float:
+        """The min latency from the most recent samples."""
+        return self._min_round_trip_time
 
     @property
     def error(self) -> Optional[Exception]:

--- a/pymongo/topology.py
+++ b/pymongo/topology.py
@@ -271,7 +271,7 @@ class Topology(object):
         """Like select_servers, but choose a random server if several match."""
         server = self._select_server(selector, server_selection_timeout, address)
         if _csot.get_timeout():
-            _csot.set_rtt(server.description.round_trip_time)
+            _csot.set_rtt(server.description.min_round_trip_time)
         return server
 
     def select_server_by_address(self, address, server_selection_timeout=None):

--- a/test/csot/command-execution.json
+++ b/test/csot/command-execution.json
@@ -3,7 +3,14 @@
   "schemaVersion": "1.9",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9"
+      "minServerVersion": "4.9",
+      "topologies": [
+        "single",
+        "replicaset",
+        "sharded-replicaset",
+        "sharded"
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [
@@ -45,7 +52,7 @@
                 ],
                 "appName": "reduceMaxTimeMSTest",
                 "blockConnection": true,
-                "blockTimeMS": 20
+                "blockTimeMS": 50
               }
             }
           }
@@ -62,7 +69,8 @@
                   "uriOptions": {
                     "appName": "reduceMaxTimeMSTest",
                     "w": 1,
-                    "timeoutMS": 500
+                    "timeoutMS": 500,
+                    "heartbeatFrequencyMS": 500
                   },
                   "observeEvents": [
                     "commandStartedEvent"
@@ -91,6 +99,23 @@
           "object": "timeoutCollection",
           "arguments": {
             "document": {
+              "_id": 1
+            },
+            "timeoutMS": 100000
+          }
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 1000
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "timeoutCollection",
+          "arguments": {
+            "document": {
               "_id": 2
             }
           }
@@ -105,9 +130,18 @@
                 "commandName": "insert",
                 "databaseName": "test",
                 "command": {
+                  "insert": "timeoutColl"
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
                   "insert": "timeoutColl",
                   "maxTimeMS": {
-                    "$$lte": 500
+                    "$$lte": 450
                   }
                 }
               }
@@ -134,7 +168,7 @@
                 ],
                 "appName": "rttTooHighTest",
                 "blockConnection": true,
-                "blockTimeMS": 20
+                "blockTimeMS": 50
               }
             }
           }
@@ -151,7 +185,8 @@
                   "uriOptions": {
                     "appName": "rttTooHighTest",
                     "w": 1,
-                    "timeoutMS": 10
+                    "timeoutMS": 10,
+                    "heartbeatFrequencyMS": 500
                   },
                   "observeEvents": [
                     "commandStartedEvent"
@@ -180,11 +215,16 @@
           "object": "timeoutCollection",
           "arguments": {
             "document": {
-              "_id": 2
-            }
-          },
-          "expectError": {
-            "isTimeoutError": true
+              "_id": 1
+            },
+            "timeoutMS": 100000
+          }
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 1000
           }
         },
         {
@@ -204,7 +244,7 @@
           "object": "timeoutCollection",
           "arguments": {
             "document": {
-              "_id": 2
+              "_id": 3
             }
           },
           "expectError": {
@@ -216,7 +256,7 @@
           "object": "timeoutCollection",
           "arguments": {
             "document": {
-              "_id": 2
+              "_id": 4
             }
           },
           "expectError": {
@@ -227,7 +267,126 @@
       "expectEvents": [
         {
           "client": "client",
-          "events": []
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "timeoutColl"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "short-circuit is not enabled with only 1 RTT measurement",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": "alwaysOn",
+              "data": {
+                "failCommands": [
+                  "hello",
+                  "isMaster"
+                ],
+                "appName": "reduceMaxTimeMSTest",
+                "blockConnection": true,
+                "blockTimeMS": 100
+              }
+            }
+          }
+        },
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "useMultipleMongoses": false,
+                  "uriOptions": {
+                    "appName": "reduceMaxTimeMSTest",
+                    "w": 1,
+                    "timeoutMS": 90,
+                    "heartbeatFrequencyMS": 100000
+                  },
+                  "observeEvents": [
+                    "commandStartedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "test"
+                }
+              },
+              {
+                "collection": {
+                  "id": "timeoutCollection",
+                  "database": "database",
+                  "collectionName": "timeoutColl"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "timeoutCollection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "timeoutMS": 100000
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "timeoutCollection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "timeoutColl"
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "timeoutColl",
+                  "maxTimeMS": {
+                    "$$lte": 450
+                  }
+                }
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
[PYTHON-3616](https://jira.mongodb.org/browse/PYTHON-3616) Use minimum RTT for CSOT maxTimeMS calculation.

Require at least 2 RTT samples, otherwise use 0 as RTT. Only keep last 10 samples.

Spec commit: https://github.com/mongodb/specifications/commit/c06650d86f7e47ea30cb2d992942bcec6ef155f9
Spec PR: https://github.com/mongodb/specifications/pull/1350