### PR TITLE
PYTHON-3823 Migrate perf testing to rhel90-dbx-perf-large, Python 3.10.4, MongoDB 6.0.6

### DIFF
--- a/.evergreen/perf.yml
+++ b/.evergreen/perf.yml
@@ -104,6 +104,11 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
+          set -o xtrace
+          echo "python3 version:"
+          python3 --version || true
+          echo "mongodbtoolchain versions:"
+          ls -la /opt/mongodbtoolchain/
           MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update

--- a/.evergreen/perf.yml
+++ b/.evergreen/perf.yml
@@ -67,6 +67,7 @@ functions:
            PROJECT_DIRECTORY: "$PROJECT_DIRECTORY"
            PREPARE_SHELL: |
               set -o errexit
+              export SKIP_LEGACY_SHELL=1
               export DRIVERS_TOOLS="$DRIVERS_TOOLS"
               export MONGO_ORCHESTRATION_HOME="$MONGO_ORCHESTRATION_HOME"
               export MONGODB_BINARIES="$MONGODB_BINARIES"
@@ -109,6 +110,8 @@ functions:
           python3 --version || true
           echo "mongodbtoolchain versions:"
           ls -la /opt/mongodbtoolchain/
+          /opt/mongodbtoolchain/v3/bin/python3 --version
+          /opt/mongodbtoolchain/v4/bin/python3 --version || true
           MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update

--- a/.evergreen/perf.yml
+++ b/.evergreen/perf.yml
@@ -198,34 +198,12 @@ post:
   - func: "cleanup"
 
 tasks:
-    - name: "perf-4.0-standalone"
-      tags: ["perf"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "4.0"
-            TOPOLOGY: "server"
-        - func: "run perf tests"
-        - func: "attach benchmark test results"
-        - func: "send dashboard data"
-
-    - name: "perf-4.4-standalone"
-      tags: ["perf"]
-      commands:
-        - func: "bootstrap mongo-orchestration"
-          vars:
-            VERSION: "4.4"
-            TOPOLOGY: "server"
-        - func: "run perf tests"
-        - func: "attach benchmark test results"
-        - func: "send dashboard data"
-
     - name: "perf-6.0-standalone"
       tags: ["perf"]
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
-            VERSION: "6.0"
+            VERSION: "v6.0-perf"
             TOPOLOGY: "server"
         - func: "run perf tests"
         - func: "attach benchmark test results"
@@ -236,8 +214,6 @@ buildvariants:
 - name: "perf-tests"
   display_name: "Performance Benchmark Tests"
   batchtime: 10080  # 7 days
-  run_on: ubuntu2004-large
+  run_on: rhel90-dbx-perf-large
   tasks:
-     - name: "perf-4.0-standalone"
-     - name: "perf-4.4-standalone"
      - name: "perf-6.0-standalone"

--- a/.evergreen/perf.yml
+++ b/.evergreen/perf.yml
@@ -105,13 +105,6 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          set -o xtrace
-          echo "python3 version:"
-          python3 --version || true
-          echo "mongodbtoolchain versions:"
-          ls -la /opt/mongodbtoolchain/
-          /opt/mongodbtoolchain/v3/bin/python3 --version
-          /opt/mongodbtoolchain/v4/bin/python3 --version || true
           MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update

--- a/.evergreen/run-perf-tests.sh
+++ b/.evergreen/run-perf-tests.sh
@@ -13,6 +13,11 @@ cd ..
 export TEST_PATH="${PROJECT_DIRECTORY}/driver-performance-test-data"
 export OUTPUT_FILE="${PROJECT_DIRECTORY}/results.json"
 
+echo "python3 version:"
+python3 --version || true
+echo "mongodbtoolchain versions:"
+ls -la /opt/mongodbtoolchain/
+
 export PYTHON_BINARY=/opt/mongodbtoolchain/v3/bin/python3
 export PERF_TEST=1
 

--- a/.evergreen/run-perf-tests.sh
+++ b/.evergreen/run-perf-tests.sh
@@ -13,11 +13,6 @@ cd ..
 export TEST_PATH="${PROJECT_DIRECTORY}/driver-performance-test-data"
 export OUTPUT_FILE="${PROJECT_DIRECTORY}/results.json"
 
-echo "python3 version:"
-python3 --version || true
-echo "mongodbtoolchain versions:"
-ls -la /opt/mongodbtoolchain/
-
 export PYTHON_BINARY=/opt/mongodbtoolchain/v3/bin/python3
 export PERF_TEST=1
 

--- a/.evergreen/run-perf-tests.sh
+++ b/.evergreen/run-perf-tests.sh
@@ -13,7 +13,7 @@ cd ..
 export TEST_PATH="${PROJECT_DIRECTORY}/driver-performance-test-data"
 export OUTPUT_FILE="${PROJECT_DIRECTORY}/results.json"
 
-export PYTHON_BINARY=/opt/mongodbtoolchain/v3/bin/python3
+export PYTHON_BINARY=/opt/mongodbtoolchain/v4/bin/python3
 export PERF_TEST=1
 
 bash ./.evergreen/tox.sh -m test-eg


### PR DESCRIPTION
[PYTHON-3823](https://jira.mongodb.org/browse/PYTHON-3823) Migrate perf testing to rhel90-dbx-perf-large, Python 3.10.4, MongoDB 6.0.6.