### PR TITLE
PYTHON-4260 Lazily load optional imports

### DIFF
--- a/pymongo/_azure_helpers.py
+++ b/pymongo/_azure_helpers.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 
 import json
 from typing import Any, Optional
-from urllib.request import Request, urlopen
 
 
 def _get_azure_response(
     resource: str, object_id: Optional[str] = None, timeout: float = 5
 ) -> dict[str, Any]:
+    # Delayed import to save import time.
+    from urllib.request import Request, urlopen
+
     url = "http://169.254.169.254/metadata/identity/oauth2/token"
     url += "?api-version=2018-02-01"
     url += f"&resource={resource}"

--- a/pymongo/_csot.py
+++ b/pymongo/_csot.py
@@ -21,9 +21,10 @@ import time
 from collections import deque
 from contextlib import AbstractContextManager
 from contextvars import ContextVar, Token
-from typing import Any, Callable, Deque, MutableMapping, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, Deque, MutableMapping, Optional, TypeVar, cast
 
-from pymongo.write_concern import WriteConcern
+if TYPE_CHECKING:
+    from pymongo.write_concern import WriteConcern
 
 TIMEOUT: ContextVar[Optional[float]] = ContextVar("TIMEOUT", default=None)
 RTT: ContextVar[float] = ContextVar("RTT", default=0.0)

--- a/pymongo/auth.py
+++ b/pymongo/auth.py
@@ -400,7 +400,7 @@ def _authenticate_gssapi(credentials: MongoCredential, conn: Connection) -> None
         # Delayed import of kerberos for performance reasons.
         use_principal = False
         if sys.platform == "win32":
-            import winkerberos as kerberos  # type:ignore[import]
+            import winkerberos as kerberos
 
             if tuple(map(int, kerberos.__version__.split(".")[:2])) >= (0, 5):
                 use_principal = True

--- a/pymongo/client_options.py
+++ b/pymongo/client_options.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, cast
 
 from bson.codec_options import _parse_codec_options
 from pymongo import common
-from pymongo.auth import MongoCredential, _build_credentials_tuple
 from pymongo.compression_support import CompressionSettings
 from pymongo.errors import ConfigurationError
 from pymongo.monitoring import _EventListener, _EventListeners
@@ -36,6 +35,7 @@ from pymongo.write_concern import WriteConcern, validate_boolean
 
 if TYPE_CHECKING:
     from bson.codec_options import CodecOptions
+    from pymongo.auth import MongoCredential
     from pymongo.encryption_options import AutoEncryptionOpts
     from pymongo.pyopenssl_context import SSLContext
     from pymongo.topology_description import _ServerSelector
@@ -45,6 +45,9 @@ def _parse_credentials(
     username: str, password: str, database: Optional[str], options: Mapping[str, Any]
 ) -> Optional[MongoCredential]:
     """Parse authentication credentials."""
+    # Delayed import to improve startup time.
+    from pymongo.auth import _build_credentials_tuple
+
     mechanism = options.get("authmechanism", "DEFAULT" if username else None)
     source = options.get("authsource")
     if username or mechanism:

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import datetime
+import importlib.util
 import warnings
 from collections import OrderedDict, abc
 from difflib import get_close_matches
@@ -429,6 +430,10 @@ _MECHANISM_PROPS = frozenset(
         "ALLOWED_HOSTS",
     ]
 )
+
+
+def import_available(name: str, package: str | None = None) -> bool:
+    return importlib.util.find_spec(name, package) is not None
 
 
 def validate_auth_mechanism_properties(option: str, value: Any) -> dict[str, Union[bool, str]]:

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -41,8 +41,6 @@ from bson import SON
 from bson.binary import UuidRepresentation
 from bson.codec_options import CodecOptions, DatetimeConversion, TypeRegistry
 from bson.raw_bson import RawBSONDocument
-from pymongo.auth import MECHANISMS
-from pymongo.auth_oidc import OIDCCallback
 from pymongo.compression_support import (
     validate_compressors,
     validate_zlib_compression_level,
@@ -381,6 +379,9 @@ def validate_read_preference_mode(dummy: Any, value: Any) -> _ServerMode:
 
 def validate_auth_mechanism(option: str, value: Any) -> str:
     """Validate the authMechanism URI option."""
+    # Delayed import to prevent import cycle.
+    from pymongo.auth import MECHANISMS
+
     if value not in MECHANISMS:
         raise ValueError(f"{option} must be in {tuple(MECHANISMS)}")
     return value
@@ -433,6 +434,7 @@ _MECHANISM_PROPS = frozenset(
 
 
 def import_available(name: str, package: str | None = None) -> bool:
+    """Check whether an import is available."""
     return importlib.util.find_spec(name, package) is not None
 
 
@@ -450,6 +452,9 @@ def validate_auth_mechanism_properties(option: str, value: Any) -> dict[str, Uni
             elif key in ["ALLOWED_HOSTS"] and isinstance(value, list):
                 props[key] = value
             elif key in ["OIDC_CALLBACK", "OIDC_HUMAN_CALLBACK"]:
+                # Delayed import to prevent import cycle.
+                from pymongo.auth_oidc import OIDCCallback
+
                 if not isinstance(value, OIDCCallback):
                     raise ValueError("callback must be an OIDCCallback object")
                 props[key] = value

--- a/pymongo/compression_support.py
+++ b/pymongo/compression_support.py
@@ -13,12 +13,19 @@
 # limitations under the License.
 from __future__ import annotations
 
+import importlib.util
 import warnings
 from typing import Any, Iterable, Optional, Union
 
-from pymongo.common import import_available
 from pymongo.hello import HelloCompat
 from pymongo.monitoring import _SENSITIVE_COMMANDS
+
+
+# Inline import_available here to avoid import cycle.
+def import_available(name: str, package: str | None = None) -> bool:
+    """Check whether an import is available."""
+    return importlib.util.find_spec(name, package) is not None
+
 
 _HAVE_SNAPPY = import_available("snappy")
 _HAVE_ZLIB = import_available("zlib")

--- a/pymongo/compression_support.py
+++ b/pymongo/compression_support.py
@@ -132,7 +132,7 @@ class ZstdContext:
     def compress(data: bytes) -> bytes:
         # ZstdCompressor is not thread safe.
         # TODO: Use a pool?
-        from zstandard import ZstdCompressor  # type:ignore[import]
+        from zstandard import ZstdCompressor
 
         return ZstdCompressor().compress(data)
 
@@ -153,7 +153,7 @@ def decompress(data: bytes, compressor_id: int) -> bytes:
     elif compressor_id == ZstdContext.compressor_id:
         # ZstdDecompressor is not thread safe.
         # TODO: Use a pool?
-        from zstandard import ZstdDecompressor  # type:ignore[import]
+        from zstandard import ZstdDecompressor
 
         return ZstdDecompressor().decompress(data)
     else:

--- a/pymongo/encryption.py
+++ b/pymongo/encryption.py
@@ -35,6 +35,18 @@ from typing import (
     cast,
 )
 
+try:
+    from pymongocrypt.auto_encrypter import AutoEncrypter  # type:ignore[import]
+    from pymongocrypt.errors import MongoCryptError  # type:ignore[import]
+    from pymongocrypt.explicit_encrypter import ExplicitEncrypter  # type:ignore[import]
+    from pymongocrypt.mongocrypt import MongoCryptOptions  # type:ignore[import]
+    from pymongocrypt.state_machine import MongoCryptCallback  # type:ignore[import]
+
+    _HAVE_PYMONGOCRYPT = True
+except ImportError:
+    _HAVE_PYMONGOCRYPT = False
+    MongoCryptCallback = object
+
 from bson import _dict_to_bson, decode, encode
 from bson.binary import STANDARD, UUID_SUBTYPE, Binary
 from bson.codec_options import CodecOptions
@@ -42,7 +54,7 @@ from bson.errors import BSONError
 from bson.raw_bson import DEFAULT_RAW_BSON_OPTIONS, RawBSONDocument, _inflate_bson
 from pymongo import _csot
 from pymongo.collection import Collection
-from pymongo.common import CONNECT_TIMEOUT, import_available
+from pymongo.common import CONNECT_TIMEOUT
 from pymongo.cursor import Cursor
 from pymongo.daemon import _spawn_daemon
 from pymongo.database import Database
@@ -66,9 +78,8 @@ from pymongo.typings import _DocumentType, _DocumentTypeArg
 from pymongo.uri_parser import parse_host
 from pymongo.write_concern import WriteConcern
 
-_HAVE_PYMONGOCRYPT = import_available("pymongocrypt")
-if TYPE_CHECKING and _HAVE_PYMONGOCRYPT:
-    from pymongocrypt.mongocrypt import MongoCryptCallback, MongoCryptKmsContext
+if TYPE_CHECKING:
+    from pymongocrypt.mongocrypt import MongoCryptKmsContext
 
 _HTTPS_PORT = 443
 _KMS_CONNECT_TIMEOUT = CONNECT_TIMEOUT  # CDRIVER-3262 redefined this value to CONNECT_TIMEOUT
@@ -153,8 +164,6 @@ class _EncryptionIO(MongoCryptCallback):  # type: ignore[misc]
             ssl_context=ctx,
         )
         host, port = parse_host(endpoint, _HTTPS_PORT)
-        from pymongocrypt.errors import MongoCryptError
-
         try:
             conn = _configured_socket((host, port), opts)
             try:
@@ -319,10 +328,6 @@ class _Encrypter:
         :param client: The encrypted MongoClient.
         :param opts: The encrypted client's :class:`AutoEncryptionOpts`.
         """
-        # Delayed import of encryption classes
-        from pymongocrypt.auto_encrypter import AutoEncrypter  # type:ignore[import]
-        from pymongocrypt.mongocrypt import MongoCryptOptions  # type:ignore[import]
-
         if opts._schema_map is None:
             schema_map = None
         else:
@@ -574,8 +579,6 @@ class ClientEncryption(Generic[_DocumentType]):
         self._io_callbacks: Optional[_EncryptionIO] = _EncryptionIO(
             None, key_vault_coll, None, opts
         )
-        from pymongocrypt import ExplicitEncrypter, MongoCryptOptions
-
         self._encryption = ExplicitEncrypter(
             self._io_callbacks, MongoCryptOptions(kms_providers, None)
         )

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -17,20 +17,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping, Optional
 
-try:
-    import pymongocrypt  # type:ignore[import] # noqa: F401
-
-    _HAVE_PYMONGOCRYPT = True
-except ImportError:
-    _HAVE_PYMONGOCRYPT = False
 from bson import int64
-from pymongo.common import validate_is_mapping
+from pymongo.common import import_available, validate_is_mapping
 from pymongo.errors import ConfigurationError
 from pymongo.uri_parser import _parse_kms_tls_options
 
 if TYPE_CHECKING:
     from pymongo.mongo_client import MongoClient
     from pymongo.typings import _DocumentTypeArg
+
+
+_HAVE_PYMONGOCRYPT = import_available("pymongocrypt")
 
 
 class AutoEncryptionOpts:

--- a/pymongo/errors.py
+++ b/pymongo/errors.py
@@ -22,17 +22,6 @@ from bson.errors import InvalidDocument
 if TYPE_CHECKING:
     from pymongo.typings import _DocumentOut
 
-try:
-    # CPython 3.7+
-    from ssl import SSLCertVerificationError as _CertificateError
-except ImportError:
-    try:
-        from ssl import CertificateError as _CertificateError
-    except ImportError:
-
-        class _CertificateError(ValueError):  # type: ignore
-            pass
-
 
 class PyMongoError(Exception):
     """Base class for all PyMongo exceptions."""

--- a/pymongo/errors.py
+++ b/pymongo/errors.py
@@ -15,6 +15,7 @@
 """Exceptions raised by PyMongo."""
 from __future__ import annotations
 
+from ssl import SSLCertVerificationError as _CertificateError  # noqa: F401
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Sequence, Union
 
 from bson.errors import InvalidDocument

--- a/pymongo/srv_resolver.py
+++ b/pymongo/srv_resolver.py
@@ -17,17 +17,15 @@ from __future__ import annotations
 
 import ipaddress
 import random
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-try:
-    from dns import resolver
-
-    _HAVE_DNSPYTHON = True
-except ImportError:
-    _HAVE_DNSPYTHON = False
-
-from pymongo.common import CONNECT_TIMEOUT
+from pymongo.common import CONNECT_TIMEOUT, import_available
 from pymongo.errors import ConfigurationError
+
+_HAVE_DNSPYTHON = import_available("dns")
+
+if TYPE_CHECKING and _HAVE_DNSPYTHON:
+    from dns import resolver
 
 
 # dnspython can return bytes or str from various parts
@@ -40,6 +38,9 @@ def maybe_decode(text: Union[str, bytes]) -> str:
 
 # PYTHON-2667 Lazily call dns.resolver methods for compatibility with eventlet.
 def _resolve(*args: Any, **kwargs: Any) -> resolver.Answer:
+    # Delayed import of resolver for performance reasons.
+    from dns import resolver
+
     if hasattr(resolver, "resolve"):
         # dnspython >= 2
         return resolver.resolve(*args, **kwargs)

--- a/pymongo/srv_resolver.py
+++ b/pymongo/srv_resolver.py
@@ -82,6 +82,9 @@ class _SrvResolver:
             raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,))
 
     def get_options(self) -> Optional[str]:
+        # Delayed import of resolver for performance reasons.
+        from dns import resolver
+
         try:
             results = _resolve(self.__fqdn, "TXT", lifetime=self.__connect_timeout)
         except (resolver.NoAnswer, resolver.NXDOMAIN):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ unfixable = [
   "RUF100", # Unused noqa
   "T20",  # Removes print statements
   "F841", # Removes unused variables
+  "F401",    # Unused imports
 ]
 exclude = []
 flake8-unused-arguments.ignore-variadic-names = true


### PR DESCRIPTION
Tests:

```
pip install -e ".[aws,oscp,encryption,snappy,gssapi,zstd]"
python -X importtime -c "import pymongo"
```

 59862 usec cumulative time on this PR vs.
157485 usec cumulative time on master.

I confirmed that `dns`, `boto3`, `cryptography`, etc. are loaded on `master` and not with these changes.