### PR TITLE
PYTHON-1744: Clean-Up, remove setdefault on multi/upsert calls

### DIFF
--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -780,12 +780,6 @@ class MatchEvaluatorUtil:
             command = spec.get("command")
             database_name = spec.get("databaseName")
             if command:
-                if actual.command_name == "update":
-                    # TODO: remove this once PYTHON-1744 is done.
-                    # Add upsert and multi fields back into expectations.
-                    for update in command.get("updates", []):
-                        update.setdefault("upsert", False)
-                        update.setdefault("multi", False)
                 self.match_result(command, actual.command)
             if database_name:
                 self.test.assertEqual(database_name, actual.database_name)


### PR DESCRIPTION
Old ticket whereby our tests still mitigated failures by setting "upsert" and "multi" values if unset in order to pass our spec tests. Thankfully, the spec tests now specify the flag `$$unsetOrMatches` which relieves the burden of needing to add in this piece.

## Test Plan
- Passes our tests