### PR TITLE
PYTHON-4016 making ReadConcernMajorityNotAvailableYet a retryable error

### DIFF
--- a/pymongo/helpers.py
+++ b/pymongo/helpers.py
@@ -83,6 +83,7 @@ _RETRYABLE_ERROR_CODES: frozenset = _NOT_PRIMARY_CODES | frozenset(
         89,  # NetworkTimeout
         9001,  # SocketException
         262,  # ExceededTimeLimit
+        134,  # ReadConcernMajorityNotAvailableYet
     ]
 )
 

--- a/test/retryable_reads/unified/readConcernMajorityNotAvailableYet.json
+++ b/test/retryable_reads/unified/readConcernMajorityNotAvailableYet.json
@@ -1,0 +1,147 @@
+{
+  "description": "ReadConcernMajorityNotAvailableYet is a retryable read",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-reads-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "readconcernmajoritynotavailableyet_test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "readconcernmajoritynotavailableyet_test",
+      "databaseName": "retryable-reads-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Find succeeds on second attempt after ReadConcernMajorityNotAvailableYet",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 134
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            }
+          },
+          "object": "collection0",
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "readconcernmajoritynotavailableyet_test",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "readconcernmajoritynotavailableyet_test",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_retryable_reads_unified.py
+++ b/test/test_retryable_reads_unified.py
@@ -15,8 +15,8 @@
 """Test the Retryable Reads unified spec tests."""
 from __future__ import annotations
 
-import os
 import sys
+from pathlib import Path
 
 sys.path[0:0] = [""]
 
@@ -24,7 +24,7 @@ from test import unittest
 from test.unified_format import generate_test_classes
 
 # Location of JSON test specifications.
-TEST_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "retryable_reads", "unified")
+TEST_PATH = Path(__file__).parent / "retryable_reads/unified"
 
 # Generate unified tests.
 globals().update(generate_test_classes(TEST_PATH, module=__name__))


### PR DESCRIPTION
Follows [DRIVERS-926](https://jira.mongodb.org/browse/DRIVERS-926). See JIRA(s) for details.