### PR TITLE
PYTHON-4103 Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # PyMongo
 
-See [the mongo site](http://www.mongodb.org) for more information.
-See [GitHub](http://github.com/mongodb/mongo-python-driver) for the
-latest source.
-
-Documentation: available at [pymongo.readthedocs.io](https://pymongo.readthedocs.io/en/stable/)
-Author: The MongoDB Python Team
+[![PyPI Version](https://img.shields.io/pypi/v/pymongo)](https://pypi.org/project/pymongo)
+[![Python Versions](https://img.shields.io/pypi/pyversions/pymongo)](https://pypi.org/project/pymongo)
+[![Monthly Downloads](https://static.pepy.tech/badge/pymongo/month)](https://pepy.tech/project/pymongo)
+[![Documentation Status](https://readthedocs.org/projects/pymongo/badge/?version=stable)](http://pymongo.readthedocs.io/en/stable/?badge=stable)
 
 ## About
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,10 @@ zstd = [
 test = ["pytest>=7"]
 
 [project.urls]
-Homepage = "http://github.com/mongodb/mongo-python-driver"
+Homepage = "https://pymongo.readthedocs.io"
+Documentation = "https://pymongo.readthedocs.io"
+Source = "https://github.com/mongodb/pymongo"
+Tracker = "https://jira.mongodb.org/projects/PYTHON/issues"
 
 [tool.setuptools.dynamic]
 version = {attr = "pymongo._version.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ zstd = [
 test = ["pytest>=7"]
 
 [project.urls]
-Homepage = "https://pymongo.readthedocs.io"
+Homepage = "https://www.mongodb.org"
 Documentation = "https://pymongo.readthedocs.io"
 Source = "https://github.com/mongodb/pymongo"
 Tracker = "https://jira.mongodb.org/projects/PYTHON/issues"


### PR DESCRIPTION
Also updates the Project [URLs](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls) that will be rendered on PyPI since we're removing a couple links from the readme.