### PR TITLE
PYTHON-3968 Fix mockupdb tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -158,8 +158,10 @@ deps =
 extras =
     {[testenv:test]extras}
 passenv = *
+allowlist_externals =
+    {[testenv:test]allowlist_externals}
 commands =
-    {[testenv:test]commands} {posargs} ./test/mockupdb
+    {[testenv:test]commands} ./test/mockupdb
 
 [testenv:manifest]
 deps =


### PR DESCRIPTION
Fixes:
```
[2023/10/31 23:28:46.782] test-mockupdb: commands[1]> .evergreen/check-c-extensions.sh
[2023/10/31 23:28:46.783] test-mockupdb: failed with .evergreen/check-c-extensions.sh (resolves to .evergreen/check-c-extensions.sh) is not allowed, use allowlist_externals to allow it
[2023/10/31 23:28:46.783] .pkg: _exit> python /opt/python/3.7/lib/python3.7/site-packages/pyproject_api/_backend.py True setuptools.build_meta
[2023/10/31 23:28:46.812]   test-mockupdb: FAIL code 1 (13.87 seconds)
[2023/10/31 23:28:46.812]   evaluation failed :( (13.97 seconds)
```