### PR TITLE
PYTHON-3793 Make tox fail with invalid environment

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -359,7 +359,7 @@ functions:
           ${PREPARE_SHELL}
 
           alias python=${PYTHON_BINARY}
-          python -m tox -e test-mockupdb
+          python -m tox -m test-mockupdb
 
   "run doctests":
      - command: shell.exec

--- a/.evergreen/run-doctests.sh
+++ b/.evergreen/run-doctests.sh
@@ -4,4 +4,4 @@ set -o xtrace
 set -o errexit
 
 ${PYTHON_BINARY} -m pip install tox
-${PYTHON_BINARY} -m tox -e doc-test
+${PYTHON_BINARY} -m tox -m doc-test

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -42,7 +42,7 @@ jobs:
           mongodb-version: 4.4
       - name: Run tests
         run: |
-          tox -e test
+          tox -m test
 
   mypytest:
     name: Run mypy
@@ -64,13 +64,13 @@ jobs:
           pip install tox
       - name: Run mypy
         run: |
-          tox -e typecheck-mypy
+          tox -m typecheck-mypy
       - name: Run pyright
         run: |
-          tox -e typecheck-pyright
+          tox -m typecheck-pyright
       - name: Run pyright strict
         run: |
-          tox -e typecheck-pyright-strict
+          tox -m typecheck-pyright-strict
 
   linkcheck:
     name: Check Links
@@ -86,4 +86,4 @@ jobs:
           pip install tox
       - name: Check links
         run: |
-          tox -e linkcheck
+          tox -m linkcheck

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -36,7 +36,7 @@ Doing a Release
    To test locally, ``python3 setup.py test`` will build the C extensions and
    test. ``python3 tools/clean.py`` will remove the extensions,
    and then ``python3 setup.py --no_ext test`` will run the tests without
-   them. You can also run the doctests: ``tox -e doc-test``.
+   them. You can also run the doctests: ``tox -m doc-test``.
 
 2. Check Jira to ensure all the tickets in this version have been completed.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -103,7 +103,7 @@ following command from the root directory of the **PyMongo** source:
 .. code-block:: bash
 
   $ pip install tox
-  $ tox -e docs
+  $ tox -m doc
 
 Indices and tables
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,19 @@ envlist =
     doc-test,
     # Linkcheck sphinx docs
     linkcheck
+labels = # Use labels and -m instead of -e so that tox -m <label> fails instantly if the label does not exist
+    test = test
+    test-encryption = test-encryption
+    lint = lint
+    lint-manual = lint-manual
+    typecheck-mypy = typecheck-mypy
+    typecheck-pyright = typecheck-pyright
+    typecheck-pyright-strict = typecheck-pyright-strict
+    typecheck = typecheck
+    doc = doc
+    doc-test = doc-test
+    linkcheck = linkcheck
+    test-mockupdb = test-mockupdb
 
 [testenv:test]
 description = run base set of unit tests with no extra functionality
@@ -40,7 +53,6 @@ extras = encryption
 commands =
     python --version
     pytest {posargs}
-
 
 [testenv:lint]
 description = run pre-commit


### PR DESCRIPTION
Using tox labels with `tox -m <label>` instantly fails if the label does not exist. This appears to be the best way to ensure that trying to run a nonexistent tox environment results in a command failure.