### PR TITLE
PYTHON-4208 [Vector Search GA] Add support for types in search index creation

### DIFF
--- a/pymongo/collection.py
+++ b/pymongo/collection.py
@@ -2410,7 +2410,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         .. versionadded:: 4.5
         """
         if not isinstance(model, SearchIndexModel):
-            model = SearchIndexModel(model["definition"], model.get("name"))
+            model = SearchIndexModel(model["definition"], model.get("name"), model.get("type"))
         return self.create_search_indexes([model], session, comment, **kwargs)[0]
 
     def create_search_indexes(

--- a/pymongo/operations.py
+++ b/pymongo/operations.py
@@ -609,7 +609,7 @@ class SearchIndexModel:
             self.__document = dict(name=name, definition=definition)
         else:
             self.__document = dict(definition=definition)
-        self.__document["type"] = type
+        self.__document["type"] = type  # type: ignore[assignment]
 
     @property
     def document(self) -> Mapping[str, Any]:

--- a/pymongo/operations.py
+++ b/pymongo/operations.py
@@ -588,7 +588,12 @@ class SearchIndexModel:
 
     __slots__ = ("__document",)
 
-    def __init__(self, definition: Mapping[str, Any], name: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        definition: Mapping[str, Any],
+        name: Optional[str] = None,
+        type: Optional[str] = "search",
+    ) -> None:
         """Create a Search Index instance.
 
         For use with :meth:`~pymongo.collection.Collection.create_search_index` and :meth:`~pymongo.collection.Collection.create_search_indexes`.
@@ -604,6 +609,7 @@ class SearchIndexModel:
             self.__document = dict(name=name, definition=definition)
         else:
             self.__document = dict(definition=definition)
+        self.__document["type"] = type
 
     @property
     def document(self) -> Mapping[str, Any]:

--- a/test/index_management/createSearchIndex.json
+++ b/test/index_management/createSearchIndex.json
@@ -135,6 +135,66 @@
           ]
         }
       ]
+    },
+        {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "fields": [
+                  {
+                    "type": "vector",
+                    "path": "plot_embedding",
+                    "numDimensions": 1536,
+                    "similarity": "euclidean"
+                  }
+                ]
+              },
+              "name": "test index",
+              "type": "vectorSearch"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/test/index_management/createSearchIndex.json
+++ b/test/index_management/createSearchIndex.json
@@ -50,54 +50,8 @@
                 "mappings": {
                   "dynamic": true
                 }
-              }
-            }
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndex",
-          "object": "collection0",
-          "arguments": {
-            "model": {
-              "definition": {
-                "mappings": {
-                  "dynamic": true
-                }
               },
-              "name": "test index"
+              "type": "search"
             }
           },
           "expectError": {
@@ -121,7 +75,57 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              },
+              "name": "test index",
+              "type": "search"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
                     }
                   ],
                   "$db": "database0"

--- a/test/index_management/createSearchIndexes.json
+++ b/test/index_management/createSearchIndexes.json
@@ -83,56 +83,8 @@
                   "mappings": {
                     "dynamic": true
                   }
-                }
-              }
-            ]
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndexes",
-          "object": "collection0",
-          "arguments": {
-            "models": [
-              {
-                "definition": {
-                  "mappings": {
-                    "dynamic": true
-                  }
                 },
-                "name": "test index"
+                "type": "search"
               }
             ]
           },
@@ -157,7 +109,59 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "mappings": {
+                    "dynamic": true
+                  }
+                },
+                "name": "test index",
+                "type": "search"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
                     }
                   ],
                   "$db": "database0"

--- a/test/index_management/createSearchIndexes.json
+++ b/test/index_management/createSearchIndexes.json
@@ -171,6 +171,68 @@
           ]
         }
       ]
+    },
+        {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "fields": [
+                    {
+                      "type": "vector",
+                      "path": "plot_embedding",
+                      "numDimensions": 1536,
+                      "similarity": "euclidean"
+                    }
+                  ]
+                },
+                "name": "test index",
+                "type": "vectorSearch"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/test/test_index_management.py
+++ b/test/test_index_management.py
@@ -60,12 +60,12 @@ class TestSearchIndexProse(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
-        # if not os.environ.get("TEST_INDEX_MANAGEMENT"):
-        #     raise unittest.SkipTest("Skipping index management tests")
+        if not os.environ.get("TEST_INDEX_MANAGEMENT"):
+            raise unittest.SkipTest("Skipping index management tests")
         url = os.environ.get("MONGODB_URI")
-        # username = os.environ["DB_USER"]
-        # password = os.environ["DB_PASSWORD"]
-        cls.client = MongoClient(url)
+        username = os.environ["DB_USER"]
+        password = os.environ["DB_PASSWORD"]
+        cls.client = MongoClient(url, username=username, password=password)
         cls.client.drop_database(_NAME)
         cls.db = cls.client.test_search_index_prose
 

--- a/test/test_index_management.py
+++ b/test/test_index_management.py
@@ -60,12 +60,12 @@ class TestSearchIndexProse(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
-        if not os.environ.get("TEST_INDEX_MANAGEMENT"):
-            raise unittest.SkipTest("Skipping index management tests")
+        # if not os.environ.get("TEST_INDEX_MANAGEMENT"):
+        #     raise unittest.SkipTest("Skipping index management tests")
         url = os.environ.get("MONGODB_URI")
-        username = os.environ["DB_USER"]
-        password = os.environ["DB_PASSWORD"]
-        cls.client = MongoClient(url, username=username, password=password)
+        # username = os.environ["DB_USER"]
+        # password = os.environ["DB_PASSWORD"]
+        cls.client = MongoClient(url)
         cls.client.drop_database(_NAME)
         cls.db = cls.client.test_search_index_prose
 
@@ -216,6 +216,70 @@ class TestSearchIndexProse(unittest.TestCase):
 
         # Run a ``dropSearchIndex`` command and assert that no error is thrown.
         coll0.drop_search_index("foo")
+
+    def test_case_7(self):
+        """Driver handles index types."""
+
+        # Create a collection with the "create" command using a randomly generated name (referred to as ``coll0``).
+        coll0 = self.db[f"col{uuid.uuid4()}"]
+        coll0.insert_one({})
+
+        # Use these search and vector search definitions for indexes.
+        search_definition = {"mappings": {"dynamic": False}}
+        vector_search_definition = {
+            "fields": [
+                {
+                    "type": "vector",
+                    "path": "plot_embedding",
+                    "numDimensions": 1536,
+                    "similarity": "euclidean",
+                },
+            ]
+        }
+
+        # Create a new search index on ``coll0`` that implicitly passes its type.
+        implicit_search_resp = coll0.create_search_index(
+            model={"name": _NAME + "-implicit", "definition": search_definition}
+        )
+
+        # Get the index definition.
+        resp = coll0.list_search_indexes(name=implicit_search_resp).next()
+
+        # Assert that the index model contains the correct index type: ``"search"``.
+        self.assertEqual(resp["type"], "search")
+
+        # Create a new search index on ``coll0`` that explicitly passes its type.
+        explicit_search_resp = coll0.create_search_index(
+            model={"name": _NAME + "-explicit", "type": "search", "definition": search_definition}
+        )
+
+        # Get the index definition.
+        resp = coll0.list_search_indexes(name=explicit_search_resp).next()
+
+        # Assert that the index model contains the correct index type: ``"search"``.
+        self.assertEqual(resp["type"], "search")
+
+        # Create a new vector search index on ``coll0`` that explicitly passes its type.
+        explicit_vector_resp = coll0.create_search_index(
+            model={
+                "name": _NAME + "-vector",
+                "type": "vectorSearch",
+                "definition": vector_search_definition,
+            }
+        )
+
+        # Get the index definition.
+        resp = coll0.list_search_indexes(name=explicit_vector_resp).next()
+
+        # Assert that the index model contains the correct index type: ``"vectorSearch"``.
+        self.assertEqual(resp["type"], "vectorSearch")
+
+        # Catch the error raised when trying to create a vector search index without specifying the type
+        with self.assertRaises(OperationFailure) as e:
+            coll0.create_search_index(
+                model={"name": _NAME + "-error", "definition": vector_search_definition}
+            )
+        self.assertIn("Attribute mappings missing.", e.exception.details["errmsg"])
 
 
 globals().update(


### PR DESCRIPTION
Python implementation for [DRIVERS-2768](https://jira.mongodb.org/browse/DRIVERS-2768).