### PR TITLE
PYTHON-3951: [Temporary] Skip list search index Unified Tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1214,7 +1214,7 @@ task_groups:
           binary: bash
           add_expansions_to_env: true
           env:
-            MONGODB_VERSION: "7.0"
+            MONGODB_VERSION: "6.0"
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update

--- a/test/test_index_management.py
+++ b/test/test_index_management.py
@@ -214,12 +214,23 @@ class TestSearchIndexProse(unittest.TestCase):
         coll0.drop_search_index("foo")
 
 
-globals().update(
-    generate_test_classes(
-        _TEST_PATH,
-        module=__name__,
+if os.environ.get("TEST_INDEX_MANAGEMENT"):
+    globals().update(
+        generate_test_classes(
+            _TEST_PATH,
+            module=__name__,
+        )
     )
-)
+else:
+
+    class TestIndexManagementUnifiedTests(unittest.TestCase):
+        @classmethod
+        def setUpClass(cls) -> None:
+            raise unittest.SkipTest("Skipping index management pending PYTHON-3951")
+
+        def test_placeholder(self):
+            pass
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Pending blocking changes in [PYTHON-3951](https://jira.mongodb.org/browse/PYTHON-3951), we are skipping the unified tests for test_index_management. 

I've gone ahead and added a conditionally included test to generate in it's place as a placeholder for when this ticket does get closed. 