### PR TITLE
PYTHON-3464 Add FaaS platform to handshake metadata

### DIFF
--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -233,7 +233,12 @@ else:
 
 
 def _is_lambda() -> bool:
-    return bool(os.getenv("AWS_EXECUTION_ENV") or os.getenv("AWS_LAMBDA_RUNTIME_API"))
+    if os.getenv("AWS_LAMBDA_RUNTIME_API"):
+        return True
+    env = os.getenv("AWS_EXECUTION_ENV")
+    if env:
+        return env.startswith("AWS_Lambda_")
+    return False
 
 
 def _is_azure_func() -> bool:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -28,6 +28,7 @@ import sys
 import threading
 import time
 from typing import Iterable, Type, no_type_check
+from unittest.mock import patch
 
 sys.path[0:0] = [""]
 
@@ -113,7 +114,6 @@ class ClientUnitTest(unittest.TestCase):
     client: MongoClient
 
     @classmethod
-    @client_context.require_connection
     def setUpClass(cls):
         cls.client = rs_or_single_client(connect=False, serverSelectionTimeoutMS=100)
 
@@ -1866,6 +1866,65 @@ class TestExhaustCursor(IntegrationTest):
         # The socket was closed and the semaphore was decremented.
         self.assertNotIn(sock_info, pool.sockets)
         self.assertEqual(0, pool.requests)
+
+    def _test_handshake(self, env_vars, expected_env):
+        mock_env = os.environ.copy()
+        mock_env.update(env_vars)
+        with patch.dict("os.environ", mock_env):
+            metadata = copy.deepcopy(_METADATA)
+            if expected_env is not None:
+                metadata["env"] = expected_env
+            with rs_or_single_client(serverSelectionTimeoutMS=10000) as client:
+                client.admin.command("ping")
+                options = client._MongoClient__options
+                self.assertEqual(options.pool_options.metadata, metadata)
+
+    def test_handshake_01_aws(self):
+        self._test_handshake(
+            {
+                "AWS_EXECUTION_ENV": "AWS_Lambda_python3.9",
+                "AWS_REGION": "us-east-2",
+                "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+            },
+            {"name": "aws.lambda", "region": "us-east-2", "memory_mb": 1024},
+        )
+
+    def test_handshake_02_azure(self):
+        self._test_handshake({"FUNCTIONS_WORKER_RUNTIME": "python"}, {"name": "azure.func"})
+
+    def test_handshake_03_gcp(self):
+        self._test_handshake(
+            {
+                "K_SERVICE": "servicename",
+                "FUNCTION_MEMORY_MB": "1024",
+                "FUNCTION_TIMEOUT_SEC": "60",
+                "FUNCTION_REGION": "us-central1",
+            },
+            {"name": "gcp.func", "region": "us-central1", "memory_mb": 1024, "timeout_sec": 60},
+        )
+
+    def test_handshake_04_vercel(self):
+        self._test_handshake(
+            {"VERCEL": "1", "VERCEL_REGION": "cdg1"}, {"name": "vercel", "region": "cdg1"}
+        )
+
+    def test_handshake_05_multiple(self):
+        self._test_handshake(
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "FUNCTIONS_WORKER_RUNTIME": "python"},
+            None,
+        )
+
+    def test_handshake_06_region_too_long(self):
+        self._test_handshake(
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_REGION": "a" * 512},
+            {"name": "aws.lambda"},
+        )
+
+    def test_handshake_07_memory_invalid_int(self):
+        self._test_handshake(
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "big"},
+            {"name": "aws.lambda"},
+        )
 
 
 class TestClientLazyConnect(IntegrationTest):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1761,13 +1761,6 @@ class TestClient(IntegrationTest):
                 options = client._MongoClient__options
                 self.assertEqual(options.pool_options.metadata, metadata)
 
-    def test_handshake_aws_ec2(self):
-        # AWS_EXECUTION_ENV needs to start with "AWS_Lambda_".
-        self._test_handshake(
-            {"AWS_EXECUTION_ENV": "EC2"},
-            None,
-        )
-
     def test_handshake_01_aws(self):
         self._test_handshake(
             {
@@ -1829,6 +1822,13 @@ class TestClient(IntegrationTest):
         self._test_handshake(
             {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "big"},
             {"name": "aws.lambda"},
+        )
+
+    def test_handshake_08_invalid_aws_ec2(self):
+        # AWS_EXECUTION_ENV needs to start with "AWS_Lambda_".
+        self._test_handshake(
+            {"AWS_EXECUTION_ENV": "EC2"},
+            None,
         )
 
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1761,6 +1761,13 @@ class TestClient(IntegrationTest):
                 options = client._MongoClient__options
                 self.assertEqual(options.pool_options.metadata, metadata)
 
+    def test_handshake_aws_ec2(self):
+        # AWS_EXECUTION_ENV needs to start with "AWS_Lambda_".
+        self._test_handshake(
+            {"AWS_EXECUTION_ENV": "EC2"},
+            None,
+        )
+
     def test_handshake_01_aws(self):
         self._test_handshake(
             {
@@ -1784,6 +1791,16 @@ class TestClient(IntegrationTest):
             },
             {"name": "gcp.func", "region": "us-central1", "memory_mb": 1024, "timeout_sec": 60},
         )
+        # Extra case for FUNCTION_NAME.
+        self._test_handshake(
+            {
+                "FUNCTION_NAME": "funcname",
+                "FUNCTION_MEMORY_MB": "1024",
+                "FUNCTION_TIMEOUT_SEC": "60",
+                "FUNCTION_REGION": "us-central1",
+            },
+            {"name": "gcp.func", "region": "us-central1", "memory_mb": 1024, "timeout_sec": 60},
+        )
 
     def test_handshake_04_vercel(self):
         self._test_handshake(
@@ -1795,6 +1812,12 @@ class TestClient(IntegrationTest):
             {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "FUNCTIONS_WORKER_RUNTIME": "python"},
             None,
         )
+        # Extra cases for other combos.
+        self._test_handshake(
+            {"FUNCTIONS_WORKER_RUNTIME": "python", "K_SERVICE": "servicename"},
+            None,
+        )
+        self._test_handshake({"K_SERVICE": "servicename", "VERCEL": "1"}, None)
 
     def test_handshake_06_region_too_long(self):
         self._test_handshake(

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1751,6 +1751,65 @@ class TestClient(IntegrationTest):
         self.assertIn("TEST COMPLETED", log_output)
         self.assertNotIn("ServerHeartbeatFailedEvent", log_output)
 
+    def _test_handshake(self, env_vars, expected_env):
+        mock_env = os.environ.copy()
+        mock_env.update(env_vars)
+        with patch.dict("os.environ", mock_env):
+            metadata = copy.deepcopy(_METADATA)
+            if expected_env is not None:
+                metadata["env"] = expected_env
+            with rs_or_single_client(serverSelectionTimeoutMS=10000) as client:
+                client.admin.command("ping")
+                options = client._MongoClient__options
+                self.assertEqual(options.pool_options.metadata, metadata)
+
+    def test_handshake_01_aws(self):
+        self._test_handshake(
+            {
+                "AWS_EXECUTION_ENV": "AWS_Lambda_python3.9",
+                "AWS_REGION": "us-east-2",
+                "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+            },
+            {"name": "aws.lambda", "region": "us-east-2", "memory_mb": 1024},
+        )
+
+    def test_handshake_02_azure(self):
+        self._test_handshake({"FUNCTIONS_WORKER_RUNTIME": "python"}, {"name": "azure.func"})
+
+    def test_handshake_03_gcp(self):
+        self._test_handshake(
+            {
+                "K_SERVICE": "servicename",
+                "FUNCTION_MEMORY_MB": "1024",
+                "FUNCTION_TIMEOUT_SEC": "60",
+                "FUNCTION_REGION": "us-central1",
+            },
+            {"name": "gcp.func", "region": "us-central1", "memory_mb": 1024, "timeout_sec": 60},
+        )
+
+    def test_handshake_04_vercel(self):
+        self._test_handshake(
+            {"VERCEL": "1", "VERCEL_REGION": "cdg1"}, {"name": "vercel", "region": "cdg1"}
+        )
+
+    def test_handshake_05_multiple(self):
+        self._test_handshake(
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "FUNCTIONS_WORKER_RUNTIME": "python"},
+            None,
+        )
+
+    def test_handshake_06_region_too_long(self):
+        self._test_handshake(
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_REGION": "a" * 512},
+            {"name": "aws.lambda"},
+        )
+
+    def test_handshake_07_memory_invalid_int(self):
+        self._test_handshake(
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "big"},
+            {"name": "aws.lambda"},
+        )
+
 
 class TestExhaustCursor(IntegrationTest):
     """Test that clients properly handle errors from exhaust cursors."""
@@ -1866,65 +1925,6 @@ class TestExhaustCursor(IntegrationTest):
         # The socket was closed and the semaphore was decremented.
         self.assertNotIn(sock_info, pool.sockets)
         self.assertEqual(0, pool.requests)
-
-    def _test_handshake(self, env_vars, expected_env):
-        mock_env = os.environ.copy()
-        mock_env.update(env_vars)
-        with patch.dict("os.environ", mock_env):
-            metadata = copy.deepcopy(_METADATA)
-            if expected_env is not None:
-                metadata["env"] = expected_env
-            with rs_or_single_client(serverSelectionTimeoutMS=10000) as client:
-                client.admin.command("ping")
-                options = client._MongoClient__options
-                self.assertEqual(options.pool_options.metadata, metadata)
-
-    def test_handshake_01_aws(self):
-        self._test_handshake(
-            {
-                "AWS_EXECUTION_ENV": "AWS_Lambda_python3.9",
-                "AWS_REGION": "us-east-2",
-                "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
-            },
-            {"name": "aws.lambda", "region": "us-east-2", "memory_mb": 1024},
-        )
-
-    def test_handshake_02_azure(self):
-        self._test_handshake({"FUNCTIONS_WORKER_RUNTIME": "python"}, {"name": "azure.func"})
-
-    def test_handshake_03_gcp(self):
-        self._test_handshake(
-            {
-                "K_SERVICE": "servicename",
-                "FUNCTION_MEMORY_MB": "1024",
-                "FUNCTION_TIMEOUT_SEC": "60",
-                "FUNCTION_REGION": "us-central1",
-            },
-            {"name": "gcp.func", "region": "us-central1", "memory_mb": 1024, "timeout_sec": 60},
-        )
-
-    def test_handshake_04_vercel(self):
-        self._test_handshake(
-            {"VERCEL": "1", "VERCEL_REGION": "cdg1"}, {"name": "vercel", "region": "cdg1"}
-        )
-
-    def test_handshake_05_multiple(self):
-        self._test_handshake(
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "FUNCTIONS_WORKER_RUNTIME": "python"},
-            None,
-        )
-
-    def test_handshake_06_region_too_long(self):
-        self._test_handshake(
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_REGION": "a" * 512},
-            {"name": "aws.lambda"},
-        )
-
-    def test_handshake_07_memory_invalid_int(self):
-        self._test_handshake(
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "big"},
-            {"name": "aws.lambda"},
-        )
 
 
 class TestClientLazyConnect(IntegrationTest):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1752,9 +1752,7 @@ class TestClient(IntegrationTest):
         self.assertNotIn("ServerHeartbeatFailedEvent", log_output)
 
     def _test_handshake(self, env_vars, expected_env):
-        mock_env = os.environ.copy()
-        mock_env.update(env_vars)
-        with patch.dict("os.environ", mock_env):
+        with patch.dict("os.environ", env_vars):
             metadata = copy.deepcopy(_METADATA)
             if expected_env is not None:
                 metadata["env"] = expected_env


### PR DESCRIPTION
Implements:
- https://jira.mongodb.org/browse/PYTHON-3464
- and part of https://jira.mongodb.org/browse/PYTHON-2052

Helpful links:
- https://github.com/mongodb/specifications/blob/5112bcc/source/mongodb-handshake/handshake.rst#limitations
- https://github.com/mongodb/specifications/blob/5112bcc/source/mongodb-handshake/handshake.rst#client-env