### PR TITLE
PYTHON-4055 Add xunit-results to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ test/lambda/env.json
 test/lambda/mongodb/pymongo/*
 test/lambda/mongodb/gridfs/*
 test/lambda/mongodb/bson/*
+
+# test results in Evergreen compatible XUnit XML
+xunit-results/

--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,14 @@ build/
 doc/_build/
 dist/
 tools/settings.py
+drivers-evergreen-tools
 pymongo.egg-info/
 *.so
-*.egg
+*.egg*
 .tox
 mongocryptd.pid
 .idea/
+.vscode/
 .nova/
 venv/
 secrets-export.sh
@@ -26,5 +28,6 @@ test/lambda/mongodb/pymongo/*
 test/lambda/mongodb/gridfs/*
 test/lambda/mongodb/bson/*
 
-# test results in Evergreen compatible XUnit XML
+# test results and logs
 xunit-results/
+server.log


### PR DESCRIPTION
One line change to `.gitignore`. xunit-results/ and test/xunit-results/ can be safely ignored. I imagine everyone has some hack to ignore them already. It's nice to be able to `git add .` :)