### PR TITLE
PYTHON-3618 Perf tests are failing on the centos6-perf boxes due to mongosh download

### DIFF
--- a/.evergreen/perf.yml
+++ b/.evergreen/perf.yml
@@ -199,17 +199,6 @@ post:
   - func: "cleanup"
 
 tasks:
-    - name: "perf-3.6-standalone"
-      tags: ["perf"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "3.6"
-            TOPOLOGY: "server"
-        - func: "run perf tests"
-        - func: "attach benchmark test results"
-        - func: "send dashboard data"
-
     - name: "perf-4.0-standalone"
       tags: ["perf"]
       commands:
@@ -243,14 +232,25 @@ tasks:
         - func: "attach benchmark test results"
         - func: "send dashboard data"
 
+    - name: "perf-6.0-standalone"
+      tags: ["perf"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            VERSION: "6.0"
+            TOPOLOGY: "server"
+        - func: "run perf tests"
+        - func: "attach benchmark test results"
+        - func: "send dashboard data"
+
 buildvariants:
 
 - name: "perf-tests"
   display_name: "Performance Benchmark Tests"
   batchtime: 10080  # 7 days
-  run_on: centos6-perf
+  run_on: ubuntu2004-large
   tasks:
-     - name: "perf-3.6-standalone"
      - name: "perf-4.0-standalone"
      - name: "perf-4.2-standalone"
      - name: "perf-4.4-standalone"
+     - name: "perf-6.0-standalone"

--- a/.evergreen/perf.yml
+++ b/.evergreen/perf.yml
@@ -210,17 +210,6 @@ tasks:
         - func: "attach benchmark test results"
         - func: "send dashboard data"
 
-    - name: "perf-4.2-standalone"
-      tags: ["perf"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "4.2"
-            TOPOLOGY: "server"
-        - func: "run perf tests"
-        - func: "attach benchmark test results"
-        - func: "send dashboard data"
-
     - name: "perf-4.4-standalone"
       tags: ["perf"]
       commands:
@@ -251,6 +240,5 @@ buildvariants:
   run_on: ubuntu2004-large
   tasks:
      - name: "perf-4.0-standalone"
-     - name: "perf-4.2-standalone"
      - name: "perf-4.4-standalone"
      - name: "perf-6.0-standalone"


### PR DESCRIPTION
Passing builds from patch: https://spruce.mongodb.com/version/63f7b44a1e2d1715c85d9c9a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC