### PR TITLE
PYTHON-3678 Username/password needs to be escaped with quote_plus to account for '/'

### DIFF
--- a/doc/examples/authentication.rst
+++ b/doc/examples/authentication.rst
@@ -11,7 +11,7 @@ Percent-Escaping Username and Password
 --------------------------------------
 
 Username and password must be percent-escaped with
-:py:func:`urllib.parse.quote`, to be used in a MongoDB URI. For example::
+:py:func:`urllib.parse.quote_plus`, to be used in a MongoDB URI. For example::
 
   >>> from pymongo import MongoClient
   >>> import urllib.parse


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3678

Resolves https://github.com/mongodb/mongo-python-driver/pull/1186