### PR TITLE
PYTHON-2963 Add tox config in preparation for migration from setup.py

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -29,13 +29,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
-      - name: Install dependencies
-        run: |
-          pip install tox
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'setup.py'
+      - name: Install dependencies
+        run: |
+          pip install tox
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.7.0
         with:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          pip install tox
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -39,7 +42,7 @@ jobs:
           mongodb-version: 4.4
       - name: Run tests
         run: |
-          python setup.py test
+          tox -e test
 
   mypytest:
     name: Run mypy
@@ -58,22 +61,16 @@ jobs:
           cache-dependency-path: 'setup.py'
       - name: Install dependencies
         run: |
-          python -m pip install -U pip mypy==1.2
-          pip install -e ".[zstd, encryption, ocsp]"
+          pip install tox
       - name: Run mypy
         run: |
-          mypy --install-types --non-interactive bson gridfs tools pymongo
-          mypy --install-types --non-interactive --disable-error-code var-annotated --disable-error-code attr-defined --disable-error-code union-attr --disable-error-code assignment --disable-error-code no-redef --disable-error-code index --allow-redefinition --allow-untyped-globals --exclude "test/mypy_fails/*.*" test
-          python -m pip install -U typing_extensions
-          mypy --install-types --non-interactive test/test_typing.py test/test_typing_strict.py
+          tox -e typecheck-mypy
       - name: Run pyright
         run: |
-          python -m pip install -U pip pyright==1.1.290
-          pyright test/test_typing.py test/test_typing_strict.py
+          tox -e typecheck-pyright
       - name: Run pyright strict
         run: |
-          echo '{"strict": ["tests/test_typing_strict.py"]}' >>  pyrightconfig.json
-          pyright test/test_typing_strict.py
+          tox -e typecheck-pyright-strict
 
   linkcheck:
     name: Check Links

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,45 @@
+[tox]
+requires =
+    tox>=4
+envlist =
+    # Test using the system Python.
+    test,
+    # Run pre-commit on all files.
+    lint,
+    # Run pre-commit on all files, including stages that require manual fixes.
+    lint-manual,
+    # Typecheck all files.
+    typecheck
+
+[testenv:test]
+description = run unit tests
+commands =
+    python --version
+    python setup.py test {posargs}
+
+[testenv:lint]
+description = run pre-commit
+deps =
+    pre-commit
+commands =
+    pre-commit run --all-files
+
+[testenv:lint-manual]
+description = run all pre-commit stages, including those that require manual fixes
+deps =
+    pre-commit
+commands =
+    pre-commit run --all-files
+    pre-commit run --all-files --hook-stage manual flake8
+    pre-commit run --all-files --hook-stage manual doc8
+
+[testenv:typecheck]
+description = run mypy to typecheck
+deps =
+    mypy
+    zstandard
+    certifi; platform_system == "win32" or platform_system == "Darwin"
+commands =
+    mypy --install-types --non-interactive bson gridfs tools pymongo
+    mypy --install-types --non-interactive --disable-error-code var-annotated --disable-error-code attr-defined --disable-error-code union-attr --disable-error-code assignment --disable-error-code no-redef --disable-error-code index --allow-redefinition --allow-untyped-globals --exclude "test/mypy_fails/*.*" test
+    mypy --install-types --non-interactive test/test_typing.py test/test_typing_strict.py

--- a/tox.ini
+++ b/tox.ini
@@ -57,10 +57,9 @@ commands =
     pyright test/test_typing.py test/test_typing_strict.py
 
 [testenv:typecheck-pyright-strict]
-description = run pyright to typecheck
+description = run pyright with strict mode to typecheck
 deps =
-    mypy
-    pyright==1.1.290
+    {[testenv:typecheck-pyright]deps}
 allowlist_externals=echo
 commands =
     echo '{"strict": ["tests/test_typing_strict.py"]}' >> pyrightconfig.json
@@ -69,21 +68,10 @@ commands =
 [testenv:typecheck]
 description = run mypy and pyright to typecheck
 deps =
-    mypy
-    zstandard
-    certifi; platform_system == "win32" or platform_system == "Darwin"
-    typing_extensions
-    pyopenssl>=17.2.0
-    requests<3.0.0
-    service_identity>=18.1.0
-    pymongocrypt>=1.6.0,<2.0.0
-    pymongo-auth-aws<2.0.0
-    pyright==1.1.290
+    {[testenv:typecheck-mypy]deps}
+    {[testenv:typecheck-pyright]deps}
 allowlist_externals=echo
 commands =
-    mypy --install-types --non-interactive bson gridfs tools pymongo
-    mypy --install-types --non-interactive --disable-error-code var-annotated --disable-error-code attr-defined --disable-error-code union-attr --disable-error-code assignment --disable-error-code no-redef --disable-error-code index --allow-redefinition --allow-untyped-globals --exclude "test/mypy_fails/*.*" test
-    mypy --install-types --non-interactive test/test_typing.py test/test_typing_strict.py
-    pyright test/test_typing.py test/test_typing_strict.py
-    echo '{"strict": ["tests/test_typing_strict.py"]}' >> pyrightconfig.json
-    pyright test/test_typing_strict.py
+    {[testenv:typecheck-mypy]commands}
+    {[testenv:typecheck-pyright]commands}
+    {[testenv:typecheck-pyright-strict]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -31,13 +31,59 @@ deps =
 commands =
     pre-commit run --all-files --hook-stage manual
 
-[testenv:typecheck]
-description = run mypy to typecheck
+[testenv:typecheck-mypy]
+description = run mypy and pyright to typecheck
 deps =
     mypy
     zstandard
     certifi; platform_system == "win32" or platform_system == "Darwin"
+    typing_extensions
+    pyopenssl>=17.2.0
+    requests<3.0.0
+    service_identity>=18.1.0
+    pymongocrypt>=1.6.0,<2.0.0
+    pymongo-auth-aws<2.0.0
 commands =
     mypy --install-types --non-interactive bson gridfs tools pymongo
     mypy --install-types --non-interactive --disable-error-code var-annotated --disable-error-code attr-defined --disable-error-code union-attr --disable-error-code assignment --disable-error-code no-redef --disable-error-code index --allow-redefinition --allow-untyped-globals --exclude "test/mypy_fails/*.*" test
     mypy --install-types --non-interactive test/test_typing.py test/test_typing_strict.py
+
+[testenv:typecheck-pyright]
+description = run pyright to typecheck
+deps =
+    mypy
+    pyright==1.1.290
+commands =
+    pyright test/test_typing.py test/test_typing_strict.py
+
+[testenv:typecheck-pyright-strict]
+description = run pyright to typecheck
+deps =
+    mypy
+    pyright==1.1.290
+allowlist_externals=echo
+commands =
+    echo '{"strict": ["tests/test_typing_strict.py"]}' >> pyrightconfig.json
+    pyright test/test_typing_strict.py
+
+[testenv:typecheck]
+description = run mypy and pyright to typecheck
+deps =
+    mypy
+    zstandard
+    certifi; platform_system == "win32" or platform_system == "Darwin"
+    typing_extensions
+    pyopenssl>=17.2.0
+    requests<3.0.0
+    service_identity>=18.1.0
+    pymongocrypt>=1.6.0,<2.0.0
+    pymongo-auth-aws<2.0.0
+    pyright==1.1.290
+allowlist_externals=echo
+commands =
+    mypy --install-types --non-interactive bson gridfs tools pymongo
+    mypy --install-types --non-interactive --disable-error-code var-annotated --disable-error-code attr-defined --disable-error-code union-attr --disable-error-code assignment --disable-error-code no-redef --disable-error-code index --allow-redefinition --allow-untyped-globals --exclude "test/mypy_fails/*.*" test
+    mypy --install-types --non-interactive test/test_typing.py test/test_typing_strict.py
+    pyright test/test_typing.py test/test_typing_strict.py
+    echo '{"strict": ["tests/test_typing_strict.py"]}' >> pyrightconfig.json
+    pyright test/test_typing_strict.py

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,7 @@ description = run all pre-commit stages, including those that require manual fix
 deps =
     pre-commit
 commands =
-    pre-commit run --all-files
-    pre-commit run --all-files --hook-stage manual flake8
-    pre-commit run --all-files --hook-stage manual doc8
+    pre-commit run --all-files --hook-stage manual
 
 [testenv:typecheck]
 description = run mypy to typecheck

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ deps =
     {[testenv:typecheck-pyright]deps}
 allowlist_externals=echo
 commands =
-    echo '{"strict": ["tests/test_typing_strict.py"]}' >> pyrightconfig.json
+    echo '{"strict": ["tests/test_typing_strict.py"]}' > pyrightconfig.json
     pyright test/test_typing_strict.py
 
 [testenv:typecheck]


### PR DESCRIPTION
This change is still using `python setup.py test` inside tox to run the unit tests: migration to pytest will be done in https://jira.mongodb.org/browse/PYTHON-3727, and migration to pyproject.toml will be done in https://jira.mongodb.org/browse/PYTHON-2965.