### PR TITLE
PYTHON-3800 Add test for SRV URI with uppercase hostname

### DIFF
--- a/test/test_dns.py
+++ b/test/test_dns.py
@@ -21,7 +21,7 @@ import sys
 
 sys.path[0:0] = [""]
 
-from test import client_context, unittest
+from test import IntegrationTest, client_context, unittest
 from test.utils import wait_until
 
 from pymongo.common import validate_read_preference_tags
@@ -184,6 +184,14 @@ class TestParsingErrors(unittest.TestCase):
             MongoClient,
             "mongodb+srv://[::1]",
         )
+
+
+class TestCaseInsensitive(IntegrationTest):
+    @unittest.skipUnless(_HAVE_DNSPYTHON, "DNS tests require the dnspython module")
+    def test_connect_case_insensitive(self):
+        client = MongoClient("mongodb+srv://TEST1.TEST.BUILD.10GEN.cc/")
+        self.addCleanup(client.close)
+        self.assertGreater(len(client.topology_description.server_descriptions()), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3800

This doesn't fully test to issue but it's a start. What we eventually want is to test the case where the hosts returned in the SRV record have uppercase letters but that will need to wait for https://jira.mongodb.org/browse/DRIVERS-2668. 