### PR TITLE
PYTHON-4043 Add changelog entry for 4.6.1

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Changes in Version 4.6.1
+------------------------
+
+PyMongo 4.6.1 fixes the following bug:
+
+- Ensure retryable read ``OperationFailure`` errors re-raise exception when 0 or NoneType error code is provided.
+
 Changes in Version 4.6
 ----------------------
 


### PR DESCRIPTION
I will backport to the v4.6 branch as well.