### PR TITLE
PYTHON-3758 Support overflow integers in fallback_encoder.

### DIFF
--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -805,7 +805,7 @@ def _encode_int(name: bytes, value: int, dummy0: Any, dummy1: Any) -> bytes:
         try:
             return b"\x12" + name + _PACK_LONG(value)
         except struct.error:
-            raise OverflowError("BSON can only handle up to 8-byte ints")
+            raise IntegerOverflow()
 
 
 def _encode_timestamp(name: bytes, value: Any, dummy0: Any, dummy1: Any) -> bytes:
@@ -896,12 +896,18 @@ def _name_value_to_bson(
     in_fallback_call: bool = False,
 ) -> bytes:
     """Encode a single name, value pair."""
+
+    was_integer_overflow = False
+
     # First see if the type is already cached. KeyError will only ever
     # happen once per subtype.
     try:
         return _ENCODERS[type(value)](name, value, check_keys, opts)  # type: ignore
     except KeyError:
         pass
+    except IntegerOverflow:
+        # Give the fallback_encoder a chance
+        was_integer_overflow = True
 
     # Second, fall back to trying _type_marker. This has to be done
     # before the loop below since users could subclass one of our
@@ -927,7 +933,7 @@ def _name_value_to_bson(
     # is done after trying the custom type encoder because checking for each
     # subtype is expensive.
     for base in _BUILT_IN_TYPES:
-        if isinstance(value, base):
+        if not was_integer_overflow and isinstance(value, base):
             func = _ENCODERS[base]
             # Cache this type for faster subsequent lookup.
             _ENCODERS[type(value)] = func
@@ -941,6 +947,8 @@ def _name_value_to_bson(
             name, fallback_encoder(value), check_keys, opts, in_fallback_call=True
         )
 
+    if was_integer_overflow:
+        raise OverflowError("BSON can only handle up to 8-byte ints")
     raise InvalidDocument(f"cannot encode object: {value!r}, of type: {type(value)!r}")
 
 
@@ -1379,6 +1387,10 @@ class BSON(bytes):
            `codec_options`.
         """
         return decode(self, codec_options)
+
+
+class IntegerOverflow(Exception):
+    pass
 
 
 def has_c() -> bool:

--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -905,9 +905,10 @@ def _name_value_to_bson(
         return _ENCODERS[type(value)](name, value, check_keys, opts)  # type: ignore
     except KeyError:
         pass
-    except OverflowError as error:
-        if error.args != ("BSON can only handle up to 8-byte ints",):
+    except OverflowError:
+        if not isinstance(value, int):
             raise
+
         # Give the fallback_encoder a chance
         was_integer_overflow = True
 

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -97,3 +97,4 @@ The following is a list of people who have contributed to
 - Sean Cheah (thalassemia)
 - Dainis Gorbunovs (DainisGorbunovs)
 - Iris Ho (sleepyStick)
+- Stephan Hof (stephan-hof)

--- a/test/test_custom_types.py
+++ b/test/test_custom_types.py
@@ -623,6 +623,15 @@ class TestCollectionWCustomType(IntegrationTest):
     def tearDown(self):
         self.db.test.drop()
 
+    def test_overflow_int_w_custom_decoder(self):
+        type_registry = TypeRegistry(fallback_encoder=lambda val: str(val))
+        codec_options = CodecOptions(type_registry=type_registry)
+        collection = self.db.get_collection("test", codec_options=codec_options)
+
+        collection.insert_one({"_id": 1, "data": 2**520})
+        ret = collection.find_one()
+        self.assertEqual(ret["data"], str(2**520))
+
     def test_command_errors_w_custom_type_decoder(self):
         db = self.db
         test_doc = {"_id": 1, "data": "a"}

--- a/test/test_custom_types.py
+++ b/test/test_custom_types.py
@@ -274,6 +274,22 @@ class TestBSONFallbackEncoder(unittest.TestCase):
         with self.assertRaises(TypeError):
             encode(document, codec_options=codecopts)
 
+    def test_call_only_once_for_not_handled_big_integers(self):
+        called_with = []
+
+        def fallback_encoder(value):
+            called_with.append(value)
+            return value
+
+        codecopts = self._get_codec_options(fallback_encoder)
+        document = {"a": {"b": {"c": 2 << 65}}}
+
+        msg = "MongoDB can only handle up to 8-byte ints"
+        with self.assertRaises(OverflowError, msg=msg):
+            encode(document, codec_options=codecopts)
+
+        self.assertEqual(called_with, [2 << 65])
+
 
 class TestBSONTypeEnDeCodecs(unittest.TestCase):
     def test_instantiation(self):

--- a/test/test_default_exports.py
+++ b/test/test_default_exports.py
@@ -20,7 +20,7 @@ import bson
 import gridfs
 import pymongo
 
-BSON_IGNORE = []
+BSON_IGNORE = ["IntegerOverflow"]
 GRIDFS_IGNORE = [
     "ASCENDING",
     "DESCENDING",

--- a/test/test_default_exports.py
+++ b/test/test_default_exports.py
@@ -20,7 +20,7 @@ import bson
 import gridfs
 import pymongo
 
-BSON_IGNORE = ["IntegerOverflow"]
+BSON_IGNORE = []
 GRIDFS_IGNORE = [
     "ASCENDING",
     "DESCENDING",


### PR DESCRIPTION
Hi,

I'm regularly dealing with 64-bit *unsigned* integers.
Those range from `[0, (2**64) - 1]`. So they are outside of the 64-bit *signed* integers from  [BSONs](https://bsonspec.org/spec.html) `"\x12" e_name int64 64-bit integer`.

Up to now pymongo rejects those immediately with an OverflowError so the application must deal with them.
For us this is pretty cumbersome, since we have a pretty complex structure and finding those large numbers would mean to 'traverse' through the whole document before giving it to pymongo.

Performance and code wise this is not very ideal so my thinking was:
To convert the document to BSON, pymongo must traverse the document anyway.
So lets handle this 'big integer' like any other unknown type and call the `fallback_encoder` (if given). 
Then let the fallback_encoder deal with it. This is now up to me, like it is already with unknown types.

In other words: If pymongo/bson detects an integer outside its supported range the `fallback_encoder` gets called.
If no `fallback_encoder` is given or if `fallback_encoder` gives back a 'big integer' again the usual `OverflowError` is thrown.