### PR TITLE
PYTHON-4070 Add setuptools as dep for test target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,8 @@ labels = # Use labels and -m instead of -e so that tox -m <label> fails instantl
 description = run base set of unit tests with no extra functionality
 extras =
     test
+deps =
+    setuptools
 allowlist_externals =
     .evergreen/check-c-extensions.sh
 commands =


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4070

If not configured correctly, tox fails to find setuptools, and thus cannot run core commands like `tox -m test`.  I could reproduce this a couple ways - using pipx and using brew. Adding setuptools as a dependency in tox.ini sidesteps any further setup work and confusion. No need to change onboarding docs either.