### PR TITLE
PYTHON-4158 Fix typo in create_index docstring

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -2003,7 +2003,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         Takes either a single key or a list containing (key, direction) pairs
         or keys.  If no direction is given, :data:`~pymongo.ASCENDING` will
         be assumed.
-        The key(s) must be an instance of :class:`str`and the direction(s) must
+        The key(s) must be an instance of :class:`str` and the direction(s) must
         be one of (:data:`~pymongo.ASCENDING`, :data:`~pymongo.DESCENDING`,
         :data:`~pymongo.GEO2D`, :data:`~pymongo.GEOSPHERE`,
         :data:`~pymongo.HASHED`, :data:`~pymongo.TEXT`).


### PR DESCRIPTION
change a minuscule typo which formats a code part in the docs wrong

![image](https://github.com/mongodb/mongo-python-driver/assets/13679272/f611832c-01f2-46e6-be32-01b48c7e9e32)

basically adds one space. I know it is a small change but it bothered me ;) 