### PR TITLE
PYTHON-4077 Make sure to upload release wheel for python 3.7 on macos…

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -12,7 +12,7 @@ stepback: true
 # Actual testing tasks are marked with `type: test`
 command_type: system
 
-# Protect ourself against rogue test case, or curl gone wild, that runs forever
+# Protect ourselves against rogue test case, or curl gone wild, that runs forever
 # Good rule of thumb: the averageish length a task takes, times 5
 # That roughly accounts for variable system performance for various buildvariants
 exec_timeout_secs: 3600 # 60 minutes is the longest we'll ever run (primarily
@@ -1154,6 +1154,7 @@ tasks:
         - func: "build release"
           vars:
               VERSION: "3.7"
+        - func: "upload release"
 
     - name: "release-windows"
       tags: ["release_tag"]


### PR DESCRIPTION
During a conversation about changes in universal wheel support in MacOS after Python 3.7, we discovered that we hadn't published 3.7 wheels for MacOS since 4.4.0. We have manually built and uploaded the missing versions. This PR fixes the mistake made in the refactor in .evergreen/config.yml.

Going forward, we will be using Github Actions for release because it supports trusted publishing. See .github/workflows/release-python.yml.