### PR TITLE
PYTHON-3737 Use __future__ annotations for forward reference type hints

### DIFF
--- a/pymongo/change_stream.py
+++ b/pymongo/change_stream.py
@@ -13,6 +13,7 @@
 # permissions and limitations under the License.
 
 """Watch changes on a collection, a database, or the entire cluster."""
+from __future__ import annotations
 
 import copy
 from typing import TYPE_CHECKING, Any, Dict, Generic, Mapping, Optional, Union
@@ -96,7 +97,7 @@ class ChangeStream(Generic[_DocumentType]):
     def __init__(
         self,
         target: Union[
-            "MongoClient[_DocumentType]", "Database[_DocumentType]", "Collection[_DocumentType]"
+            MongoClient[_DocumentType], Database[_DocumentType], Collection[_DocumentType]
         ],
         pipeline: Optional[_Pipeline],
         full_document: Optional[str],
@@ -105,7 +106,7 @@ class ChangeStream(Generic[_DocumentType]):
         batch_size: Optional[int],
         collation: Optional[_CollationIn],
         start_at_operation_time: Optional[Timestamp],
-        session: Optional["ClientSession"],
+        session: Optional[ClientSession],
         start_after: Optional[Mapping[str, Any]],
         comment: Optional[Any] = None,
         full_document_before_change: Optional[str] = None,

--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -133,6 +133,8 @@ Classes
 =======
 """
 
+from __future__ import annotations
+
 import collections
 import time
 import uuid
@@ -478,7 +480,7 @@ class ClientSession:
 
     def __init__(
         self,
-        client: "MongoClient",
+        client: MongoClient,
         server_session: Any,
         options: SessionOptions,
         implicit: bool,
@@ -524,7 +526,7 @@ class ClientSession:
         self._end_session(lock=True)
 
     @property
-    def client(self) -> "MongoClient":
+    def client(self) -> MongoClient:
         """The :class:`~pymongo.mongo_client.MongoClient` this session was
         created from.
         """

--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Collection level utilities for Mongo."""
+from __future__ import annotations
 
 from collections import abc
 from typing import (
@@ -114,14 +115,14 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
 
     def __init__(
         self,
-        database: "Database[_DocumentType]",
+        database: Database[_DocumentType],
         name: str,
         create: Optional[bool] = False,
-        codec_options: Optional["CodecOptions[_DocumentTypeArg]"] = None,
+        codec_options: Optional[CodecOptions[_DocumentTypeArg]] = None,
         read_preference: Optional[_ServerMode] = None,
         write_concern: Optional[WriteConcern] = None,
-        read_concern: Optional["ReadConcern"] = None,
-        session: Optional["ClientSession"] = None,
+        read_concern: Optional[ReadConcern] = None,
+        session: Optional[ClientSession] = None,
         **kwargs: Any,
     ) -> None:
         """Get / create a Mongo collection.
@@ -335,7 +336,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
                 session=session,
             )
 
-    def __getattr__(self, name: str) -> "Collection[_DocumentType]":
+    def __getattr__(self, name: str) -> Collection[_DocumentType]:
         """Get a sub-collection of this collection by name.
 
         Raises InvalidName if an invalid collection name is used.
@@ -351,7 +352,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
             )
         return self.__getitem__(name)
 
-    def __getitem__(self, name: str) -> "Collection[_DocumentType]":
+    def __getitem__(self, name: str) -> Collection[_DocumentType]:
         return Collection(
             self.__database,
             f"{self.__name}.{name}",
@@ -397,7 +398,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         return self.__name
 
     @property
-    def database(self) -> "Database[_DocumentType]":
+    def database(self) -> Database[_DocumentType]:
         """The :class:`~pymongo.database.Database` that this
         :class:`Collection` is a part of.
         """
@@ -405,11 +406,11 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
 
     def with_options(
         self,
-        codec_options: Optional["bson.CodecOptions[_DocumentTypeArg]"] = None,
+        codec_options: Optional[bson.CodecOptions[_DocumentTypeArg]] = None,
         read_preference: Optional[_ServerMode] = None,
         write_concern: Optional[WriteConcern] = None,
-        read_concern: Optional["ReadConcern"] = None,
-    ) -> "Collection[_DocumentType]":
+        read_concern: Optional[ReadConcern] = None,
+    ) -> Collection[_DocumentType]:
         """Get a clone of this collection changing the specified settings.
 
           >>> coll1.read_preference
@@ -455,7 +456,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         requests: Sequence[_WriteOp[_DocumentType]],
         ordered: bool = True,
         bypass_document_validation: bool = False,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         let: Optional[Mapping] = None,
     ) -> BulkWriteResult:
@@ -585,7 +586,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         self,
         document: Union[_DocumentType, RawBSONDocument],
         bypass_document_validation: bool = False,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
     ) -> InsertOneResult:
         """Insert a single document.
@@ -653,7 +654,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         documents: Iterable[Union[_DocumentType, RawBSONDocument]],
         ordered: bool = True,
         bypass_document_validation: bool = False,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
     ) -> InsertManyResult:
         """Insert an iterable of documents.
@@ -855,7 +856,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         bypass_document_validation: bool = False,
         collation: Optional[_CollationIn] = None,
         hint: Optional[_IndexKeyHint] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         let: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
     ) -> UpdateResult:
@@ -959,7 +960,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         collation: Optional[_CollationIn] = None,
         array_filters: Optional[Sequence[Mapping[str, Any]]] = None,
         hint: Optional[_IndexKeyHint] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         let: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
     ) -> UpdateResult:
@@ -1073,7 +1074,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         bypass_document_validation: Optional[bool] = None,
         collation: Optional[_CollationIn] = None,
         hint: Optional[_IndexKeyHint] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         let: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
     ) -> UpdateResult:
@@ -1168,7 +1169,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
 
     def drop(
         self,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         encrypted_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
@@ -1306,7 +1307,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         filter: Mapping[str, Any],
         collation: Optional[_CollationIn] = None,
         hint: Optional[_IndexKeyHint] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         let: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
     ) -> DeleteResult:
@@ -1373,7 +1374,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         filter: Mapping[str, Any],
         collation: Optional[_CollationIn] = None,
         hint: Optional[_IndexKeyHint] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         let: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
     ) -> DeleteResult:
@@ -1769,7 +1770,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
     def count_documents(
         self,
         filter: Mapping[str, Any],
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> int:
@@ -1860,7 +1861,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
     def create_indexes(
         self,
         indexes: Sequence[IndexModel],
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> List[str]:
@@ -1952,7 +1953,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
     def create_index(
         self,
         keys: _IndexKeyHint,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> str:
@@ -2071,7 +2072,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
 
     def drop_indexes(
         self,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> None:
@@ -2107,7 +2108,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
     def drop_index(
         self,
         index_or_name: _IndexKeyHint,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> None:
@@ -2174,7 +2175,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
 
     def list_indexes(
         self,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
     ) -> CommandCursor[MutableMapping[str, Any]]:
         """Get a cursor over the index documents for this collection.
@@ -2239,7 +2240,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
 
     def index_information(
         self,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
     ) -> MutableMapping[str, Any]:
         """Get information on this collection's indexes.
@@ -2282,7 +2283,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
 
     def options(
         self,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
     ) -> MutableMapping[str, Any]:
         """Get the options set on this collection.
@@ -2361,7 +2362,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
     def aggregate(
         self,
         pipeline: _Pipeline,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         let: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
@@ -2458,7 +2459,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
     def aggregate_raw_batches(
         self,
         pipeline: _Pipeline,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> RawBatchCursor[_DocumentType]:
@@ -2509,7 +2510,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         batch_size: Optional[int] = None,
         collation: Optional[_CollationIn] = None,
         start_at_operation_time: Optional[Timestamp] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         start_after: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
         full_document_before_change: Optional[str] = None,
@@ -2644,7 +2645,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
     def rename(
         self,
         new_name: str,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> MutableMapping[str, Any]:
@@ -2709,7 +2710,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         self,
         key: str,
         filter: Optional[Mapping[str, Any]] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> List:
@@ -2860,7 +2861,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         projection: Optional[Union[Mapping[str, Any], Iterable[str]]] = None,
         sort: Optional[_IndexList] = None,
         hint: Optional[_IndexKeyHint] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         let: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
@@ -2953,7 +2954,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         upsert: bool = False,
         return_document: bool = ReturnDocument.BEFORE,
         hint: Optional[_IndexKeyHint] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         let: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
@@ -3062,7 +3063,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         return_document: bool = ReturnDocument.BEFORE,
         array_filters: Optional[Sequence[Mapping[str, Any]]] = None,
         hint: Optional[_IndexKeyHint] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         let: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,

--- a/pymongo/command_cursor.py
+++ b/pymongo/command_cursor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """CommandCursor class to iterate over command results."""
+from __future__ import annotations
 
 from collections import deque
 from typing import TYPE_CHECKING, Any, Generic, Iterator, Mapping, NoReturn, Optional
@@ -36,12 +37,12 @@ class CommandCursor(Generic[_DocumentType]):
 
     def __init__(
         self,
-        collection: "Collection[_DocumentType]",
+        collection: Collection[_DocumentType],
         cursor_info: Mapping[str, Any],
         address: Optional[_Address],
         batch_size: int = 0,
         max_await_time_ms: Optional[int] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         explicit_session: bool = False,
         comment: Any = None,
     ) -> None:
@@ -267,7 +268,7 @@ class CommandCursor(Generic[_DocumentType]):
         return self.__address
 
     @property
-    def session(self) -> Optional["ClientSession"]:
+    def session(self) -> Optional[ClientSession]:
         """The cursor's :class:`~pymongo.client_session.ClientSession`, or None.
 
         .. versionadded:: 3.6
@@ -312,12 +313,12 @@ class RawBatchCommandCursor(CommandCursor, Generic[_DocumentType]):
 
     def __init__(
         self,
-        collection: "Collection[_DocumentType]",
+        collection: Collection[_DocumentType],
         cursor_info: Mapping[str, Any],
         address: Optional[_Address],
         batch_size: int = 0,
         max_await_time_ms: Optional[int] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         explicit_session: bool = False,
         comment: Any = None,
     ) -> None:

--- a/pymongo/cursor.py
+++ b/pymongo/cursor.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 """Cursor class to iterate over Mongo query results."""
+from __future__ import annotations
+
 import copy
 import warnings
 from collections import deque
@@ -163,7 +165,7 @@ class Cursor(Generic[_DocumentType]):
 
     def __init__(
         self,
-        collection: "Collection[_DocumentType]",
+        collection: Collection[_DocumentType],
         filter: Optional[Mapping[str, Any]] = None,
         projection: Optional[Union[Mapping[str, Any], Iterable[str]]] = None,
         skip: int = 0,
@@ -184,7 +186,7 @@ class Cursor(Generic[_DocumentType]):
         show_record_id: Optional[bool] = None,
         snapshot: Optional[bool] = None,
         comment: Optional[Any] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         allow_disk_use: Optional[bool] = None,
         let: Optional[bool] = None,
     ) -> None:
@@ -202,7 +204,7 @@ class Cursor(Generic[_DocumentType]):
         self.__exhaust = False
         self.__sock_mgr: Any = None
         self.__killed = False
-        self.__session: Optional["ClientSession"]
+        self.__session: Optional[ClientSession]
 
         if session:
             self.__session = session
@@ -312,7 +314,7 @@ class Cursor(Generic[_DocumentType]):
         self.__collname = collection.name
 
     @property
-    def collection(self) -> "Collection[_DocumentType]":
+    def collection(self) -> Collection[_DocumentType]:
         """The :class:`~pymongo.collection.Collection` that this
         :class:`Cursor` is iterating.
         """
@@ -1230,7 +1232,7 @@ class Cursor(Generic[_DocumentType]):
         return self.__address
 
     @property
-    def session(self) -> Optional["ClientSession"]:
+    def session(self) -> Optional[ClientSession]:
         """The cursor's :class:`~pymongo.client_session.ClientSession`, or None.
 
         .. versionadded:: 3.6
@@ -1313,7 +1315,7 @@ class RawBatchCursor(Cursor, Generic[_DocumentType]):
     _query_class = _RawBatchQuery
     _getmore_class = _RawBatchGetMore
 
-    def __init__(self, collection: "Collection[_DocumentType]", *args: Any, **kwargs: Any) -> None:
+    def __init__(self, collection: Collection[_DocumentType], *args: Any, **kwargs: Any) -> None:
         """Create a new cursor / iterator over raw batches of BSON data.
 
         Should not be called directly by application developers -

--- a/pymongo/database.py
+++ b/pymongo/database.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 """Database level operations."""
+from __future__ import annotations
+
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
@@ -74,10 +76,10 @@ class Database(common.BaseObject, Generic[_DocumentType]):
         self,
         client: "MongoClient[_DocumentType]",
         name: str,
-        codec_options: Optional["bson.CodecOptions[_DocumentTypeArg]"] = None,
+        codec_options: Optional[bson.CodecOptions[_DocumentTypeArg]] = None,
         read_preference: Optional[_ServerMode] = None,
-        write_concern: Optional["WriteConcern"] = None,
-        read_concern: Optional["ReadConcern"] = None,
+        write_concern: Optional[WriteConcern] = None,
+        read_concern: Optional[ReadConcern] = None,
     ) -> None:
         """Get a database by client and name.
 
@@ -154,10 +156,10 @@ class Database(common.BaseObject, Generic[_DocumentType]):
 
     def with_options(
         self,
-        codec_options: Optional["bson.CodecOptions[_DocumentTypeArg]"] = None,
+        codec_options: Optional[bson.CodecOptions[_DocumentTypeArg]] = None,
         read_preference: Optional[_ServerMode] = None,
-        write_concern: Optional["WriteConcern"] = None,
-        read_concern: Optional["ReadConcern"] = None,
+        write_concern: Optional[WriteConcern] = None,
+        read_concern: Optional[ReadConcern] = None,
     ) -> "Database[_DocumentType]":
         """Get a clone of this database changing the specified settings.
 
@@ -241,10 +243,10 @@ class Database(common.BaseObject, Generic[_DocumentType]):
     def get_collection(
         self,
         name: str,
-        codec_options: Optional["bson.CodecOptions[_DocumentTypeArg]"] = None,
+        codec_options: Optional[bson.CodecOptions[_DocumentTypeArg]] = None,
         read_preference: Optional[_ServerMode] = None,
-        write_concern: Optional["WriteConcern"] = None,
-        read_concern: Optional["ReadConcern"] = None,
+        write_concern: Optional[WriteConcern] = None,
+        read_concern: Optional[ReadConcern] = None,
     ) -> Collection[_DocumentType]:
         """Get a :class:`~pymongo.collection.Collection` with the given name
         and options.
@@ -319,11 +321,11 @@ class Database(common.BaseObject, Generic[_DocumentType]):
     def create_collection(
         self,
         name: str,
-        codec_options: Optional["bson.CodecOptions[_DocumentTypeArg]"] = None,
+        codec_options: Optional[bson.CodecOptions[_DocumentTypeArg]] = None,
         read_preference: Optional[_ServerMode] = None,
-        write_concern: Optional["WriteConcern"] = None,
-        read_concern: Optional["ReadConcern"] = None,
-        session: Optional["ClientSession"] = None,
+        write_concern: Optional[WriteConcern] = None,
+        read_concern: Optional[ReadConcern] = None,
+        session: Optional[ClientSession] = None,
         check_exists: Optional[bool] = True,
         **kwargs: Any,
     ) -> Collection[_DocumentType]:
@@ -472,7 +474,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
             )
 
     def aggregate(
-        self, pipeline: _Pipeline, session: Optional["ClientSession"] = None, **kwargs: Any
+        self, pipeline: _Pipeline, session: Optional[ClientSession] = None, **kwargs: Any
     ) -> CommandCursor[_DocumentType]:
         """Perform a database-level aggregation.
 
@@ -557,7 +559,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
         batch_size: Optional[int] = None,
         collation: Optional[_CollationIn] = None,
         start_at_operation_time: Optional[Timestamp] = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         start_after: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
         full_document_before_change: Optional[str] = None,
@@ -720,7 +722,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
         allowable_errors: Optional[Sequence[Union[str, int]]] = None,
         read_preference: Optional[_ServerMode] = None,
         codec_options: "Optional[bson.codec_options.CodecOptions[_CodecDocumentType]]" = None,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> _CodecDocumentType:
@@ -883,7 +885,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
 
     def list_collections(
         self,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         filter: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
@@ -924,7 +926,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
 
     def list_collection_names(
         self,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         filter: Optional[Mapping[str, Any]] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
@@ -989,7 +991,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
     def drop_collection(
         self,
         name_or_collection: Union[str, Collection[_DocumentTypeArg]],
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         encrypted_fields: Optional[Mapping[str, Any]] = None,
     ) -> Dict[str, Any]:
@@ -1069,7 +1071,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
         name_or_collection: Union[str, Collection[_DocumentTypeArg]],
         scandata: bool = False,
         full: bool = False,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         background: Optional[bool] = None,
         comment: Optional[Any] = None,
     ) -> Dict[str, Any]:
@@ -1165,7 +1167,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
     def dereference(
         self,
         dbref: DBRef,
-        session: Optional["ClientSession"] = None,
+        session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
         **kwargs: Any,
     ) -> Optional[_DocumentType]:

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Support for automatic client-side field level encryption."""
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Mapping, Optional
 
@@ -38,7 +39,7 @@ class AutoEncryptionOpts:
         self,
         kms_providers: Mapping[str, Any],
         key_vault_namespace: str,
-        key_vault_client: Optional["MongoClient"] = None,
+        key_vault_client: Optional[MongoClient] = None,
         schema_map: Optional[Mapping[str, Any]] = None,
         bypass_auto_encryption: bool = False,
         mongocryptd_uri: str = "mongodb://localhost:27020",

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -30,6 +30,7 @@ access:
   >>> c["test-database"]
   Database(MongoClient(host=['localhost:27017'], document_class=dict, tz_aware=False, connect=True), 'test-database')
 """
+from __future__ import annotations
 
 import contextlib
 import os
@@ -1762,7 +1763,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
     @contextlib.contextmanager
     def _tmp_session(
         self, session: Optional[client_session.ClientSession], close: bool = True
-    ) -> "Generator[Optional[client_session.ClientSession], None, None]":
+    ) -> Generator[Optional[client_session.ClientSession], None, None]:
         """If provided session is None, lend a temporary session."""
         if session is not None:
             if not isinstance(session, client_session.ClientSession):
@@ -1939,10 +1940,10 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
     def get_default_database(
         self,
         default: Optional[str] = None,
-        codec_options: Optional["bson.CodecOptions[_DocumentTypeArg]"] = None,
+        codec_options: Optional[bson.CodecOptions[_DocumentTypeArg]] = None,
         read_preference: Optional[_ServerMode] = None,
         write_concern: Optional[WriteConcern] = None,
-        read_concern: Optional["ReadConcern"] = None,
+        read_concern: Optional[ReadConcern] = None,
     ) -> database.Database[_DocumentType]:
         """Get the database named in the MongoDB connection URI.
 
@@ -2000,10 +2001,10 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
     def get_database(
         self,
         name: Optional[str] = None,
-        codec_options: Optional["bson.CodecOptions[_DocumentTypeArg]"] = None,
+        codec_options: Optional[bson.CodecOptions[_DocumentTypeArg]] = None,
         read_preference: Optional[_ServerMode] = None,
         write_concern: Optional[WriteConcern] = None,
-        read_concern: Optional["ReadConcern"] = None,
+        read_concern: Optional[ReadConcern] = None,
     ) -> database.Database[_DocumentType]:
         """Get a :class:`~pymongo.database.Database` with the given name and
         options.

--- a/pymongo/monitoring.py
+++ b/pymongo/monitoring.py
@@ -183,6 +183,8 @@ will not add that listener to existing client instances.
   handler first.
 """
 
+from __future__ import annotations
+
 import datetime
 from collections import abc, namedtuple
 from typing import TYPE_CHECKING, Any, Dict, Optional
@@ -1128,8 +1130,8 @@ class ServerDescriptionChangedEvent(_ServerEvent):
 
     def __init__(
         self,
-        previous_description: "ServerDescription",
-        new_description: "ServerDescription",
+        previous_description: ServerDescription,
+        new_description: ServerDescription,
         *args: Any,
     ) -> None:
         super().__init__(*args)
@@ -1137,14 +1139,14 @@ class ServerDescriptionChangedEvent(_ServerEvent):
         self.__new_description = new_description
 
     @property
-    def previous_description(self) -> "ServerDescription":
+    def previous_description(self) -> ServerDescription:
         """The previous
         :class:`~pymongo.server_description.ServerDescription`.
         """
         return self.__previous_description
 
     @property
-    def new_description(self) -> "ServerDescription":
+    def new_description(self) -> ServerDescription:
         """The new
         :class:`~pymongo.server_description.ServerDescription`.
         """
@@ -1204,8 +1206,8 @@ class TopologyDescriptionChangedEvent(TopologyEvent):
 
     def __init__(
         self,
-        previous_description: "TopologyDescription",
-        new_description: "TopologyDescription",
+        previous_description: TopologyDescription,
+        new_description: TopologyDescription,
         *args: Any,
     ) -> None:
         super().__init__(*args)
@@ -1213,14 +1215,14 @@ class TopologyDescriptionChangedEvent(TopologyEvent):
         self.__new_description = new_description
 
     @property
-    def previous_description(self) -> "TopologyDescription":
+    def previous_description(self) -> TopologyDescription:
         """The previous
         :class:`~pymongo.topology_description.TopologyDescription`.
         """
         return self.__previous_description
 
     @property
-    def new_description(self) -> "TopologyDescription":
+    def new_description(self) -> TopologyDescription:
         """The new
         :class:`~pymongo.topology_description.TopologyDescription`.
         """

--- a/test/test_comment.py
+++ b/test/test_comment.py
@@ -14,9 +14,10 @@
 
 """Test the keyword argument 'comment' in various helpers."""
 
+from __future__ import annotations
+
 import inspect
 import sys
-from typing import Any, Union
 
 sys.path[0:0] = [""]
 
@@ -69,7 +70,7 @@ class TestComment(IntegrationTest):
                         "signature of function %s" % (h.__name__),
                     )
                     self.assertEqual(
-                        inspect.signature(h).parameters["comment"].annotation, Union[Any, None]
+                        inspect.signature(h).parameters["comment"].annotation, "Optional[Any]"
                     )
                     if isinstance(maybe_cursor, CommandCursor):
                         maybe_cursor.close()


### PR DESCRIPTION
The `test/test_comment.py` changes are due to `__future__` annotations explicitly not evaluating all type annotations, causing the test to fail due to comparing the string `"Optional[Any]"` to the evaluated value `Union[Any, None]`. If we want to keep the original, evaluated comparison, we could explicitly evaluate the type annotation as described here: https://docs.python.org/3/library/typing.html#typing.get_type_hints.