### PR TITLE
PYTHON-1366 About DocumentTooLarge - insert_one case

### DIFF
--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -855,7 +855,7 @@ class TestCollection(IntegrationTest):
         half_str = "x" * half_size
         self.assertEqual(max_size, 16777216)
 
-        self.assertRaises(OperationFailure, self.db.test.insert_one, {"foo": max_str})
+        self.assertRaises(DocumentTooLarge, self.db.test.insert_one, {"foo": max_str})
         self.assertRaises(
             OperationFailure, self.db.test.replace_one, {}, {"foo": max_str}, upsert=True
         )


### PR DESCRIPTION
This PR handles the first case of https://jira.mongodb.org/browse/PYTHON-1366 - insert_one(large_doc)
We no longer raise an Operation error if the document is larger than the document size limit but under the command size limit. 
