### PR TITLE
PYTHON-4354 & PYTHON-4355 - Increase logging limit for tests

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -129,6 +129,10 @@ GCP_CREDS = {
 }
 KMIP_CREDS = {"endpoint": os.environ.get("FLE_KMIP_ENDPOINT", "localhost:5698")}
 
+os.environ[
+    "MONGOB_LOG_MAX_DOCUMENT_LENGTH"
+] = "2000"  # Ensure Evergreen metadata doesn't result in truncation
+
 
 def is_server_resolvable():
     """Returns True if 'server' is resolvable."""

--- a/test/test_command_logging.py
+++ b/test/test_command_logging.py
@@ -26,8 +26,6 @@ from test.unified_format import generate_test_classes
 # Location of JSON test specifications.
 _TEST_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "command_logging")
 
-os.environ["MONGOB_LOG_MAX_DOCUMENT_LENGTH"] = "2000"
-
 globals().update(
     generate_test_classes(
         _TEST_PATH,

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1770,15 +1770,16 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         def format_logs(log_list):
             client_to_log = defaultdict(list)
             for log in log_list:
-                data = json_util.loads(log.message)
-                client = data.pop("clientId")
-                client_to_log[client].append(
-                    {
-                        "level": log.levelname.lower(),
-                        "component": log.name.replace("pymongo.", "", 1),
-                        "data": data,
-                    }
-                )
+                if log.module != "ocsp_support":
+                    data = json_util.loads(log.message)
+                    client = data.pop("clientId")
+                    client_to_log[client].append(
+                        {
+                            "level": log.levelname.lower(),
+                            "component": log.name.replace("pymongo.", "", 1),
+                            "data": data,
+                        }
+                    )
             return client_to_log
 
         with self.assertLogs("pymongo", level="DEBUG") as cm:


### PR DESCRIPTION
The green framework failures were actually due to `ocsp_support` logging non-JSON messages. Our test framework expects all logs to be in JSON format, so I've added a check to exclude `ocsp_support` logs from test verification.