### PR TITLE
[bug-fix] Return empty list if server_descriptions do not exist

### DIFF
--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -267,12 +267,18 @@ class TopologyDescription:
     def _apply_local_threshold(self, selection: Optional[Selection]) -> List[ServerDescription]:
         if not selection:
             return []
+    
+        server_descriptions = selection.server_descriptions
+        server_descriptions = [s for s in server_descriptions if s.round_trip_time != None]
+        if not server_descriptions:
+            return []
+        
         # Round trip time in seconds.
         fastest = min(cast(float, s.round_trip_time) for s in selection.server_descriptions)
         threshold = self._topology_settings.local_threshold_ms / 1000.0
         return [
             s
-            for s in selection.server_descriptions
+            for s in server_descriptions
             if (cast(float, s.round_trip_time) - fastest) <= threshold
         ]
 


### PR DESCRIPTION
This PR fixes the following error. This is a part of our CI pipeline (withplum.com)
Unfortunately, almost in every build we encounter this failure. Locally it's difficult to reproduce. 
Here's the Jira ticket from Mongodb https://jira.mongodb.org/browse/PYTHON-1271

```
.venv/lib/python3.9/site-packages/pymongo/database.py:959: in list_collection_names
    return [result["name"] for result in self.list_collections(session=session, **kwargs)]
.venv/lib/python3.9/site-packages/pymongo/database.py:911: in list_collections
    return self.__client._retryable_read(_cmd, read_pref, session)
.venv/lib/python3.9/site-packages/pymongo/_csot.py:105: in csot_wrapper
    return func(self, *args, **kwargs)
.venv/lib/python3.9/site-packages/pymongo/mongo_client.py:1441: in _retryable_read
    server = self._select_server(read_pref, session, address=address)
.venv/lib/python3.9/site-packages/pymongo/mongo_client.py:1257: in _select_server
    server = topology.select_server(server_selector)
.venv/lib/python3.9/site-packages/pymongo/topology.py:272: in select_server
    server = self._select_server(selector, server_selection_timeout, address)
.venv/lib/python3.9/site-packages/pymongo/topology.py:261: in _select_server
    servers = self.select_servers(selector, server_selection_timeout, address)
.venv/lib/python3.9/site-packages/pymongo/topology.py:223: in select_servers
    server_descriptions = self._select_servers_loop(selector, server_timeout, address)
.venv/lib/python3.9/site-packages/pymongo/topology.py:231: in _select_servers_loop
    server_descriptions = self._description.apply_selector(
.venv/lib/python3.9/site-packages/pymongo/topology_description.py:317: in apply_selector
    return self._apply_local_threshold(selection)
.venv/lib/python3.9/site-packages/pymongo/topology_description.py:261: in _apply_local_threshold
    return [
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <list_iterator object at 0x7f562981f5b0>

    return [
>       s for s in selection.server_descriptions if (s.round_trip_time - fastest) <= threshold
    ]
E   TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'

.venv/lib/python3.9/site-packages/pymongo/topology_description.py:262: TypeError
```