### PR TITLE
PYTHON-4143 Optimize JSON encoding of int, float, str, and None

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -920,6 +920,8 @@ def default(obj: Any, json_options: JSONOptions = DEFAULT_JSON_OPTIONS) -> Any:
                 # original value, when float() is called on it.
                 return {"$numberDouble": str(repr(obj))}
         return obj
+    elif isinstance(obj, str):
+        return obj
     elif isinstance(obj, datetime.datetime):
         if json_options.datetime_representation == DatetimeRepresentation.ISO8601:
             if not obj.tzinfo:

--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -902,6 +902,24 @@ def default(obj: Any, json_options: JSONOptions = DEFAULT_JSON_OPTIONS) -> Any:
             return _encoders[type_marker](obj, json_options)  # type: ignore[no-untyped-call]
         except KeyError:
             raise TypeError("%r is not JSON serializable" % obj) from None
+    elif isinstance(obj, int):
+        if json_options.json_mode == JSONMode.CANONICAL:
+            if -(2**31) <= obj < 2**31:
+                return {"$numberInt": str(obj)}
+            return {"$numberLong": str(obj)}
+        return obj
+    elif isinstance(obj, float):
+        if json_options.json_mode != JSONMode.LEGACY:
+            if math.isnan(obj):
+                return {"$numberDouble": "NaN"}
+            elif math.isinf(obj):
+                representation = "Infinity" if obj > 0 else "-Infinity"
+                return {"$numberDouble": representation}
+            elif json_options.json_mode == JSONMode.CANONICAL:
+                # repr() will return the shortest string guaranteed to produce the
+                # original value, when float() is called on it.
+                return {"$numberDouble": str(repr(obj))}
+        return obj
     elif isinstance(obj, datetime.datetime):
         if json_options.datetime_representation == DatetimeRepresentation.ISO8601:
             if not obj.tzinfo:
@@ -931,18 +949,4 @@ def default(obj: Any, json_options: JSONOptions = DEFAULT_JSON_OPTIONS) -> Any:
             return _encode_binary(binval, binval.subtype, json_options)
         else:
             return {"$uuid": obj.hex}
-    elif json_options.json_mode == JSONMode.CANONICAL and isinstance(obj, int):
-        if -(2**31) <= obj < 2**31:
-            return {"$numberInt": str(obj)}
-        return {"$numberLong": str(obj)}
-    elif json_options.json_mode != JSONMode.LEGACY and isinstance(obj, float):
-        if math.isnan(obj):
-            return {"$numberDouble": "NaN"}
-        elif math.isinf(obj):
-            representation = "Infinity" if obj > 0 else "-Infinity"
-            return {"$numberDouble": representation}
-        elif json_options.json_mode == JSONMode.CANONICAL:
-            # repr() will return the shortest string guaranteed to produce the
-            # original value, when float() is called on it.
-            return {"$numberDouble": str(repr(obj))}
     raise TypeError("%r is not JSON serializable" % obj)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4143

Explanation:
Previously, when our default() method would encounter an object of type int, float, str, or None it would go through every isintance if/else check, reach the bottom, raise a TypeError, then `_json_convert` would catch the TypeError and return the object. This is extremely wasteful and it's much faster to simply return the object when we know it's one of these types.