### PR TITLE
PYTHON-3962 Make delimiting slash between hosts and options optional

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,7 @@ Changes in Version 4.6
 ----------------------
 
 PyMongo 4.6 brings a number of improvements including:
+
 - Added the ``serverMonitoringMode`` URI and keyword argument to :class:`~pymongo.mongo_client.MongoClient`.
 - Improved client performance and reduced connection requirements in Function-as-a-service (FaaS)
   environments like AWS Lambda, Google Cloud Functions, and Microsoft Azure Functions.
@@ -22,7 +23,7 @@ PyMongo 4.6 brings a number of improvements including:
     >>> client.t.t.insert_one({})
     InsertOneResult(ObjectId('65319acdd55bb3a27ab5502b'), acknowledged=True)
     >>> client.t.t.insert_many([{} for _ in range(3)])
-    InsertManyResult([ObjectId('65319af2d55bb3a27ab5502c'), ObjectId('65319af2d55bb3a27ab5502d'), ObjectId('65319af2d55bb3a27ab5502e')], acknowledged=True)': [], 'writeConcernErrors': [], 'nInserted': 1, 'nUpserted': 0, 'nMatched': 0, 'nModified': 0, 'nRemoved': 0, 'upserted': []}, acknowledged=True)
+    InsertManyResult([ObjectId('6532f85e826f2b6125d6ce39'), ObjectId('6532f85e826f2b6125d6ce3a'), ObjectId('6532f85e826f2b6125d6ce3b')], acknowledged=True)
 
 - :meth:`~pymongo.uri_parser.parse_uri` now considers the delimiting slash (``/``)
   between hosts and connection options optional. For example,

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,8 +5,28 @@ Changes in Version 4.6
 ----------------------
 
 PyMongo 4.6 brings a number of improvements including:
+- Added the ``serverMonitoringMode`` URI and keyword argument to :class:`~pymongo.mongo_client.MongoClient`.
+- Improved client performance and reduced connection requirements in Function-as-a-service (FaaS)
+  environments like AWS Lambda, Google Cloud Functions, and Microsoft Azure Functions.
 - Added the :attr:`pymongo.monitoring.CommandSucceededEvent.database_name` property.
 - Added the :attr:`pymongo.monitoring.CommandFailedEvent.database_name` property.
+- Allow passing a ``dict`` to sort/create_index/hint.
+- Added :func:`repr` support to the write result classes:
+  :class:`~pymongo.results.BulkWriteResult`,
+  :class:`~pymongo.results.DeleteResult`,
+  :class:`~pymongo.results.InsertManyResult`,
+  :class:`~pymongo.results.InsertOneResult`,
+  :class:`~pymongo.results.UpdateResult`, and
+  :class:`~pymongo.encryption.RewrapManyDataKeyResult`. For example:
+
+    >>> client.t.t.insert_one({})
+    InsertOneResult(ObjectId('65319acdd55bb3a27ab5502b'), acknowledged=True)
+    >>> client.t.t.insert_many([{} for _ in range(3)])
+    InsertManyResult([ObjectId('65319af2d55bb3a27ab5502c'), ObjectId('65319af2d55bb3a27ab5502d'), ObjectId('65319af2d55bb3a27ab5502e')], acknowledged=True)': [], 'writeConcernErrors': [], 'nInserted': 1, 'nUpserted': 0, 'nMatched': 0, 'nModified': 0, 'nRemoved': 0, 'upserted': []}, acknowledged=True)
+
+- :meth:`~pymongo.uri_parser.parse_uri` now considers the delimiting slash (``/``)
+  between hosts and connection options optional. For example,
+  "mongodb://example.com?tls=true" is now a valid URI.
 
 Changes in Version 4.5
 ----------------------

--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -513,7 +513,7 @@ def parse_uri(
     if path_part:
         dbase, _, opts = path_part.partition("?")
     else:
-        # No slash scheme_free, check for sole "?".
+        # There was no slash in scheme_free, check for a sole "?".
         host_part, _, opts = host_part.partition("?")
 
     if dbase:

--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -456,7 +456,11 @@ def parse_uri(
           to their internally-used names. Default: ``True``.
         - `connect_timeout` (optional): The maximum time in milliseconds to
           wait for a response from the DNS server.
-        - 'srv_service_name` (optional): A custom SRV service name
+        - `srv_service_name` (optional): A custom SRV service name
+
+    .. versionchanged:: 4.6
+       The delimiting slash (``/``) between hosts and connection options is now optional.
+       For example, "mongodb://example.com?tls=true" is now a valid URI.
 
     .. versionchanged:: 4.0
        To better follow RFC 3986, unquoted percent signs ("%") are no longer
@@ -506,22 +510,23 @@ def parse_uri(
         host_part = path_part
         path_part = ""
 
-    if not path_part and "?" in host_part:
-        raise InvalidURI("A '/' is required between the host list and any options.")
-
     if path_part:
         dbase, _, opts = path_part.partition("?")
-        if dbase:
-            dbase = unquote_plus(dbase)
-            if "." in dbase:
-                dbase, collection = dbase.split(".", 1)
-            if _BAD_DB_CHARS.search(dbase):
-                raise InvalidURI('Bad database name "%s"' % dbase)
-        else:
-            dbase = None
+    else:
+        # No slash scheme_free, check for sole "?".
+        host_part, _, opts = host_part.partition("?")
 
-        if opts:
-            options.update(split_options(opts, validate, warn, normalize))
+    if dbase:
+        dbase = unquote_plus(dbase)
+        if "." in dbase:
+            dbase, collection = dbase.split(".", 1)
+        if _BAD_DB_CHARS.search(dbase):
+            raise InvalidURI('Bad database name "%s"' % dbase)
+    else:
+        dbase = None
+
+    if opts:
+        options.update(split_options(opts, validate, warn, normalize))
     if srv_service_name is None:
         srv_service_name = options.get("srvServiceName", SRV_SERVICE_NAME)
     if "@" in host_part:

--- a/test/connection_string/test/invalid-uris.json
+++ b/test/connection_string/test/invalid-uris.json
@@ -163,15 +163,6 @@
       "options": null
     },
     {
-      "description": "Missing delimiting slash between hosts and options",
-      "uri": "mongodb://example.com?w=1",
-      "valid": false,
-      "warning": null,
-      "hosts": null,
-      "auth": null,
-      "options": null
-    },
-    {
       "description": "Incomplete key value pair for option",
       "uri": "mongodb://example.com/?w",
       "valid": false,

--- a/test/connection_string/test/valid-options.json
+++ b/test/connection_string/test/valid-options.json
@@ -20,6 +20,23 @@
       "options": {
         "authmechanism": "MONGODB-CR"
       }
+    },
+    {
+      "description": "Missing delimiting slash between hosts and options",
+      "uri": "mongodb://example.com?tls=true",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "tls": true
+      }
     }
   ]
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-3962

Also added some changelog entries that were missing.