### PR TITLE
PYTHON-4366 Increase benchmark timeout to 3 minutes to reduce variance

### DIFF
--- a/doc/examples/encryption.rst
+++ b/doc/examples/encryption.rst
@@ -603,7 +603,7 @@ An application using GCP credentials would look like:
     }
     client_encryption.create_data_key("gcp", master_key)
 
-The driver will query the `VM instance metadata <https://cloud.google.com/compute/docs/metadata/default-metadata-values>`_ to obtain credentials.
+The driver will query the `VM instance metadata <https://cloud.google.com/compute/docs/metadata/querying-metadata>`_ to obtain credentials.
 
 An application using Azure credentials would look like, this time using
 :class:`~pymongo.encryption_options.AutoEncryptionOpts`:

--- a/test/performance/perf_test.py
+++ b/test/performance/perf_test.py
@@ -62,10 +62,10 @@ from gridfs import GridFSBucket
 from pymongo import MongoClient
 
 # Spec says to use at least 1 minute cumulative execution time and up to 100 iterations or 5 minutes but that
-# makes the benchmarks too slow. Instead, we use at least 30 seconds and at most 60 seconds.
+# makes the benchmarks too slow. Instead, we use at least 30 seconds and at most 3 minutes.
 NUM_ITERATIONS = 100
 MIN_ITERATION_TIME = 30
-MAX_ITERATION_TIME = 60
+MAX_ITERATION_TIME = 180
 NUM_DOCS = 10000
 # When debugging or prototyping it's often useful to run the benchmarks locally, set FASTBENCH=1 to run quickly.
 if bool(os.getenv("FASTBENCH")):


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4366