### PR TITLE
PYTHON-4298 Fix _apply_local_threshold TypeError

### DIFF
--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -266,12 +266,12 @@ class TopologyDescription:
         if not selection:
             return []
         # Round trip time in seconds.
-        fastest = min(cast(float, s.round_trip_time) for s in selection.server_descriptions)
+        fastest = min(s.round_trip_time for s in selection.server_descriptions if s.round_trip_time is not None)
         threshold = self._topology_settings.local_threshold_ms / 1000.0
         return [
             s
             for s in selection.server_descriptions
-            if (cast(float, s.round_trip_time) - fastest) <= threshold
+            if s.round_trip_time is not None and (s.round_trip_time - fastest) <= threshold
         ]
 
     def apply_selector(


### PR DESCRIPTION
Fix for TypeError caused by substraction between nulls when round_trip_time is None

```python
    return [
>       s for s in selection.server_descriptions if (s.round_trip_time - fastest) <= threshold
    ]
E   TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'
```
Jira ticket: https://jira.mongodb.org/browse/PYTHON-4298
Linked to previous PR https://github.com/mongodb/mongo-python-driver/pull/1361