### PR TITLE
PYTHON-4155 Run perf tests with TLS enabled

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2149,6 +2149,18 @@ tasks:
         - func: "attach benchmark test results"
         - func: "send dashboard data"
 
+    - name: "perf-6.0-standalone-ssl"
+      tags: ["perf"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            VERSION: "v6.0-perf"
+            TOPOLOGY: "server"
+            SSL: "ssl"
+        - func: "run perf tests"
+        - func: "attach benchmark test results"
+        - func: "send dashboard data"
+
 axes:
   # Choice of distro
   - id: platform
@@ -3118,6 +3130,7 @@ buildvariants:
   run_on: rhel90-dbx-perf-large
   tasks:
      - name: "perf-6.0-standalone"
+     - name: "perf-6.0-standalone-ssl"
 
       # Platform notes
       # i386 builds of OpenSSL or Cyrus SASL are not available

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -281,6 +281,8 @@ class ClientContext:
     def client_options(self):
         """Return the MongoClient options for creating a duplicate client."""
         opts = client_context.default_client_options.copy()
+        opts["host"] = host
+        opts["port"] = port
         if client_context.auth_enabled:
             opts["username"] = db_user
             opts["password"] = db_pwd

--- a/test/performance/perf_test.py
+++ b/test/performance/perf_test.py
@@ -431,13 +431,10 @@ def insert_json_file_with_file_id(filename):
 def read_json_file(filename):
     assert proc_client is not None
     coll = proc_client.perftest.corpus
-    temp = tempfile.TemporaryFile(mode="w")
-    try:
-        temp.writelines(
-            [json.dumps(doc) + "\n" for doc in coll.find({"file": filename}, {"_id": False})]
-        )
-    finally:
-        temp.close()
+    with tempfile.TemporaryFile(mode="w") as temp:
+        for doc in coll.find({"file": filename}, {"_id": False}):
+            temp.write(json.dumps(doc))
+            temp.write("\n")
 
 
 def insert_gridfs_file(filename):
@@ -460,24 +457,22 @@ def read_gridfs_file(filename):
 
 
 class TestJsonMultiImport(PerformanceTest, unittest.TestCase):
-    data_size = 565000000
-
     def setUp(self):
         self.client = client_context.client
         self.client.drop_database("perftest")
+        ldjson_path = os.path.join(TEST_PATH, os.path.join("parallel", "ldjson_multi"))
+        self.files = [os.path.join(ldjson_path, s) for s in os.listdir(ldjson_path)]
+        self.data_size = sum(os.path.getsize(fname) for fname in self.files)
+        self.corpus = self.client.perftest.corpus
 
     def before(self):
         self.client.perftest.command({"create": "corpus"})
-        self.corpus = self.client.perftest.corpus
-
-        ldjson_path = os.path.join(TEST_PATH, os.path.join("parallel", "ldjson_multi"))
-        self.files = [os.path.join(ldjson_path, s) for s in os.listdir(ldjson_path)]
 
     def do_task(self):
         self.mp_map(insert_json_file, self.files)
 
     def after(self):
-        self.client.perftest.drop_collection("corpus")
+        self.corpus.drop()
 
     def tearDown(self):
         super().tearDown()
@@ -485,8 +480,6 @@ class TestJsonMultiImport(PerformanceTest, unittest.TestCase):
 
 
 class TestJsonMultiExport(PerformanceTest, unittest.TestCase):
-    data_size = 565000000
-
     def setUp(self):
         self.client = client_context.client
         self.client.drop_database("perftest")
@@ -494,6 +487,7 @@ class TestJsonMultiExport(PerformanceTest, unittest.TestCase):
 
         ldjson_path = os.path.join(TEST_PATH, os.path.join("parallel", "ldjson_multi"))
         self.files = [os.path.join(ldjson_path, s) for s in os.listdir(ldjson_path)]
+        self.data_size = sum(os.path.getsize(fname) for fname in self.files)
 
         self.mp_map(insert_json_file_with_file_id, self.files)
 

--- a/test/test_read_preferences.py
+++ b/test/test_read_preferences.py
@@ -321,7 +321,6 @@ class TestCommandAndReadPreference(IntegrationTest):
     def setUpClass(cls):
         super().setUpClass()
         cls.c = ReadPrefTester(
-            client_context.pair,
             # Ignore round trip times, to test ReadPreference modes only.
             localThresholdMS=1000 * 1000,
         )


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4155

https://spruce.mongodb.com/task/mongo_python_driver_perf_tests_perf_6.0_standalone_ssl_patch_c4e4bd638f7b82032cbd13b8e56a7593b56e964c_65aafe9ad1fe07c55152cba2_24_01_19_22_58_36/trend-charts?execution=0&sortBy=STATUS&sortDir=ASC 

Results:
test | no-ssl MB/s | ssl MB/s | diff %
-- | -- | -- | --
GridFsMultiFileDownload | 2241.312311 | 1390.521729 | -37.95948373
GridFsMultiFileUpload | 587.071831 | 560.0242854 | -4.607195274
JsonMultiExport | 81.56780701 | 79.51976841 | -2.510841797
JsonMultiImport | 243.055593 | 235.5447564 | -3.090172317
GridFsDownload | 609.4982366 | 393.7977959 | -35.38983836
GridFsUpload | 338.6111882 | 252.5824448 | -25.40634992
LargeDocBulkInsert | 104.5846324 | 94.05588566 | -10.06720249
SmallDocBulkInsert | 38.57742683 | 36.75833318 | -4.715435437
FindManyAndEmptyCursor | 79.79403695 | 72.12921893 | -9.605752902
LargeDocInsertOne | 108.6530608 | 97.18336995 | -10.55625194
SmallDocInsertOne | 0.9305379959 | 0.8202515162 | -11.85190504
FindOneByID | 4.519436183 | 4.045484225 | -10.4869709
RunCommand | 0.06646477592 | 0.05744304515 | -13.57370222
JsonFullDecoding | 14.00451737 | 13.99241453 | -0.08642095437
JsonFullEncoding | 18.12583891 | 18.12102029 | -0.02658429293
JsonDeepDecoding | 25.22142509 | 25.51211066 | 1.152534255
JsonDeepEncoding | 19.38661823 | 19.28966083 | -0.5001253715
JsonFlatDecoding | 41.44312456 | 41.76845546 | 0.7850057197
JsonFlatEncoding | 43.07909727 | 42.41985537 | -1.530305754
FullDecoding | 96.65824687 | 96.77898807 | 0.1249155678
FullEncoding | 191.7291776 | 193.9694708 | 1.168467563
DeepDecoding | 99.65225822 | 99.30337922 | -0.3500964374
DeepEncoding | 118.9012259 | 115.178514 | -3.130928127
FlatDecoding | 280.1459854 | 276.2744521 | -1.381969956
FlatEncoding | 317.2246289 | 321.0129116 | 1.194195641

