### PR TITLE
PYTHON-3823 Audit benchmark data_size and calculate dynamically it where possible

### DIFF
--- a/test/performance/perf_test.py
+++ b/test/performance/perf_test.py
@@ -86,7 +86,9 @@ class PerformanceTest:
         name = self.__class__.__name__[4:]
         median = self.percentile(50)
         megabytes_per_sec = self.data_size / median / 1000000
-        print(f"Running {self.__class__.__name__}. MEDIAN={self.percentile(50)}")
+        print(
+            f"Running {self.__class__.__name__}. MB/s={megabytes_per_sec}, MEDIAN={self.percentile(50)}"
+        )
         result_data.append(
             {
                 "info": {


### PR DESCRIPTION
[PYTHON-3823](https://jira.mongodb.org/browse/PYTHON-3823) While working on this project I realized that almost all of the data_sizes were incorrect. Instead of hardcoding them I decided to dynamically calculate the data size where it was straightforward to do so.

For example:
- TestDeepEncoding/Decoding the data size is actually 19660000, not 19640000.
- TestFlatEncoding/Decoding the data size is actually 60460000, not 75310000.
- TestFullEncoding/Decoding the data size is actually 40260000, not 57340000.
- TestFindOneByID/TestFindManyAndEmptyCursor the data size is actually 15310000, not 16220000.
- TestSmallDocInsertOne/TestSmallDocBulkInsert the data size is actually 2500000, not 2750000.
- TestLargeDocInsertOne/TestLargeDocBulkInsert the data size is actually 25000640, not 27310890.
- etc...

This will make the perf results more accurate.