### PR TITLE
PYTHON-4038: Ensure retryable read `OperationFailure`s re-raise exception when 0 or NoneType error code is provided. 

### DIFF
--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -2329,7 +2329,8 @@ class _ClientConnectionRetryable(Generic[T]):
                         # ConnectionFailures do not supply a code property
                         exc_code = getattr(exc, "code", None)
                         if self._is_not_eligible_for_retry() or (
-                            exc_code and exc_code not in helpers._RETRYABLE_ERROR_CODES
+                            isinstance(exc, OperationFailure)
+                            and exc_code not in helpers._RETRYABLE_ERROR_CODES
                         ):
                             raise
                         self._retrying = True

--- a/test/mockupdb/test_cursor.py
+++ b/test/mockupdb/test_cursor.py
@@ -16,11 +16,13 @@
 from __future__ import annotations
 
 import unittest
+from test import PyMongoTestCase
 
 from mockupdb import MockupDB, OpMsg, going
 
 from bson.objectid import ObjectId
 from pymongo import MongoClient
+from pymongo.errors import OperationFailure
 
 
 class TestCursor(unittest.TestCase):
@@ -55,6 +57,32 @@ class TestCursor(unittest.TestCase):
                 self.assertEqual(request.flags, 0, "exhaustAllowed should not be set")
                 cursor_id = 123 if i < 2 else 0
                 request.replies({"cursor": {"id": cursor_id, "nextBatch": [{}]}})
+
+
+class TestNonRetryableErrorCodeCatch(PyMongoTestCase):
+    def _test_fail_on_operation_failure_with_code(self, code):
+        """Test reads on error codes that should not be retried"""
+        server = MockupDB()
+        server.run()
+        self.addCleanup(server.stop)
+        server.autoresponds("ismaster", maxWireVersion=6)
+
+        client = MongoClient(server.uri)
+
+        with going(lambda: server.receives(OpMsg({"find": "collection"})).command_err(code=code)):
+            cursor = client.db.collection.find()
+            with self.assertRaises(OperationFailure) as ctx:
+                cursor.next()
+            self.assertEqual(ctx.exception.code, code)
+
+    def test_fail_on_operation_failure_none(self):
+        self._test_fail_on_operation_failure_with_code(None)
+
+    def test_fail_on_operation_failure_zero(self):
+        self._test_fail_on_operation_failure_with_code(0)
+
+    def test_fail_on_operation_failure_one(self):
+        self._test_fail_on_operation_failure_with_code(1)
 
 
 if __name__ == "__main__":

--- a/test/mockupdb/test_cursor.py
+++ b/test/mockupdb/test_cursor.py
@@ -59,7 +59,7 @@ class TestCursor(unittest.TestCase):
                 request.replies({"cursor": {"id": cursor_id, "nextBatch": [{}]}})
 
 
-class TestNonRetryableErrorCodeCatch(PyMongoTestCase):
+class TestRetryableErrorCodeCatch(PyMongoTestCase):
     def _test_fail_on_operation_failure_with_code(self, code):
         """Test reads on error codes that should not be retried"""
         server = MockupDB()


### PR DESCRIPTION
TICKET: https://jira.mongodb.org/browse/PYTHON-4038

Pymongo is retrying a failed find connection ONCE that has a 0 or NoneType error code. 

This is undesired behavior because if, theoretically, we introduce an error type that does not have an error code but is an instance of an `OperationFailure`, we will mistakenly retry leading to unexpected consequences.

Added 3 tests: 
- Test nonetype case
- Test 0 case 
- Test 1 case
