### PR TITLE
PYTHON-4112 Revert to testing with pymongocrypt@master

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -138,7 +138,9 @@ if [ -n "$TEST_ENCRYPTION" ] || [ -n "$TEST_FLE_AZURE_AUTO" ] || [ -n "$TEST_FLE
     export PYMONGOCRYPT_LIB
 
     # TODO: Test with 'pip install pymongocrypt'
-    git clone https://github.com/mongodb/libmongocrypt.git libmongocrypt_git
+    if [ ! -d "libmongocrypt_git" ]; then
+      git clone https://github.com/mongodb/libmongocrypt.git libmongocrypt_git
+    fi
     python -m pip install ./libmongocrypt_git/bindings/python
     python -c "import pymongocrypt; print('pymongocrypt version: '+pymongocrypt.__version__)"
     python -c "import pymongocrypt; print('libmongocrypt version: '+pymongocrypt.libmongocrypt_version())"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -136,6 +136,11 @@ if [ -n "$TEST_ENCRYPTION" ] || [ -n "$TEST_FLE_AZURE_AUTO" ] || [ -n "$TEST_FLE
         exit 1
     fi
     export PYMONGOCRYPT_LIB
+
+    # TODO: Test with 'pip install pymongocrypt'
+    git clone https://github.com/mongodb/libmongocrypt.git libmongocrypt_git
+    python -m pip install --prefer-binary -r .evergreen/test-encryption-requirements.txt
+    python -m pip install ./libmongocrypt_git/bindings/python
     python -c "import pymongocrypt; print('pymongocrypt version: '+pymongocrypt.__version__)"
     python -c "import pymongocrypt; print('libmongocrypt version: '+pymongocrypt.libmongocrypt_version())"
     # PATH is updated by PREPARE_SHELL for access to mongocryptd.

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -139,7 +139,6 @@ if [ -n "$TEST_ENCRYPTION" ] || [ -n "$TEST_FLE_AZURE_AUTO" ] || [ -n "$TEST_FLE
 
     # TODO: Test with 'pip install pymongocrypt'
     git clone https://github.com/mongodb/libmongocrypt.git libmongocrypt_git
-    python -m pip install --prefer-binary -r .evergreen/test-encryption-requirements.txt
     python -m pip install ./libmongocrypt_git/bindings/python
     python -c "import pymongocrypt; print('pymongocrypt version: '+pymongocrypt.__version__)"
     python -c "import pymongocrypt; print('libmongocrypt version: '+pymongocrypt.libmongocrypt_version())"

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -2024,7 +2024,7 @@ class TestKmsTLSProse(EncryptionIntegrationTest):
         # Some examples:
         # certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'. (_ssl.c:1129)"
         # hostname '127.0.0.1' doesn't match 'wronghost.com'
-        # 127.0.0.1:8001: ('Certificate does not contain any `subjectAltName`s.',)
+        # 127.0.0.1:9001: ('Certificate does not contain any `subjectAltName`s.',)
         with self.assertRaisesRegex(
             EncryptionError, "IP address mismatch|wronghost|IPAddressMismatch|Certificate"
         ):
@@ -2093,12 +2093,12 @@ class TestKmsTLSOptions(EncryptionIntegrationTest):
         # 4, Test named KMS providers.
         providers = {
             "aws:no_client_cert": AWS_CREDS,
-            "azure:no_client_cert": {"identityPlatformEndpoint": "127.0.0.1:8002", **AZURE_CREDS},
-            "gcp:no_client_cert": {"endpoint": "127.0.0.1:8002", **GCP_CREDS},
+            "azure:no_client_cert": {"identityPlatformEndpoint": "127.0.0.1:9002", **AZURE_CREDS},
+            "gcp:no_client_cert": {"endpoint": "127.0.0.1:9002", **GCP_CREDS},
             "kmip:no_client_cert": KMIP_CREDS,
             "aws:with_tls": AWS_CREDS,
-            "azure:with_tls": {"identityPlatformEndpoint": "127.0.0.1:8002", **AZURE_CREDS},
-            "gcp:with_tls": {"endpoint": "127.0.0.1:8002", **GCP_CREDS},
+            "azure:with_tls": {"identityPlatformEndpoint": "127.0.0.1:9002", **AZURE_CREDS},
+            "gcp:with_tls": {"endpoint": "127.0.0.1:9002", **GCP_CREDS},
             "kmip:with_tls": KMIP_CREDS,
         }
         no_cert = {"tlsCAFile": CA_PEM}
@@ -2137,7 +2137,7 @@ class TestKmsTLSOptions(EncryptionIntegrationTest):
         # Some examples:
         # certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'. (_ssl.c:1129)"
         # hostname '127.0.0.1' doesn't match 'wronghost.com'
-        # 127.0.0.1:8001: ('Certificate does not contain any `subjectAltName`s.',)
+        # 127.0.0.1:9001: ('Certificate does not contain any `subjectAltName`s.',)
         key["endpoint"] = "127.0.0.1:9001"
         with self.assertRaisesRegex(
             EncryptionError, "IP address mismatch|wronghost|IPAddressMismatch|Certificate"
@@ -2208,7 +2208,7 @@ class TestKmsTLSOptions(EncryptionIntegrationTest):
         key = {
             "region": "us-east-1",
             "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
-            "endpoint": "127.0.0.1:8002",
+            "endpoint": "127.0.0.1:9002",
         }
         # Missing client cert error.
         with self.assertRaisesRegex(EncryptionError, self.cert_error):


### PR DESCRIPTION
Fixes these failures:
```
 [2024/01/30 13:28:18.641] test/unified_format.py:1722: in run_scenario
 [2024/01/30 13:28:18.641]     self._run_scenario(spec, uri)
 [2024/01/30 13:28:18.641] test/unified_format.py:1747: in _run_scenario
 [2024/01/30 13:28:18.641]     self.run_operations(spec["operations"])
 [2024/01/30 13:28:18.641] test/unified_format.py:1656: in run_operations
 [2024/01/30 13:28:18.641]     self.run_entity_operation(op)
 [2024/01/30 13:28:18.641] test/unified_format.py:1398: in run_entity_operation
 [2024/01/30 13:28:18.641]     result = cmd(**dict(arguments))
 [2024/01/30 13:28:18.641] /opt/python/pypy3.10/lib/pypy3.10/functools.py:303: in __call__
 [2024/01/30 13:28:18.641]     return self.func(*self.args, *args, **keywords)
 [2024/01/30 13:28:18.641] test/unified_format.py:1278: in _clientEncryptionOperation_createDataKey
 [2024/01/30 13:28:18.641]     return target.create_data_key(*args, **kwargs)
 [2024/01/30 13:28:18.641] pymongo/encryption.py:747: in create_data_key
 [2024/01/30 13:28:18.641]     with _wrap_encryption_errors():
 [2024/01/30 13:28:18.641] /opt/python/pypy3.10/lib/pypy3.10/contextlib.py:153: in __exit__
 [2024/01/30 13:28:18.641]     self.gen.throw(typ, value, traceback)
 [2024/01/30 13:28:18.641] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 [2024/01/30 13:28:18.641]     @contextlib.contextmanager
 [2024/01/30 13:28:18.641]     def _wrap_encryption_errors() -> Iterator[None]:
 [2024/01/30 13:28:18.641]         """Context manager to wrap encryption related errors."""
 [2024/01/30 13:28:18.641]         try:
 [2024/01/30 13:28:18.641]             yield
 [2024/01/30 13:28:18.641]         except BSONError:
 [2024/01/30 13:28:18.641]             # BSON encoding/decoding errors are unrelated to encryption so
 [2024/01/30 13:28:18.641]             # we should propagate them unchanged.
 [2024/01/30 13:28:18.641]             raise
 [2024/01/30 13:28:18.641]         except Exception as exc:
 [2024/01/30 13:28:18.641] >           raise EncryptionError(exc) from exc
 [2024/01/30 13:28:18.642] E           pymongo.errors.EncryptionError: unknown kms_provider: aws:name1
 [2024/01/30 13:28:18.642] pymongo/encryption.py:104: EncryptionError
 [2024/01/30 13:28:18.642] _ TestUnifiedNamedKMSCreateDataKey.test_create_datakey_with_named_Azure_KMS_provider _
 [2024/01/30 13:28:18.642]     @contextlib.contextmanager
 [2024/01/30 13:28:18.642]     def _wrap_encryption_errors() -> Iterator[None]:
 [2024/01/30 13:28:18.642]         """Context manager to wrap encryption related errors."""
 [2024/01/30 13:28:18.642]         try:
 [2024/01/30 13:28:18.642] >           yield
 [2024/01/30 13:28:18.642] pymongo/encryption.py:98:
```
https://spruce.mongodb.com/task/mongo_python_driver_tests_python_version_rhel8_test_encryption__platform~rhel8_auth_ssl~noauth_nossl_python_version~3.7_encryption~encryption_test_4.2_replica_set_0615df47b5251dc718ef91b24da3efb95d7b4f6f_24_01_30_20_00_24?execution=0&sortBy=STATUS&sortDir=ASC