### PR TITLE
PYTHON-3728 Simplify convert_codec_options signature

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -83,7 +83,7 @@ struct module_state {
 #define DATETIME_AUTO 4
 
 /* Converts integer to its string representation in decimal notation. */
-int cbson_long_long_to_str(long long num, char* str, size_t size) {
+extern int cbson_long_long_to_str(long long num, char* str, size_t size) {
     // Buffer should fit 64-bit signed integer
     if (size < 21) {
         PyErr_Format(

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -599,8 +599,7 @@ fail:
  * Return 1 on success. options->document_class is a new reference.
  * Return 0 on failure.
  */
-int convert_codec_options(PyObject* self, PyObject* options_obj, void* p) {
-    codec_options_t* options = (codec_options_t*)p;
+int convert_codec_options(PyObject* self, PyObject* options_obj, codec_options_t* options) {
     PyObject* type_registry_obj = NULL;
     long type_marker;
 
@@ -613,8 +612,9 @@ int convert_codec_options(PyObject* self, PyObject* options_obj, void* p) {
                           &options->unicode_decode_error_handler,
                           &options->tzinfo,
                           &type_registry_obj,
-                          &options->datetime_conversion))
+                          &options->datetime_conversion)) {
         return 0;
+    }
 
     type_marker = _type_marker(options->document_class,
                                GETSTATE(self)->_type_marker_str);

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -83,7 +83,7 @@ struct module_state {
 #define DATETIME_AUTO 4
 
 /* Converts integer to its string representation in decimal notation. */
-extern int cbson_long_long_to_str(long long num, char* str, size_t size) {
+int cbson_long_long_to_str(long long num, char* str, size_t size) {
     // Buffer should fit 64-bit signed integer
     if (size < 21) {
         PyErr_Format(

--- a/bson/_cbsonmodule.h
+++ b/bson/_cbsonmodule.h
@@ -49,7 +49,7 @@
 /* Just enough space in char array to hold LLONG_MIN and null terminator */
 #define BUF_SIZE 21
 /* Converts integer to its string representation in decimal notation. */
-extern int cbson_long_long_to_str(long long int num, char* str, size_t size);
+int cbson_long_long_to_str(long long int num, char* str, size_t size);
 #define LL2STR(buffer, i) cbson_long_long_to_str((i), (buffer), sizeof(buffer))
 
 typedef struct type_registry_t {

--- a/bson/_cbsonmodule.h
+++ b/bson/_cbsonmodule.h
@@ -49,7 +49,7 @@
 /* Just enough space in char array to hold LLONG_MIN and null terminator */
 #define BUF_SIZE 21
 /* Converts integer to its string representation in decimal notation. */
-int cbson_long_long_to_str(long long int num, char* str, size_t size);
+extern int cbson_long_long_to_str(long long int num, char* str, size_t size);
 #define LL2STR(buffer, i) cbson_long_long_to_str((i), (buffer), sizeof(buffer))
 
 typedef struct type_registry_t {

--- a/bson/_cbsonmodule.h
+++ b/bson/_cbsonmodule.h
@@ -93,7 +93,7 @@ typedef struct codec_options_t {
 
 #define _cbson_convert_codec_options_INDEX 4
 #define _cbson_convert_codec_options_RETURN int
-#define _cbson_convert_codec_options_PROTO (PyObject* self, PyObject* options_obj, void* p)
+#define _cbson_convert_codec_options_PROTO (PyObject* self, PyObject* options_obj, codec_options_t* options)
 
 #define _cbson_destroy_codec_options_INDEX 5
 #define _cbson_destroy_codec_options_RETURN void

--- a/setup.py
+++ b/setup.py
@@ -263,12 +263,7 @@ ext_modules = [
     Extension(
         "pymongo._cmessage",
         include_dirs=["bson"],
-        sources=[
-            "pymongo/_cmessagemodule.c",
-            "bson/_cbsonmodule.c",
-            "bson/time64.c",
-            "bson/buffer.c",
-        ],
+        sources=["pymongo/_cmessagemodule.c", "bson/buffer.c"],
     ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -263,7 +263,12 @@ ext_modules = [
     Extension(
         "pymongo._cmessage",
         include_dirs=["bson"],
-        sources=["pymongo/_cmessagemodule.c", "bson/buffer.c"],
+        sources=[
+            "pymongo/_cmessagemodule.c",
+            "bson/_cbsonmodule.c",
+            "bson/time64.c",
+            "bson/buffer.c",
+        ],
     ),
 ]
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3728

I'm convinced the Coverity issue is a false positive and that simplifying the convert_codec_options signature should help. 