### PR TITLE
PYTHON-2267: Allow UUID key_id to be passed to ClientEncryption.encrypt

### DIFF
--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -766,7 +766,7 @@ class ClientEncryption(Generic[_DocumentType]):
     ) -> Any:
         self._check_closed()
         if isinstance(key_id, uuid.UUID):
-            key_id = Binary(key_id.bytes, UUID_SUBTYPE)
+            key_id = Binary.from_uuid(key_id)
         if key_id is not None and not (
             isinstance(key_id, Binary) and key_id.subtype == UUID_SUBTYPE
         ):

--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -826,6 +826,9 @@ class ClientEncryption(Generic[_DocumentType]):
 
         :return: The encrypted value, a :class:`~bson.binary.Binary` with subtype 6.
 
+        .. versionchanged:: 4.7
+            ``key_id`` can now be passed in as a :class:`uuid.UUID`.
+
         .. versionchanged:: 4.2
            Added the `query_type` and `contention_factor` parameters.
         """
@@ -874,6 +877,9 @@ class ClientEncryption(Generic[_DocumentType]):
         :param range_opts: Experimental only, not intended for public use.
 
         :return: The encrypted expression, a :class:`~bson.RawBSONDocument`.
+
+        .. versionchanged:: 4.7
+            ``key_id`` can now be passed in as a :class:`uuid.UUID`.
 
         .. versionadded:: 4.4
         """

--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextlib
 import enum
 import socket
+import uuid
 import weakref
 from copy import deepcopy
 from typing import (
@@ -30,6 +31,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Union,
     cast,
 )
 
@@ -755,7 +757,7 @@ class ClientEncryption(Generic[_DocumentType]):
         self,
         value: Any,
         algorithm: str,
-        key_id: Optional[Binary] = None,
+        key_id: Optional[Union[Binary, uuid.UUID]] = None,
         key_alt_name: Optional[str] = None,
         query_type: Optional[str] = None,
         contention_factor: Optional[int] = None,
@@ -763,6 +765,8 @@ class ClientEncryption(Generic[_DocumentType]):
         is_expression: bool = False,
     ) -> Any:
         self._check_closed()
+        if isinstance(key_id, uuid.UUID):
+            key_id = Binary(key_id.bytes, UUID_SUBTYPE)
         if key_id is not None and not (
             isinstance(key_id, Binary) and key_id.subtype == UUID_SUBTYPE
         ):
@@ -795,7 +799,7 @@ class ClientEncryption(Generic[_DocumentType]):
         self,
         value: Any,
         algorithm: str,
-        key_id: Optional[Binary] = None,
+        key_id: Optional[Union[Binary, uuid.UUID]] = None,
         key_alt_name: Optional[str] = None,
         query_type: Optional[str] = None,
         contention_factor: Optional[int] = None,
@@ -843,7 +847,7 @@ class ClientEncryption(Generic[_DocumentType]):
         self,
         expression: Mapping[str, Any],
         algorithm: str,
-        key_id: Optional[Binary] = None,
+        key_id: Optional[Union[Binary, uuid.UUID]] = None,
         key_alt_name: Optional[str] = None,
         query_type: Optional[str] = None,
         contention_factor: Optional[int] = None,

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -461,6 +461,13 @@ class TestExplicitSimple(EncryptionIntegrationTest):
         )
         self.assertEqual(encrypted_ssn, encrypted_ssn2)
 
+        encrypted_ssn3 = client_encryption.encrypt(
+            doc["ssn"],
+            Algorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic,
+            key_id=key_id.as_uuid(),
+        )
+        self.assertEqual(encrypted_ssn, encrypted_ssn3)
+
         # Test decryption.
         decrypted_ssn = client_encryption.decrypt(encrypted_ssn)
         self.assertEqual(decrypted_ssn, doc["ssn"])
@@ -479,9 +486,6 @@ class TestExplicitSimple(EncryptionIntegrationTest):
 
         msg = "key_id must be a bson.binary.Binary with subtype 4"
         algo = Algorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic
-        uid = uuid.uuid4()
-        with self.assertRaisesRegex(TypeError, msg):
-            client_encryption.encrypt("str", algo, key_id=uid)  # type: ignore[arg-type]
         with self.assertRaisesRegex(TypeError, msg):
             client_encryption.encrypt("str", algo, key_id=Binary(b"123"))
 

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -461,6 +461,7 @@ class TestExplicitSimple(EncryptionIntegrationTest):
         )
         self.assertEqual(encrypted_ssn, encrypted_ssn2)
 
+        # Test encryption via UUID
         encrypted_ssn3 = client_encryption.encrypt(
             doc["ssn"],
             Algorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic,


### PR DESCRIPTION
Modify the ClientEncryption.encrypt API to accept native UUIDs directly. [jira task](https://jira.mongodb.org/projects/PYTHON/issues/PYTHON-2267)
I validated my changes with the TestExplicitSimple cases. pytest -v -s test/test_encryption.py::TestExplicitSimple
I tried to run all the test_encryption.py tests, but some of the tests require environment credentials, and as far as I understand, I need MongoDB Enterprise for mongocryptd support.