### PR TITLE
PYTHON-3824 Optimize BSON encoding of standard Python list and tuples

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -1184,9 +1184,9 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
                 return 0;
             }
             if (is_list) {
-                item_value = PyList_GetItem(value, i);
+                item_value = PyList_GET_ITEM(value, i);
             } else {
-                item_value = PyTuple_GetItem(value, i);
+                item_value = PyTuple_GET_ITEM(value, i);
             }
             if (!item_value) {
                 return 0;

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -859,6 +859,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
     PyObject* new_value = NULL;
     int retval;
     PyObject* uuid_type;
+    int is_list;
     /*
      * Don't use PyObject_IsInstance for our custom types. It causes
      * problems with python sub interpreters. Our custom types should
@@ -1138,8 +1139,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
     } else if (PyDict_Check(value)) {
         *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x03;
         return write_dict(self, buffer, value, check_keys, options, 0);
-    } else if (PyList_Check(value) || PyTuple_Check(value)) {
-        int is_list = PyList_Check(value);
+    } else if ((is_list = PyList_Check(value)) || PyTuple_Check(value)) {
         Py_ssize_t items, i;
         int start_position,
             length_location,
@@ -1188,8 +1188,9 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
             } else {
                 item_value = PyTuple_GetItem(value, i);
             }
-            if (!item_value)
+            if (!item_value) {
                 return 0;
+            }
             if (!write_element_to_buffer(self, buffer, list_type_byte,
                                          item_value, check_keys, options,
                                          0, 0)) {

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -1138,7 +1138,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
     } else if (PyDict_Check(value)) {
         *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x03;
         return write_dict(self, buffer, value, check_keys, options, 0);
-    } else if (PyList_Check(value) || PyTuple_Check(value)) {
+    } else if (PyList_Check(value)) {
         Py_ssize_t items, i;
         int start_position,
             length_location,
@@ -1154,7 +1154,7 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
             return 0;
         }
 
-        if ((items = PySequence_Size(value)) > BSON_MAX_SIZE) {
+        if ((items = PyList_Size(value)) > BSON_MAX_SIZE) {
             PyObject* BSONError = _error("BSONError");
             if (BSONError) {
                 PyErr_SetString(BSONError,
@@ -1179,15 +1179,71 @@ static int _write_element_to_buffer(PyObject* self, buffer_t buffer,
                 return 0;
             }
 
-            if (!(item_value = PySequence_GetItem(value, i)))
+            if (!(item_value = PyList_GetItem(value, i)))
                 return 0;
             if (!write_element_to_buffer(self, buffer, list_type_byte,
                                          item_value, check_keys, options,
                                          0, 0)) {
-                Py_DECREF(item_value);
                 return 0;
             }
-            Py_DECREF(item_value);
+        }
+
+        /* write null byte and fill in length */
+        if (!buffer_write_bytes(buffer, &zero, 1)) {
+            return 0;
+        }
+        length = pymongo_buffer_get_position(buffer) - start_position;
+        buffer_write_int32_at_position(
+            buffer, length_location, (int32_t)length);
+        return 1;
+    } else if (PyTuple_Check(value)) {
+        Py_ssize_t items, i;
+        int start_position,
+            length_location,
+            length;
+        char zero = 0;
+
+        *(pymongo_buffer_get_buffer(buffer) + type_byte) = 0x04;
+        start_position = pymongo_buffer_get_position(buffer);
+
+        /* save space for length */
+        length_location = pymongo_buffer_save_space(buffer, 4);
+        if (length_location == -1) {
+            return 0;
+        }
+
+        if ((items = PyTuple_Size(value)) > BSON_MAX_SIZE) {
+            PyObject* BSONError = _error("BSONError");
+            if (BSONError) {
+                PyErr_SetString(BSONError,
+                                "Too many items to serialize.");
+                Py_DECREF(BSONError);
+            }
+            return 0;
+        }
+        for(i = 0; i < items; i++) {
+            int list_type_byte = pymongo_buffer_save_space(buffer, 1);
+            char name[BUF_SIZE];
+            PyObject* item_value;
+
+            if (list_type_byte == -1) {
+                return 0;
+            }
+            int res = LL2STR(name, (long long)i);
+            if (res == -1) {
+                return 0;
+            }
+            if (!buffer_write_bytes(buffer, name, (int)strlen(name) + 1)) {
+                return 0;
+            }
+
+            if (!(item_value = PyTuple_GetItem(value, i)))
+                return 0;
+            if (!write_element_to_buffer(self, buffer, list_type_byte,
+                                         item_value, check_keys, options,
+                                         0, 0)) {
+                return 0;
+            }
         }
 
         /* write null byte and fill in length */


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3824

Manual testing shows the following results:
before:
```
python -m timeit -s 'from bson import encode;doc={"a": list((["a"], "b") for _ in range(1000))}' 'encode(doc)'
2000 loops, best of 5: 170 usec per loop

python -m timeit -s 'from bson import encode;doc={"a": list(range(1000))}' 'encode(doc)'
10000 loops, best of 5: 38.9 usec per loop
```
after:
```
python -m timeit -s 'from bson import encode;doc={"a": list((["a"], "b") for _ in range(1000))}' 'encode(doc)'
2000 loops, best of 5: 159 usec per loop

python -m timeit -s 'from bson import encode;doc={"a": list(range(1000))}' 'encode(doc)'
10000 loops, best of 5: 38.5 usec per loop
```