### PR TITLE
PYTHON-3958 BSON failure - TestDatetimeConversion.test_millis_from_da…

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ extras =
     test
 commands =
     python --version
+    python setup.py build_ext -i
     pytest -v --durations=5 --maxfail=10 {posargs}
 
 [testenv:test-eg]


### PR DESCRIPTION
Resolve by always compiling the C extensions as part of `tox -e test`, adding about 15-20 seconds to each test run. Is this an acceptable tradeoff for ensuring the C extensions are always up to date?