### PR TITLE
PYTHON-4072 Add test decorator turning off test.test_database.TestDat…

### DIFF
--- a/test/test_database.py
+++ b/test/test_database.py
@@ -375,6 +375,7 @@ class TestDatabase(IntegrationTest):
         self.assertTrue(db.validate_collection(db.test, True, True))
 
     @client_context.require_version_min(4, 3, 3)
+    @client_context.require_no_standalone
     def test_validate_collection_background(self):
         db = self.client.pymongo_test
         db.test.insert_one({"dummy": "object"})


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/PYTHON-4072

Summary:
Recent changes from the server team changed how the client kwarg "background" was treated. Specifically, this option is not intended to be used in standalone mode so they added a validation of this. 

Changes required:
Adding decorator to toggle off in standalone mode
@client_context.require_no_standalone