### PR TITLE
PYTHON-4147-fix: Remove quote wrapping and remove shell=true usage

### DIFF
--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -83,9 +83,9 @@ class TestMonitor(IntegrationTest):
     def test_no_thread_start_runtime_err_on_shutdown(self):
         """Test we silence noisy runtime errors fired when the MongoClient spawns a new thread
         on process shutdown."""
-        command = [sys.executable, "-c", "'from pymongo import MongoClient; c = MongoClient()'"]
+        command = [sys.executable, "-c", "from pymongo import MongoClient; c = MongoClient()"]
         completed_process: subprocess.CompletedProcess = subprocess.run(
-            " ".join(command), shell=True, capture_output=True
+            command, capture_output=True
         )
 
         self.assertFalse(completed_process.stderr)


### PR DESCRIPTION
Leveraged the [shlex.split](https://docs.python.org/3/library/shlex.html#shlex.split) command to get my shell output as a proper list of args. It gave me: ` [sys.executable, "-c", '"from pymongo import MongoClient; c = MongoClient()"']`
Tested Output on MacOS when commenting out RuntimeError catch:
```python
test/test_monitor.py::TestMonitor::test_no_thread_start_runtime_err_on_shutdown FAILED                                                                                                                                                                                                                                                                                                 [100%]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

self = <test.test_monitor.TestMonitor testMethod=test_no_thread_start_runtime_err_on_shutdown>

    def test_no_thread_start_runtime_err_on_shutdown(self):
        """Test we silence noisy runtime errors fired when the MongoClient spawns a new thread
        on process shutdown."""
        command = [sys.executable, "-c", "from pymongo import MongoClient; c = MongoClient()"]
        completed_process: subprocess.CompletedProcess = subprocess.run(
            command, capture_output=True
        )
    
>       self.assertFalse(completed_process.stderr)
E       AssertionError: b'Exception in thread pymongo_server_monitor_thread:\nTraceback (most recent call last):\n  File "/opt/homebrew/Cellar/python@3.12/3.12.0/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1052, in _bootstrap_inner\n    self.run()\n  File "/opt/homebrew/Cellar/python@3.12/3.12.0/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 989, in run\n    self._target(*self._args, **self._kwargs)\n  File "/Users/jib/mongo/mongo-python-driver/pymongo/periodic_executor.py", line 141, in _run\n    if not self._target():\n           ^^^^^^^^^^^^^^\n  File "/Users/jib/mongo/mongo-python-driver/pymongo/monitor.py", line 62, in target\n    monitor._run()  # type:ignore[attr-defined]\n    ^^^^^^^^^^^^^^\n  File "/Users/jib/mongo/mongo-python-driver/pymongo/monitor.py", line 216, in _run\n    self._start_rtt_monitor()\n  File "/Users/jib/mongo/mongo-python-driver/pymongo/monitor.py", line 168, in _start_rtt_monitor\n    self._rtt_monitor.open()\n  File "/Users/jib/mongo/mongo-python-driver/pymongo/monitor.py", line 88, in open\n    self._executor.open()\n  File "/Users/jib/mongo/mongo-python-driver/pymongo/periodic_executor.py", line 98, in open\n    thread.start()\n  File "/opt/homebrew/Cellar/python@3.12/3.12.0/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 971, in start\n    _start_new_thread(self._bootstrap, ())\nRuntimeError: can\'t create new thread at interpreter shutdown\n' is not false

test/test_monitor.py:91: AssertionError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

```

[Evergreen Patch Run for Windows](https://spruce.mongodb.com/version/65c3ab420ae6063d5f9948f9/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Etests-windows-python-version__platform~windows-64-vsMulti-small_auth-ssl~noauth-nossl_python-version-windows~3.12%24)