### PR TITLE
PYTHON-3658 Reload expansions before deleting Azure resources

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1181,6 +1181,10 @@ task_groups:
       params:
         file: testazurekms-expansions.yml
     teardown_group:
+    # Load expansions again. The setup task may have failed before running `expansions.update`.
+    - command: expansions.update
+      params:
+        file: testazurekms-expansions.yml
     - command: shell.exec
       params:
         shell: bash


### PR DESCRIPTION
# Summary
- Reload expansions before deleting Azure resources

Verified with this patch: https://spruce.mongodb.com/version/643454523066158dd65bd5d9

# Background & Motivation

This is an improvement to the `testazurekms_task_group` added as part of DRIVERS-2411. https://github.com/mongodb/mongo-c-driver/pull/1234 explains this improvement.
