### PR TITLE
PYTHON-4112 Support named KMS providers

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -157,7 +157,7 @@ if [ -n "$TEST_ENCRYPTION" ] || [ -n "$TEST_FLE_AZURE_AUTO" ] || [ -n "$TEST_FLE
     export PYMONGOCRYPT_LIB
 
     # TODO: Test with 'pip install pymongocrypt'
-    git clone https://github.com/ShaneHarvey/libmongocrypt.git --branch PYTHON-4112 libmongocrypt_git
+    git clone https://github.com/mongodb/libmongocrypt.git libmongocrypt_git
     python -m pip install --prefer-binary -r .evergreen/test-encryption-requirements.txt
     python -m pip install ./libmongocrypt_git/bindings/python
     python -c "import pymongocrypt; print('pymongocrypt version: '+pymongocrypt.__version__)"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -157,7 +157,7 @@ if [ -n "$TEST_ENCRYPTION" ] || [ -n "$TEST_FLE_AZURE_AUTO" ] || [ -n "$TEST_FLE
     export PYMONGOCRYPT_LIB
 
     # TODO: Test with 'pip install pymongocrypt'
-    git clone https://github.com/mongodb/libmongocrypt.git libmongocrypt_git
+    git clone https://github.com/ShaneHarvey/libmongocrypt.git --branch PYTHON-4112 libmongocrypt_git
     python -m pip install --prefer-binary -r .evergreen/test-encryption-requirements.txt
     python -m pip install ./libmongocrypt_git/bindings/python
     python -c "import pymongocrypt; print('pymongocrypt version: '+pymongocrypt.__version__)"

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,6 +14,12 @@ PyMongo 4.7 brings a number of improvements including:
 - Replaced usage of :class:`bson.son.SON` on all internal classes and commands to dict,
   :attr:`options.pool_options.metadata` is now of type ``dict`` as opposed to :class:`bson.son.SON`.
 - Significantly improved the performance of encoding BSON documents to JSON.
+- Support for named KMS providers for client side field level encryption.
+  Previously supported KMS providers were only: aws, azure, gcp, kmip, and local.
+  The KMS provider is now expanded to support name suffixes (e.g. local:myname).
+  Named KMS providers enables more than one of each KMS provider type to be configured.
+  See the docstring for :class:`~pymongo.encryption_options.AutoEncryptionOpts`.
+  Note that named KMS providers requires pymongocrypt >=1.9 and libmongocrypt >=1.9.
 - Fixed a bug where :class:`~bson.int64.Int64` instances could not always be encoded by `orjson`_. The following now
   works::
 

--- a/doc/examples/encryption.rst
+++ b/doc/examples/encryption.rst
@@ -125,8 +125,8 @@ examples show how to setup automatic client-side field level encryption
 using :class:`~pymongo.encryption.ClientEncryption` to create a new
 encryption data key.
 
-.. note:: Automatic client-side field level encryption requires MongoDB 4.2
-   enterprise or a MongoDB 4.2 Atlas cluster. The community version of the
+.. note:: Automatic client-side field level encryption requires MongoDB >=4.2
+   enterprise or a MongoDB >=4.2 Atlas cluster. The community version of the
    server supports automatic decryption as well as
    :ref:`explicit-client-side-encryption`.
 
@@ -255,7 +255,7 @@ will result in an error.
 Server-Side Field Level Encryption Enforcement
 ``````````````````````````````````````````````
 
-The MongoDB 4.2 server supports using schema validation to enforce encryption
+MongoDB >=4.2 servers supports using schema validation to enforce encryption
 of specific fields in a collection. This schema validation will prevent an
 application from inserting unencrypted values for any fields marked with the
 ``"encrypt"`` JSON schema keyword.
@@ -457,8 +457,8 @@ Explicit encryption is a MongoDB community feature and does not use the
 Explicit Encryption with Automatic Decryption
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Although automatic encryption requires MongoDB 4.2 enterprise or a
-MongoDB 4.2 Atlas cluster, automatic *decryption* is supported for all users.
+Although automatic encryption requires MongoDB >=4.2 enterprise or a
+MongoDB >=4.2 Atlas cluster, automatic *decryption* is supported for all users.
 To configure automatic *decryption* without automatic *encryption* set
 ``bypass_auto_encryption=True`` in
 :class:`~pymongo.encryption_options.AutoEncryptionOpts`:

--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -101,7 +101,7 @@ def _wrap_encryption_errors() -> Iterator[None]:
         # we should propagate them unchanged.
         raise
     except Exception as exc:
-        raise EncryptionError(exc) from None
+        raise EncryptionError(exc) from exc
 
 
 class _EncryptionIO(MongoCryptCallback):  # type: ignore[misc]

--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -520,6 +520,9 @@ class ClientEncryption(Generic[_DocumentType]):
                 data keys. This key should be generated and stored as securely
                 as possible.
 
+            KMS providers may be specified with an optional name suffix
+            separated by a colon, for example "kmip:name" or "aws:name".
+            Named KMS providers do not support :ref:`CSFLE on-demand credentials`.
         :param key_vault_namespace: The namespace for the key vault collection.
             The key vault collection contains all data keys used for encryption
             and decryption. Data keys are stored as documents in this MongoDB
@@ -674,12 +677,13 @@ class ClientEncryption(Generic[_DocumentType]):
         """Create and insert a new data key into the key vault collection.
 
         :param kms_provider: The KMS provider to use. Supported values are
-            "aws", "azure", "gcp", "kmip", and "local".
+            "aws", "azure", "gcp", "kmip", "local", or a named provider like
+            "kmip:name".
         :param master_key: Identifies a KMS-specific key used to encrypt the
             new data key. If the kmsProvider is "local" the `master_key` is
             not applicable and may be omitted.
 
-            If the `kms_provider` is "aws" it is required and has the
+            If the `kms_provider` type is "aws" it is required and has the
             following fields::
 
               - `region` (string): Required. The AWS region, e.g. "us-east-1".
@@ -689,7 +693,7 @@ class ClientEncryption(Generic[_DocumentType]):
                 requests to. May include port number, e.g.
                 "kms.us-east-1.amazonaws.com:443".
 
-            If the `kms_provider` is "azure" it is required and has the
+            If the `kms_provider` type is "azure" it is required and has the
             following fields::
 
               - `keyVaultEndpoint` (string): Required. Host with optional
@@ -697,7 +701,7 @@ class ClientEncryption(Generic[_DocumentType]):
               - `keyName` (string): Required. Key name in the key vault.
               - `keyVersion` (string): Optional. Version of the key to use.
 
-            If the `kms_provider` is "gcp" it is required and has the
+            If the `kms_provider` type is "gcp" it is required and has the
             following fields::
 
               - `projectId` (string): Required. The Google cloud project ID.
@@ -709,7 +713,7 @@ class ClientEncryption(Generic[_DocumentType]):
               - `endpoint` (string): Optional. Host with optional port.
                 Defaults to "cloudkms.googleapis.com".
 
-            If the `kms_provider` is "kmip" it is optional and has the
+            If the `kms_provider` type is "kmip" it is optional and has the
             following fields::
 
               - `keyId` (string): Optional. `keyId` is the KMIP Unique

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -97,6 +97,14 @@ class AutoEncryptionOpts:
             KMS providers may be specified with an optional name suffix
             separated by a colon, for example "kmip:name" or "aws:name".
             Named KMS providers do not support :ref:`CSFLE on-demand credentials`.
+            Named KMS providers enables more than one of each KMS provider type to be configured.
+            For example, to configure multiple local KMS providers::
+
+              kms_providers = {
+                  "local": {"key": local_kek1},        # Unnamed KMS provider.
+                  "local:myname": {"key": local_kek2}, # Named KMS provider with name "myname".
+              }
+
         :param key_vault_namespace: The namespace for the key vault collection.
             The key vault collection contains all data keys used for encryption
             and decryption. Data keys are stored as documents in this MongoDB

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -55,13 +55,13 @@ class AutoEncryptionOpts:
     ) -> None:
         """Options to configure automatic client-side field level encryption.
 
-        Automatic client-side field level encryption requires MongoDB 4.2
-        enterprise or a MongoDB 4.2 Atlas cluster. Automatic encryption is not
+        Automatic client-side field level encryption requires MongoDB >=4.2
+        enterprise or a MongoDB >=4.2 Atlas cluster. Automatic encryption is not
         supported for operations on a database or view and will result in
         error.
 
-        Although automatic encryption requires MongoDB 4.2 enterprise or a
-        MongoDB 4.2 Atlas cluster, automatic *decryption* is supported for all
+        Although automatic encryption requires MongoDB >=4.2 enterprise or a
+        MongoDB >=4.2 Atlas cluster, automatic *decryption* is supported for all
         users. To configure automatic *decryption* without automatic
         *encryption* set ``bypass_auto_encryption=True``. Explicit
         encryption and explicit decryption is also supported for all users
@@ -94,12 +94,15 @@ class AutoEncryptionOpts:
                 data keys. This key should be generated and stored as securely
                 as possible.
 
+            KMS providers may be specified with an optional name suffix
+            separated by a colon, for example "kmip:name" or "aws:name".
+            Named KMS providers do not support :ref:`CSFLE on-demand credentials`.
         :param key_vault_namespace: The namespace for the key vault collection.
             The key vault collection contains all data keys used for encryption
             and decryption. Data keys are stored as documents in this MongoDB
             collection. Data keys are protected with encryption by a KMS
             provider.
-        :param key_vault_client: By default the key vault collection
+        :param key_vault_client: By default, the key vault collection
             is assumed to reside in the same MongoDB cluster as the encrypted
             MongoClient. Use this option to route data key queries to a
             separate MongoDB cluster.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -113,6 +113,10 @@ AWS_CREDS = {
     "accessKeyId": os.environ.get("FLE_AWS_KEY", ""),
     "secretAccessKey": os.environ.get("FLE_AWS_SECRET", ""),
 }
+AWS_CREDS_2 = {
+    "accessKeyId": os.environ.get("FLE_AWS_KEY2", ""),
+    "secretAccessKey": os.environ.get("FLE_AWS_SECRET2", ""),
+}
 AZURE_CREDS = {
     "tenantId": os.environ.get("FLE_AZURE_TENANTID", ""),
     "clientId": os.environ.get("FLE_AZURE_CLIENTID", ""),

--- a/test/client-side-encryption/spec/legacy/fle2v2-BypassQueryAnalysis.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-BypassQueryAnalysis.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Compact.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Compact.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-CreateCollection-OldServer.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-CreateCollection-OldServer.json
@@ -55,6 +55,38 @@
           "result": {
             "errorContains": "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
           }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
         }
       ]
     }

--- a/test/client-side-encryption/spec/legacy/fle2v2-CreateCollection.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-CreateCollection.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-DecryptExistingData.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-DecryptExistingData.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Delete.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-EncryptedFields-vs-jsonSchema.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-EncryptedFields-vs-jsonSchema.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-EncryptedFieldsMap-defaults.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-EncryptedFieldsMap-defaults.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-FindOneAndUpdate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-InsertFind-Indexed.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-InsertFind-Indexed.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-MissingKey.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-MissingKey.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-NoEncryption.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-NoEncryption.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-Correctness.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-Delete.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-Update.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Date-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-Update.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Decimal-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-Correctness.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-Delete.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-Update.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Double-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-Correctness.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-Delete.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-Update.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Int-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-Correctness.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-Delete.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-Update.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-Long-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Range-WrongType.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Range-WrongType.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-Update.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/fle2v2-validatorAndPartialFieldExpression.json
+++ b/test/client-side-encryption/spec/legacy/fle2v2-validatorAndPartialFieldExpression.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/client-side-encryption/spec/legacy/getMore.json
+++ b/test/client-side-encryption/spec/legacy/getMore.json
@@ -216,7 +216,10 @@
           "command_started_event": {
             "command": {
               "getMore": {
-                "$$type": "long"
+                "$$type": [
+                  "int",
+                  "long"
+                ]
               },
               "collection": "default",
               "batchSize": 2

--- a/test/client-side-encryption/spec/legacy/namedKMS.json
+++ b/test/client-side-encryption/spec/legacy/namedKMS.json
@@ -1,89 +1,73 @@
 {
   "runOn": [
     {
-      "minServerVersion": "7.0.0",
-      "topology": [
-        "replicaset",
-        "sharded",
-        "load-balanced"
-      ]
+      "minServerVersion": "4.1.10"
     }
   ],
   "database_name": "default",
   "collection_name": "default",
   "data": [],
-  "encrypted_fields": {
-    "fields": [
-      {
-        "keyId": {
-          "$binary": {
-            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
-            "subType": "04"
-          }
-        },
-        "path": "encryptedIndexed",
-        "bsonType": "string",
-        "queries": {
-          "queryType": "equality",
-          "contention": {
-            "$numberLong": "0"
-          }
+  "json_schema": {
+    "properties": {
+      "encrypted_string": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "local+name2+AAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
         }
-      },
-      {
-        "keyId": {
-          "$binary": {
-            "base64": "q83vqxI0mHYSNBI0VniQEg==",
-            "subType": "04"
-          }
-        },
-        "path": "encryptedUnindexed",
-        "bsonType": "string"
       }
-    ]
+    },
+    "bsonType": "object"
   },
   "key_vault_data": [
     {
       "_id": {
         "$binary": {
-          "base64": "q83vqxI0mHYSNBI0VniQEg==",
+          "base64": "local+name2+AAAAAAAAAA==",
           "subType": "04"
         }
       },
       "keyMaterial": {
         "$binary": {
-          "base64": "HBk9BWihXExNDvTp1lUxOuxuZK2Pe2ZdVdlsxPEBkiO1bS4mG5NNDsQ7zVxJAH8BtdOYp72Ku4Y3nwc0BUpIKsvAKX4eYXtlhv5zUQxWdeNFhg9qK7qb8nqhnnLeT0f25jFSqzWJoT379hfwDeu0bebJHr35QrJ8myZdPMTEDYF08QYQ48ShRBli0S+QzBHHAQiM2iJNr4svg2WR8JSeWQ==",
+          "base64": "DX3iUuOlBsx6wBX9UZ3v/qXk1HNeBace2J+h/JwsDdF/vmSXLZ1l1VmZYIcpVFy6ODhdbzLjd4pNgg9wcm4etYig62KNkmtZ0/s1tAL5VsuW/s7/3PYnYGznZTFhLjIVcOH/RNoRj2eQb/sRTyivL85wePEpAU/JzuBj6qO9Y5txQgs1k0J3aNy10R9aQ8kC1NuSSpLAIXwE6DlNDDJXhw==",
           "subType": "00"
         }
       },
       "creationDate": {
         "$date": {
-          "$numberLong": "1648914851981"
+          "$numberLong": "1552949630483"
         }
       },
       "updateDate": {
         "$date": {
-          "$numberLong": "1648914851981"
+          "$numberLong": "1552949630483"
         }
       },
       "status": {
         "$numberInt": "0"
       },
       "masterKey": {
-        "provider": "local"
+        "provider": "local:name2"
       }
     }
   ],
   "tests": [
     {
-      "description": "Insert and find FLE2 unindexed field",
+      "description": "Automatically encrypt and decrypt with a named KMS provider",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {
-            "local": {
+            "local:name2": {
               "key": {
                 "$binary": {
-                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "base64": "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
                   "subType": "00"
                 }
               }
@@ -97,7 +81,7 @@
           "arguments": {
             "document": {
               "_id": 1,
-              "encryptedUnindexed": "value123"
+              "encrypted_string": "string0"
             }
           }
         },
@@ -111,7 +95,7 @@
           "result": [
             {
               "_id": 1,
-              "encryptedUnindexed": "value123"
+              "encrypted_string": "string0"
             }
           ]
         }
@@ -139,7 +123,7 @@
                       "$in": [
                         {
                           "$binary": {
-                            "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                            "base64": "local+name2+AAAAAAAAAA==",
                             "subType": "04"
                           }
                         }
@@ -168,8 +152,11 @@
               "documents": [
                 {
                   "_id": 1,
-                  "encryptedUnindexed": {
-                    "$$type": "binData"
+                  "encrypted_string": {
+                    "$binary": {
+                      "base64": "AZaHGpfp2pntvgAAAAAAAAAC07sFvTQ0I4O2U49hpr4HezaK44Ivluzv5ntQBTYHDlAJMLyRMyB6Dl+UGHBgqhHe/Xw+pcT9XdiUoOJYAx9g+w==",
+                      "subType": "06"
+                    }
                   }
                 }
               ],
@@ -183,9 +170,7 @@
             "command": {
               "find": "default",
               "filter": {
-                "_id": {
-                  "$eq": 1
-                }
+                "_id": 1
               }
             },
             "command_name": "find"
@@ -197,52 +182,16 @@
           "data": [
             {
               "_id": 1,
-              "encryptedUnindexed": {
-                "$$type": "binData"
+              "encrypted_string": {
+                "$binary": {
+                  "base64": "AZaHGpfp2pntvgAAAAAAAAAC07sFvTQ0I4O2U49hpr4HezaK44Ivluzv5ntQBTYHDlAJMLyRMyB6Dl+UGHBgqhHe/Xw+pcT9XdiUoOJYAx9g+w==",
+                  "subType": "06"
+                }
               }
             }
           ]
         }
       }
-    },
-    {
-      "description": "Query with an unindexed field fails",
-      "clientOptions": {
-        "autoEncryptOpts": {
-          "kmsProviders": {
-            "local": {
-              "key": {
-                "$binary": {
-                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
-                  "subType": "00"
-                }
-              }
-            }
-          }
-        }
-      },
-      "operations": [
-        {
-          "name": "insertOne",
-          "arguments": {
-            "document": {
-              "_id": 1,
-              "encryptedUnindexed": "value123"
-            }
-          }
-        },
-        {
-          "name": "find",
-          "arguments": {
-            "filter": {
-              "encryptedUnindexed": "value123"
-            }
-          },
-          "result": {
-            "errorContains": "encrypt"
-          }
-        }
-      ]
     }
   ]
 }

--- a/test/client-side-encryption/spec/unified/namedKMS-createDataKey.json
+++ b/test/client-side-encryption/spec/unified/namedKMS-createDataKey.json
@@ -1,0 +1,396 @@
+{
+  "description": "namedKMS-createDataKey",
+  "schemaVersion": "1.18",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws:name1": {
+              "accessKeyId": {
+                "$$placeholder": 1
+              },
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            },
+            "azure:name1": {
+              "tenantId": {
+                "$$placeholder": 1
+              },
+              "clientId": {
+                "$$placeholder": 1
+              },
+              "clientSecret": {
+                "$$placeholder": 1
+              }
+            },
+            "gcp:name1": {
+              "email": {
+                "$$placeholder": 1
+              },
+              "privateKey": {
+                "$$placeholder": 1
+              }
+            },
+            "kmip:name1": {
+              "endpoint": {
+                "$$placeholder": 1
+              }
+            },
+            "local:name1": {
+              "key": {
+                "$$placeholder": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "keyvault"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "datakeys"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "create data key with named AWS KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "aws:name1",
+            "opts": {
+              "masterKey": {
+                "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+                "region": "us-east-1"
+              }
+            }
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "aws:name1",
+                        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+                        "region": "us-east-1"
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create datakey with named Azure KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "azure:name1",
+            "opts": {
+              "masterKey": {
+                "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                "keyName": "key-name-csfle"
+              }
+            }
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "azure:name1",
+                        "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                        "keyName": "key-name-csfle"
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create datakey with named GCP KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "gcp:name1",
+            "opts": {
+              "masterKey": {
+                "projectId": "devprod-drivers",
+                "location": "global",
+                "keyRing": "key-ring-csfle",
+                "keyName": "key-name-csfle"
+              }
+            }
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "gcp:name1",
+                        "projectId": "devprod-drivers",
+                        "location": "global",
+                        "keyRing": "key-ring-csfle",
+                        "keyName": "key-name-csfle"
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create datakey with named KMIP KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "kmip:name1"
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "kmip:name1",
+                        "keyId": {
+                          "$$type": "string"
+                        }
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create datakey with named local KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "local:name1"
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "local:name1"
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/client-side-encryption/spec/unified/namedKMS-explicit.json
+++ b/test/client-side-encryption/spec/unified/namedKMS-explicit.json
@@ -1,0 +1,130 @@
+{
+  "description": "namedKMS-explicit",
+  "schemaVersion": "1.18",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "local:name2": {
+              "key": "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
+            }
+          }
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "keyvault"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "datakeys"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": [
+        {
+          "_id": {
+            "$binary": {
+              "base64": "local+name2+AAAAAAAAAA==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "local:name2"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "DX3iUuOlBsx6wBX9UZ3v/qXk1HNeBace2J+h/JwsDdF/vmSXLZ1l1VmZYIcpVFy6ODhdbzLjd4pNgg9wcm4etYig62KNkmtZ0/s1tAL5VsuW/s7/3PYnYGznZTFhLjIVcOH/RNoRj2eQb/sRTyivL85wePEpAU/JzuBj6qO9Y5txQgs1k0J3aNy10R9aQ8kC1NuSSpLAIXwE6DlNDDJXhw==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1552949630483"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1552949630483"
+            }
+          },
+          "status": {
+            "$numberInt": "0"
+          },
+          "masterKey": {
+            "provider": "local:name2"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "can explicitly encrypt with a named KMS provider",
+      "operations": [
+        {
+          "name": "encrypt",
+          "object": "clientEncryption0",
+          "arguments": {
+            "value": "foobar",
+            "opts": {
+              "keyAltName": "local:name2",
+              "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+          },
+          "expectResult": {
+            "$binary": {
+              "base64": "AZaHGpfp2pntvgAAAAAAAAAC4yX2LTAuN253GAkEO2ZXp4GpCyM7yoVNJMQQl+6uzxMs03IprLC7DL2vr18x9LwOimjTS9YbMJhrnFkEPuNhbg==",
+              "subType": "06"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "can explicitly decrypt with a named KMS provider",
+      "operations": [
+        {
+          "name": "decrypt",
+          "object": "clientEncryption0",
+          "arguments": {
+            "value": {
+              "$binary": {
+                "base64": "AZaHGpfp2pntvgAAAAAAAAAC4yX2LTAuN253GAkEO2ZXp4GpCyM7yoVNJMQQl+6uzxMs03IprLC7DL2vr18x9LwOimjTS9YbMJhrnFkEPuNhbg==",
+                "subType": "06"
+              }
+            }
+          },
+          "expectResult": "foobar"
+        }
+      ]
+    }
+  ]
+}

--- a/test/client-side-encryption/spec/unified/namedKMS-rewrapManyDataKey.json
+++ b/test/client-side-encryption/spec/unified/namedKMS-rewrapManyDataKey.json
@@ -1,0 +1,1385 @@
+{
+  "description": "namedKMS-rewrapManyDataKey",
+  "schemaVersion": "1.18",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws:name1": {
+              "accessKeyId": {
+                "$$placeholder": 1
+              },
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            },
+            "azure:name1": {
+              "tenantId": {
+                "$$placeholder": 1
+              },
+              "clientId": {
+                "$$placeholder": 1
+              },
+              "clientSecret": {
+                "$$placeholder": 1
+              }
+            },
+            "gcp:name1": {
+              "email": {
+                "$$placeholder": 1
+              },
+              "privateKey": {
+                "$$placeholder": 1
+              }
+            },
+            "kmip:name1": {
+              "endpoint": {
+                "$$placeholder": 1
+              }
+            },
+            "local:name1": {
+              "key": {
+                "$$placeholder": 1
+              }
+            },
+            "local:name2": {
+              "key": "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
+            },
+            "aws:name2": {
+              "accessKeyId": {
+                "$$placeholder": 1
+              },
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "keyvault"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "datakeys"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": [
+        {
+          "_id": {
+            "$binary": {
+              "base64": "YXdzYXdzYXdzYXdzYXdzYQ==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "aws:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gFXJqbF0Fy872MD7xl56D/2AAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDO7HPisPUlGzaio9vgIBEIB7/Qow46PMh/8JbEUbdXgTGhLfXPE+KIVW7T8s6YEMlGiRvMu7TV0QCIUJlSHPKZxzlJ2iwuz5yXeOag+EdY+eIQ0RKrsJ3b8UTisZYzGjfzZnxUKLzLoeXremtRCm3x47wCuHKd1dhh6FBbYt5TL2tDaj+vL2GBrKat2L",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "aws:name1",
+            "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+            "region": "us-east-1"
+          }
+        },
+        {
+          "_id": {
+            "$binary": {
+              "base64": "YXp1cmVhenVyZWF6dXJlYQ==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "azure:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "azure:name1",
+            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+            "keyName": "key-name-csfle"
+          }
+        },
+        {
+          "_id": {
+            "$binary": {
+              "base64": "Z2NwZ2NwZ2NwZ2NwZ2NwZw==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "gcp:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "CiQAIgLj0USbQtof/pYRLQO96yg/JEtZbD1UxKueaC37yzT5tTkSiQEAhClWB5ZCSgzHgxv8raWjNB4r7e8ePGdsmSuYTYmLC5oHHS/BdQisConzNKFaobEQZHamTCjyhy5NotKF8MWoo+dyfQApwI29+vAGyrUIQCXzKwRnNdNQ+lb3vJtS5bqvLTvSxKHpVca2kqyC9nhonV+u4qru5Q2bAqUgVFc8fL4pBuvlowZFTQ==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "gcp:name1",
+            "projectId": "devprod-drivers",
+            "location": "global",
+            "keyRing": "key-ring-csfle",
+            "keyName": "key-name-csfle"
+          }
+        },
+        {
+          "_id": {
+            "$binary": {
+              "base64": "a21pcGttaXBrbWlwa21pcA==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "kmip:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "kmip:name1",
+            "keyId": "1"
+          }
+        },
+        {
+          "_id": {
+            "$binary": {
+              "base64": "bG9jYWxrZXlsb2NhbGtleQ==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [
+            "local:name1_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "ABKBldDEoDW323yejOnIRk6YQmlD9d3eQthd16scKL75nz2LjNL9fgPDZWrFFOlqlhMCFaSrNJfGrFUjYk5JFDO7soG5Syb50k1niJoKg4ilsj0L4mpimFUtTpOr2nzZOeQtvAksEXc7gsFgq8gV7t/U3lsaXPY7I0t42DfSE8EGlPdxRjFdHnxh+OR8h7U9b8Qs5K5UuhgyeyxaBZ1Hgw==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "local:name1"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "rewrap to aws:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "aws:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "aws:name1",
+              "masterKey": {
+                "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                "region": "us-east-1"
+              }
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "aws:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name1",
+                            "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name1",
+                            "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name1",
+                            "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name1",
+                            "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap to azure:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "azure:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "azure:name1",
+              "masterKey": {
+                "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                "keyName": "key-name-csfle"
+              }
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "azure:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "azure:name1",
+                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "azure:name1",
+                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "azure:name1",
+                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "azure:name1",
+                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap to gcp:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "gcp:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "gcp:name1",
+              "masterKey": {
+                "projectId": "devprod-drivers",
+                "location": "global",
+                "keyRing": "key-ring-csfle",
+                "keyName": "key-name-csfle"
+              }
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "gcp:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "gcp:name1",
+                            "projectId": "devprod-drivers",
+                            "location": "global",
+                            "keyRing": "key-ring-csfle",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "gcp:name1",
+                            "projectId": "devprod-drivers",
+                            "location": "global",
+                            "keyRing": "key-ring-csfle",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "gcp:name1",
+                            "projectId": "devprod-drivers",
+                            "location": "global",
+                            "keyRing": "key-ring-csfle",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "gcp:name1",
+                            "projectId": "devprod-drivers",
+                            "location": "global",
+                            "keyRing": "key-ring-csfle",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap to kmip:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "kmip:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "kmip:name1"
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "kmip:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip:name1",
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip:name1",
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip:name1",
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip:name1",
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap to local:name1",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "local:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "local:name1"
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 4,
+              "modifiedCount": 4,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "local:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap from local:name1 to local:name2",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$eq": "local:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "local:name2"
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 1,
+              "modifiedCount": 1,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$eq": "local:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local:name2"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap from aws:name1 to aws:name2",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$eq": "aws:name1_key"
+              }
+            },
+            "opts": {
+              "provider": "aws:name2",
+              "masterKey": {
+                "key": "arn:aws:kms:us-east-1:857654397073:key/0f8468f0-f135-4226-aa0b-bd05c4c30df5",
+                "region": "us-east-1"
+              }
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 1,
+              "modifiedCount": 1,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$eq": "aws:name1_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws:name2",
+                            "key": "arn:aws:kms:us-east-1:857654397073:key/0f8468f0-f135-4226-aa0b-bd05c4c30df5",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/clientEncryptionOpts-kmsProviders-invalidName.json
+++ b/test/unified-test-format/invalid/clientEncryptionOpts-kmsProviders-invalidName.json
@@ -1,0 +1,29 @@
+{
+  "description": "clientEncryptionOpts-kmsProviders-invalidName",
+  "schemaVersion": "1.18",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws:name_with_invalid_character*": {}
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/test/unified-test-format/invalid/expectedError-errorResponse-type.json
+++ b/test/unified-test-format/invalid/expectedError-errorResponse-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorResponse-type",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorResponse": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/entity-commandCursor.json
+++ b/test/unified-test-format/valid-pass/entity-commandCursor.json
@@ -1,0 +1,278 @@
+{
+  "description": "entity-commandCursor",
+  "schemaVersion": "1.3",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "db",
+        "client": "client",
+        "databaseName": "db"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "db",
+        "collectionName": "collection"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection",
+      "databaseName": "db",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        },
+        {
+          "_id": 5,
+          "x": 55
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "runCursorCommand creates and exhausts cursor by running getMores",
+      "operations": [
+        {
+          "name": "runCursorCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "batchSize": 2,
+            "command": {
+              "find": "collection",
+              "filter": {},
+              "batchSize": 2
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "collection",
+                  "filter": {},
+                  "batchSize": 2,
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection",
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection",
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "createCommandCursor creates a cursor and stores it as an entity that can be iterated one document at a time",
+      "operations": [
+        {
+          "name": "createCommandCursor",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "batchSize": 2,
+            "command": {
+              "find": "collection",
+              "filter": {},
+              "batchSize": 2
+            }
+          },
+          "saveResultAsEntity": "myRunCommandCursor"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "myRunCommandCursor",
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "myRunCommandCursor",
+          "expectResult": {
+            "_id": 2,
+            "x": 22
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "myRunCommandCursor",
+          "expectResult": {
+            "_id": 3,
+            "x": 33
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "myRunCommandCursor",
+          "expectResult": {
+            "_id": 4,
+            "x": 44
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "myRunCommandCursor",
+          "expectResult": {
+            "_id": 5,
+            "x": 55
+          }
+        }
+      ]
+    },
+    {
+      "description": "createCommandCursor's cursor can be closed and will perform a killCursors operation",
+      "operations": [
+        {
+          "name": "createCommandCursor",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "batchSize": 2,
+            "command": {
+              "find": "collection",
+              "filter": {},
+              "batchSize": 2
+            }
+          },
+          "saveResultAsEntity": "myRunCommandCursor"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "myRunCommandCursor",
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        },
+        {
+          "name": "close",
+          "object": "myRunCommandCursor"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "collection",
+                  "filter": {},
+                  "batchSize": 2,
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "killCursors": "collection",
+                  "cursors": {
+                    "$$type": "array"
+                  }
+                },
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/expectedError-errorResponse.json
+++ b/test/unified-test-format/valid-pass/expectedError-errorResponse.json
@@ -1,0 +1,70 @@
+{
+  "description": "expectedError-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Unsupported command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "unsupportedCommand",
+            "command": {
+              "unsupportedCommand": 1
+            }
+          },
+          "expectError": {
+            "errorResponse": {
+              "errmsg": {
+                "$$type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Unsupported query operator",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "$unsupportedQueryOperator": 1
+            }
+          },
+          "expectError": {
+            "errorResponse": {
+              "errmsg": {
+                "$$type": "string"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1056,8 +1056,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         expect_result = spec.get("expectResult")
         error_response = spec.get("errorResponse")
         if error_response:
-            for k in error_response.keys():
-                self.assertEqual(error_response[k], exception.details[k])
+            self.match_evaluator.match_result(error_response, exception.details)
 
         if is_error:
             # already satisfied because exception was raised

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -140,7 +140,13 @@ KMS_TLS_OPTS = {
 
 
 # Build up a placeholder map.
-PLACEHOLDER_MAP = {"key": LOCAL_MASTER_KEY, **AWS_CREDS, **AZURE_CREDS, **GCP_CREDS, **KMIP_CREDS}
+PLACEHOLDER_MAP: Dict[str, Any] = {
+    "key": LOCAL_MASTER_KEY,
+    **AWS_CREDS,
+    **AZURE_CREDS,
+    **GCP_CREDS,
+    **KMIP_CREDS,
+}
 
 
 def interrupt_loop():

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -527,12 +527,18 @@ class EntityMapUtil:
             opts = camel_to_snake_args(spec["clientEncryptionOpts"].copy())
             if isinstance(opts["key_vault_client"], str):
                 opts["key_vault_client"] = self[opts["key_vault_client"]]
+            # Set TLS options for providers like "kmip:name1".
+            kms_tls_options = {}
+            for provider in opts["kms_providers"]:
+                provider_type = provider.split(":")[0]
+                if provider_type in KMS_TLS_OPTS:
+                    kms_tls_options[provider] = KMS_TLS_OPTS[provider_type]
             self[spec["id"]] = ClientEncryption(
                 opts["kms_providers"],
                 opts["key_vault_namespace"],
                 opts["key_vault_client"],
                 DEFAULT_CODEC_OPTIONS,
-                opts.get("kms_tls_options", KMS_TLS_OPTS),
+                opts.get("kms_tls_options", kms_tls_options),
             )
             return
         elif entity_type == "thread":


### PR DESCRIPTION
[PYTHON-4112](https://jira.mongodb.org/browse/PYTHON-4112) implements the tests and documentation for named KMS providers added in  https://github.com/mongodb/specifications/pull/1492.

Note that there are actually no driver changes here, only tests and documentation. So even pymongo 4.6 users can take advantage of the named KMS provider feature as long as they upgrade to pymongocrypt >=1.9. This pymongocrypt PR unblocks use of named providers: https://github.com/mongodb/libmongocrypt/pull/739