### PR TITLE
PYTHON-3800 Add lower() to node when validate hosts of srv records

### DIFF
--- a/pymongo/srv_resolver.py
+++ b/pymongo/srv_resolver.py
@@ -118,7 +118,7 @@ class _SrvResolver:
         # Validate hosts
         for node in nodes:
             try:
-                nlist = node[0].split(".")[1:][-self.__slen :]
+                nlist = node[0].lower().split(".")[1:][-self.__slen :]
             except Exception:
                 raise ConfigurationError(f"Invalid SRV host: {node[0]}")
             if self.__plist != nlist:


### PR DESCRIPTION
### Background 
When using `mongodb+srv` DNS Seed List Connection String, I had no problems with the other drivers, but only when using the pymongo driver. 

The error is as follows 
```shell 
python3 main.py        
Traceback (most recent call last):  
  File "/Users/user/Workspace/tmp/pymongo-test/main.py", line 11, in <module>  
    client = pymongo.MongoClient(uri)  
             ^^^^^^^^^^^^^^^^^^^^^^^^  
  File "/Users/user/Workspace/tmp/pymongo-test/venv/lib/python3.11/site-packages/pymongo/mongo_client.py", line 748, in __init__  
    res = uri_parser.parse_uri(  
          ^^^^^^^^^^^^^^^^^^^^^  
  File "/Users/user/Workspace/tmp/pymongo-test/venv/lib/python3.11/site-packages/pymongo/uri_parser.py", line 539, in parse_uri  
    nodes = dns_resolver.get_hosts()  
            ^^^^^^^^^^^^^^^^^^^^^^^^  
  File "/Users/user/Workspace/tmp/pymongo-test/venv/lib/python3.11/site-packages/pymongo/srv_resolver.py", line 121, in get_hosts  
    _, nodes = self._get_srv_response_and_hosts(True)  
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  
  File "/Users/user/Workspace/tmp/pymongo-test/venv/lib/python3.11/site-packages/pymongo/srv_resolver.py", line 115, in _get_srv_response_and_hosts  
    raise ConfigurationError(f"Invalid SRV host: {node[0]}")  
pymongo.errors.ConfigurationError: Invalid SRV host: mongodb-r.jeongmu-rs-b001.mdev-RegionOne.mg.db.***.com
```
It was weird that it only happened with the python driver. 

### Cause 

First, the `uri` in the connection string that I was using contained uppercase letters, and the SRV Records also contained uppercase letters. 
For example, 
- connection string : `mongodb+srv://username:password@mongodb-jeongmu-rs.mdev-RegionOne.mg.db.***.com`
- SRV records : 
 ```shell 
nslookup -type=SRV _mongodb._tcp.mongodb-jeongmu-rs.mdev-RegionOne.mg.db.***.com
Server:         10.28.4.200
Address:        10.28.4.200#53

_mongodb._tcp.mongodb-jeongmu-rs.mdev-regionone.mg.db.***.com service = 1 1 20011 mongodb-r.jeongmu-rs-b001.mdev-RegionOne.mg.db.***.com.
_mongodb._tcp.mongodb-jeongmu-rs.mdev-regionone.mg.db.***.com service = 1 1 20011 mongodb-r.jeongmu-rs-c001.mdev-RegionOne.mg.db.***.com.
_mongodb._tcp.mongodb-jeongmu-rs.mdev-regionone.mg.db.***.com service = 1 1 20011 mongodb-r.jeongmu-rs-c002.mdev-RegionOne.mg.db.***.com.
```

If you look at line 144 of `uri_parser.py`, inside the `parse_host` function, the hostname is converted to lowercase via lower(), but the imported SRV records still contain uppercase letters. 
```python 
# Normalize hostname to lowercase, since DNS is case-insensitive:
# http://tools.ietf.org/html/rfc4343
# This prevents useless rediscovery if "foo.com" is in the seed list but
# "FOO.com" is in the hello response.
return host.lower(), port
```
Therefore, when comparing the fqdn and node at `_get_srv_response_and_hosts`, the fqdn has been changed to lowercase and the node still contains uppercase letters.   
It cause `pymongo.errors.ConfigurationError: Invalid SRV host`. 
