### PR TITLE
PYTHON-4303 Temporarily skip two transaction tests

### DIFF
--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1069,7 +1069,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         if "unpin after TransientTransactionError error on" in spec["description"]:
             self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
         if "withTransaction commits after callback returns" in spec["description"]:
-            self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
+            self.skipTest("Skipping TransientTransactionError pending PYTHON-4303")
         if "unpin on successful abort" in spec["description"]:
             self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
 

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1070,6 +1070,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
         if "withTransaction commits after callback returns" in spec["description"]:
             self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
+        if "unpin on successful abort" in spec["description"]:
+            self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
 
         if "unpin after non-transient error on abort" in spec["description"]:
             if client_context.version[0] == 8:

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1068,6 +1068,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
 
         if "unpin after TransientTransactionError error on" in spec["description"]:
             self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
+        if "withTransaction commits after callback returns" in spec["description"]:
+            self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
 
         if "unpin after non-transient error on abort" in spec["description"]:
             if client_context.version[0] == 8:


### PR DESCRIPTION
See JIRA for details and link to patches that show the errors.
These failures will be fixed pending the tickets that are referred to in test/unified_format.py: [PYTHON-4303] and [PYTHON-4227].