### PR TITLE
PYTHON-3657 Allow index name explicitly set to None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pymongo.egg-info/
 mongocryptd.pid
 .idea/
 .nova/
+venv/

--- a/pymongo/operations.py
+++ b/pymongo/operations.py
@@ -494,7 +494,7 @@ class IndexModel(object):
         .. _wildcard index: https://mongodb.com/docs/master/core/index-wildcard/
         """
         keys = _index_list(keys)
-        if "name" not in kwargs:
+        if kwargs.get("name") is None:
             kwargs["name"] = _gen_index_name(keys)
         kwargs["key"] = _index_document(keys)
         collation = validate_collation_or_none(kwargs.pop("collation", None))

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -307,6 +307,10 @@ class TestCollection(IntegrationTest):
         db.test.create_index([("hello", DESCENDING), ("world", ASCENDING)])
         self.assertTrue("hello_-1_world_1" in db.test.index_information())
 
+        db.test.drop_indexes()
+        db.test.create_index([("hello", DESCENDING), ("world", ASCENDING)], name=None)
+        self.assertTrue("hello_-1_world_1" in db.test.index_information())
+
         db.test.drop()
         db.test.insert_one({"a": 1})
         db.test.insert_one({"a": 1})


### PR DESCRIPTION
Closes Issue [PYTHON-3657](https://jira.mongodb.org/browse/PYTHON-3657)