### PR TITLE
Fix auth MD5 error for FIPS enabled machines

### DIFF
--- a/pymongo/auth.py
+++ b/pymongo/auth.py
@@ -353,19 +353,19 @@ def _password_digest(username: str, password: str) -> str:
     if not isinstance(username, str):
         raise TypeError("username must be an instance of str")
 
-    md5hash = hashlib.md5()  # noqa: S324
+    sha256hash = hashlib.sha256()
     data = f"{username}:mongo:{password}"
-    md5hash.update(data.encode("utf-8"))
-    return md5hash.hexdigest()
+    sha256hash.update(data.encode("utf-8"))
+    return sha256hash.hexdigest()
 
 
 def _auth_key(nonce: str, username: str, password: str) -> str:
     """Get an auth key to use for authentication."""
     digest = _password_digest(username, password)
-    md5hash = hashlib.md5()  # noqa: S324
+    sha256hash = hashlib.sha256()
     data = f"{nonce}{username}{digest}"
-    md5hash.update(data.encode("utf-8"))
-    return md5hash.hexdigest()
+    sha256hash.update(data.encode("utf-8"))
+    return sha256hash.hexdigest()
 
 
 def _canonicalize_hostname(hostname: str) -> str:


### PR DESCRIPTION
Switched from `md5` to `sha256` as that [performs faster](https://github.com/roskakori/pygount/pull/137#issuecomment-1947227101) than `md5` and is [FIPS compliant](https://csrc.nist.gov/pubs/fips/180-4/upd1/final). Note: the `usedforsecurity` flag could be used but was only [introduced in Python 3.9](https://docs.python.org/3/library/hashlib.html#hash-algorithms).

This is the error that is thrown on FIPS enabled machines:
`ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS`

Not sure if this needs to be changed anywhere else such as tests. Let me know if this is the case and I would be happy to amend!