### PR TITLE
PYTHON-3717 Speed up _type_marker check in BSON

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -428,12 +428,13 @@ static int _load_python_objects(PyObject* module) {
  *
  * Return the type marker, 0 if there is no marker, or -1 on failure.
  */
+static PyObject *TYPEMARKERSTR;
 static long _type_marker(PyObject* object) {
     PyObject* type_marker = NULL;
     long type = 0;
 
-    if (PyObject_HasAttrString(object, "_type_marker")) {
-        type_marker = PyObject_GetAttrString(object, "_type_marker");
+    if (PyObject_HasAttr(object, TYPEMARKERSTR)) {
+        type_marker = PyObject_GetAttr(object, TYPEMARKERSTR);
         if (type_marker == NULL) {
             return -1;
         }
@@ -450,13 +451,6 @@ static long _type_marker(PyObject* object) {
     if (type_marker && PyLong_CheckExact(type_marker)) {
         type = PyLong_AsLong(type_marker);
         Py_DECREF(type_marker);
-        /*
-         * Py(Long|Int)_AsLong returns -1 for error but -1 is a valid value
-         * so we call PyErr_Occurred to differentiate.
-         */
-        if (type == -1 && PyErr_Occurred()) {
-            return -1;
-        }
     } else {
         Py_XDECREF(type_marker);
     }
@@ -3030,6 +3024,8 @@ PyInit__cbson(void)
         Py_DECREF(m);
         INITERROR;
     }
+
+    TYPEMARKERSTR = PyUnicode_FromString("_type_marker");
 
     return m;
 }

--- a/bson/_cbsonmodule.h
+++ b/bson/_cbsonmodule.h
@@ -86,7 +86,7 @@ typedef struct codec_options_t {
 
 #define _cbson_convert_codec_options_INDEX 4
 #define _cbson_convert_codec_options_RETURN int
-#define _cbson_convert_codec_options_PROTO (PyObject* options_obj, void* p)
+#define _cbson_convert_codec_options_PROTO (PyObject* self, PyObject* options_obj, void* p)
 
 #define _cbson_destroy_codec_options_INDEX 5
 #define _cbson_destroy_codec_options_RETURN void

--- a/pymongo/_cmessagemodule.c
+++ b/pymongo/_cmessagemodule.c
@@ -75,19 +75,21 @@ static PyObject* _cbson_query_message(PyObject* self, PyObject* args) {
     int num_to_return;
     PyObject* query;
     PyObject* field_selector;
+    PyObject* options_obj;
     codec_options_t options;
     buffer_t buffer = NULL;
     int length_location, message_length;
     PyObject* result = NULL;
 
-    if (!PyArg_ParseTuple(args, "Iet#iiOOO&",
+    if (!(PyArg_ParseTuple(args, "Iet#iiOOO",
                           &flags,
                           "utf-8",
                           &collection_name,
                           &collection_name_length,
                           &num_to_skip, &num_to_return,
                           &query, &field_selector,
-                          convert_codec_options, &options)) {
+                          &options_obj) &&
+            convert_codec_options(state->_cbson, options_obj, &options))) {
         return NULL;
     }
     buffer = pymongo_buffer_new();
@@ -220,6 +222,7 @@ static PyObject* _cbson_op_msg(PyObject* self, PyObject* args) {
     Py_ssize_t identifier_length = 0;
     PyObject* docs;
     PyObject* doc;
+    PyObject* options_obj;
     codec_options_t options;
     buffer_t buffer = NULL;
     int length_location, message_length;
@@ -229,14 +232,15 @@ static PyObject* _cbson_op_msg(PyObject* self, PyObject* args) {
     PyObject* iterator = NULL;
 
     /*flags, command, identifier, docs, opts*/
-    if (!PyArg_ParseTuple(args, "IOet#OO&",
+    if (!(PyArg_ParseTuple(args, "IOet#OO",
                           &flags,
                           &command,
                           "utf-8",
                           &identifier,
                           &identifier_length,
                           &docs,
-                          convert_codec_options, &options)) {
+                          &options_obj) &&
+            convert_codec_options(state->_cbson, options_obj, &options))) {
         return NULL;
     }
     buffer = pymongo_buffer_new();
@@ -528,14 +532,15 @@ _cbson_encode_batched_op_msg(PyObject* self, PyObject* args) {
     PyObject* ctx = NULL;
     PyObject* to_publish = NULL;
     PyObject* result = NULL;
+    PyObject* options_obj;
     codec_options_t options;
     buffer_t buffer;
     struct module_state *state = GETSTATE(self);
 
-    if (!PyArg_ParseTuple(args, "bOObO&O",
+    if (!(PyArg_ParseTuple(args, "bOObOO",
                           &op, &command, &docs, &ack,
-                          convert_codec_options, &options,
-                          &ctx)) {
+                          &options_obj, &ctx) &&
+            convert_codec_options(state->_cbson, options_obj, &options))) {
         return NULL;
     }
     if (!(buffer = pymongo_buffer_new())) {
@@ -581,14 +586,15 @@ _cbson_batched_op_msg(PyObject* self, PyObject* args) {
     PyObject* ctx = NULL;
     PyObject* to_publish = NULL;
     PyObject* result = NULL;
+    PyObject* options_obj;
     codec_options_t options;
     buffer_t buffer;
     struct module_state *state = GETSTATE(self);
 
-    if (!PyArg_ParseTuple(args, "bOObO&O",
+    if (!(PyArg_ParseTuple(args, "bOObOO",
                           &op, &command, &docs, &ack,
-                          convert_codec_options, &options,
-                          &ctx)) {
+                          &options_obj, &ctx) &&
+            convert_codec_options(state->_cbson, options_obj, &options))) {
         return NULL;
     }
     if (!(buffer = pymongo_buffer_new())) {
@@ -850,14 +856,15 @@ _cbson_encode_batched_write_command(PyObject* self, PyObject* args) {
     PyObject* ctx = NULL;
     PyObject* to_publish = NULL;
     PyObject* result = NULL;
+    PyObject* options_obj;
     codec_options_t options;
     buffer_t buffer;
     struct module_state *state = GETSTATE(self);
 
-    if (!PyArg_ParseTuple(args, "et#bOOO&O", "utf-8",
+    if (!(PyArg_ParseTuple(args, "et#bOOOO", "utf-8",
                           &ns, &ns_len, &op, &command, &docs,
-                          convert_codec_options, &options,
-                          &ctx)) {
+                          &options_obj, &ctx) &&
+            convert_codec_options(state->_cbson, options_obj, &options))) {
         return NULL;
     }
     if (!(buffer = pymongo_buffer_new())) {


### PR DESCRIPTION
In _cbsonmodule.c, [the `_type_marker` function](https://github.com/mongodb/mongo-python-driver/blob/bda9e3a0bb533b6d0c6c5141feeecb77c4d31709/bson/_cbsonmodule.c#L431-L440) uses `PyObject_HasAttrString(object, "_type_marker")` and `PyObject_GetAttrString(object, "_type_marker")`. In my workloads (highly nested documents with many large array fields), these functions become severe bottlenecks to performance, because they each create new Python string objects by calling `PyUnicode_FromString("_type_marker")` internally every time they run.

 

This simple change improved my performance by more than double. One caveat is that this leaks the `TYPEMARKERSTR` object in the case that the `cbson` module is unloaded.

 

Also, correct me if I'm wrong, but I believe [these lines are redundant](https://github.com/mongodb/mongo-python-driver/blob/bda9e3a0bb533b6d0c6c5141feeecb77c4d31709/bson/_cbsonmodule.c#L453-L459) because the function returns type at the end regardless.