### PR TITLE
fix wrong urllib parse function being used to percent encode usernames and passwords, where before spaces would be incorrectly encoded to '+' instead of '%20' which is behaviour for a different usecase

### DIFF
--- a/doc/examples/authentication.rst
+++ b/doc/examples/authentication.rst
@@ -15,10 +15,10 @@ Username and password must be percent-escaped with
 
   >>> from pymongo import MongoClient
   >>> import urllib.parse
-  >>> username = urllib.parse.quote_plus('user')
+  >>> username = urllib.parse.quote('user')
   >>> username
   'user'
-  >>> password = urllib.parse.quote_plus('pass/word')
+  >>> password = urllib.parse.quote('pass/word')
   >>> password
   'pass%2Fword'
   >>> MongoClient('mongodb://%s:%s@127.0.0.1' % (username, password))


### PR DESCRIPTION
The example given for percent-encoding usernames and passwords for a MongoDB URI first mentions .quote() should be used, but proceeds to incorrectly use .quote_plus(), changing spaces to plus signs instead of their percent encoding equivalent.

The example should use .quote() to be clear and exemplify proper use.