### PR TITLE
PYTHON-3760 Add C extension building as part of tox test environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,8 @@ https://pymongo.readthedocs.io/en/stable/installation.html#osx
         try:
             build_ext.run(self)
         except Exception:
+            if "TOX_ENV_NAME" in os.environ:
+                raise
             e = sys.exc_info()[1]
             sys.stdout.write("%s\n" % str(e))
             warnings.warn(
@@ -141,6 +143,8 @@ https://pymongo.readthedocs.io/en/stable/installation.html#osx
         try:
             build_ext.build_extension(self, ext)
         except Exception:
+            if "TOX_ENV_NAME" in os.environ:
+                raise
             e = sys.exc_info()[1]
             sys.stdout.write("%s\n" % str(e))
             warnings.warn(
@@ -169,7 +173,6 @@ ext_modules = [
         ],
     ),
 ]
-
 
 if "--no_ext" in sys.argv or "NO_EXT" in os.environ:
     sys.argv.remove("--no_ext")

--- a/setup.py
+++ b/setup.py
@@ -174,6 +174,7 @@ ext_modules = [
     ),
 ]
 
+
 if "--no_ext" in sys.argv or "NO_EXT" in os.environ:
     sys.argv.remove("--no_ext")
     ext_modules = []


### PR DESCRIPTION
Fails as expected when the c extension has an error now:

```
      gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -arch x86_64 -g -Ibson -I/Users/steve.silvester/workspace/mongo-python-driver/.tox/test/include -I/Library/Frameworks/Python.framework/Versions/3.7/include/python3.7m -c bson/_cbsonmodule.c -o build/temp.macosx-10.9-x86_64-cpython-37/bson/_cbsonmodule.o
      bson/_cbsonmodule.c:282:5: error: use of undeclared identifier 'a'
          a = b;
          ^
      bson/_cbsonmodule.c:282:9: error: use of undeclared identifier 'b'
          a = b;
              ^
      2 errors generated.
      /private/tmp/pip-build-env-4cfbi019/overlay/lib/python3.7/site-packages/setuptools/config/pyprojecttoml.py:66: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
        config = read_configuration(filepath, True, ignore_option_errors, dist)
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pymongo
ERROR: Could not build wheels for pymongo, which is required to install pyproject.toml-based projects

test: exit 1 (4.24 seconds) /Users/steve.silvester/workspace/mongo-python-driver> python -I -m pip install --force-reinstall --no-deps /Users/steve.silvester/workspace/mongo-python-driver/.tox/.tmp/package/9/pymongo-4.5.0.dev0.tar.gz pid=44837
.pkg: _exit> python /Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pyproject_api/_backend.py True setuptools.build_meta
  test: FAIL code 1 (5.28 seconds)
  evaluation failed :( (5.36 seconds)
```