### PR TITLE
PYTHON-4038 [v4.6]: Ensure retryable read `OperationFailure`s re-raise exception when 0 or NoneType error code is provided.  (#1425)

### DIFF
--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -2329,7 +2329,8 @@ class _ClientConnectionRetryable(Generic[T]):
                         # ConnectionFailures do not supply a code property
                         exc_code = getattr(exc, "code", None)
                         if self._is_not_eligible_for_retry() or (
-                            exc_code and exc_code not in helpers._RETRYABLE_ERROR_CODES
+                            isinstance(exc, OperationFailure)
+                            and exc_code not in helpers._RETRYABLE_ERROR_CODES
                         ):
                             raise
                         self._retrying = True


### PR DESCRIPTION
(cherry picked from commit 0ff6a87438fd9a324a8bfee198f9906183cc51d5)