### PR TITLE
PYTHON-3725 Fix Test Failure - MockupDB test_network_disconnect_primary

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -94,3 +94,4 @@ The following is a list of people who have contributed to
 - Arie Bovenberg (ariebovenberg)
 - Ben Warner (bcwarner)
 - Jean-Christophe Fillion-Robin (jcfr)
+- Dainis Gorbunovs (DainisGorbunovs)

--- a/test/mockupdb/test_network_disconnect_primary.py
+++ b/test/mockupdb/test_network_disconnect_primary.py
@@ -26,12 +26,12 @@ class TestNetworkDisconnectPrimary(unittest.TestCase):
         # Application operation fails against primary. Test that topology
         # type changes from ReplicaSetWithPrimary to ReplicaSetNoPrimary.
         # http://bit.ly/1B5ttuL
-        primary, secondary = servers = [MockupDB() for _ in range(2)]
-        for server in servers:
+        primary, secondary = MockupDB(), MockupDB()
+        for server in primary, secondary:
             server.run()
             self.addCleanup(server.stop)
 
-        hosts = [server.address_string for server in servers]
+        hosts = [server.address_string for server in (primary, secondary)]
         primary_response = OpReply(
             ismaster=True, setName="rs", hosts=hosts, minWireVersion=2, maxWireVersion=6
         )

--- a/test/mockupdb/test_network_disconnect_primary.py
+++ b/test/mockupdb/test_network_disconnect_primary.py
@@ -26,7 +26,7 @@ class TestNetworkDisconnectPrimary(unittest.TestCase):
         # Application operation fails against primary. Test that topology
         # type changes from ReplicaSetWithPrimary to ReplicaSetNoPrimary.
         # http://bit.ly/1B5ttuL
-        primary, secondary = servers = (MockupDB() for _ in range(2))
+        primary, secondary = servers = [MockupDB() for _ in range(2)]
         for server in servers:
             server.run()
             self.addCleanup(server.stop)


### PR DESCRIPTION
This PR addresses issue PYTHON-3725, related to test_network_disconnect_primary's failure in MockupDB.

- Initial issue:
  - `primary` and `secondary` assignments exhausted `(MockupDB() for _ in range(2))` generator, causing `servers` to become an empty generator, leading to test failures.
- Changes based on PR review:
  - Replaced generator with direct assignment: `primary, secondary = MockupDB(), MockupDB()`
  - Eliminated `servers` variable and its usage in the test
  - Modifications aimed at consistency with similar tests and future problem prevention.