### PR TITLE
PYTHON-4371 Fix include_system_collections example in migration guide

### DIFF
--- a/doc/migrate-to-pymongo4.rst
+++ b/doc/migrate-to-pymongo4.rst
@@ -328,13 +328,13 @@ Removed :meth:`pymongo.database.Database.collection_names`. Use
 :meth:`~pymongo.database.Database.list_collection_names` instead. Code like
 this::
 
-    names = client.collection_names()
-    non_system_names = client.collection_names(include_system_collections=False)
+    names = client.db.collection_names()
+    non_system_names = client.db.collection_names(include_system_collections=False)
 
 can be changed to this::
 
-    names = client.list_collection_names()
-    non_system_names = client.list_collection_names(filter={"name": {"$regex": r"^(?!system\\.)"}})
+    names = client.db.list_collection_names()
+    non_system_names = client.db.list_collection_names(filter={"name": {"$regex": "^(?!system\\.)"}})
 
 Database.current_op is removed
 ..............................


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4371

```python
# Before
>>> client.db.list_collection_names(filter={"name": {"$regex": r"^(?!system\\.)"}})
['coll', 'system.views', 'time', 'system.buckets.time', 'view']

# After
>>> client.db.list_collection_names(filter={"name": {"$regex": "^(?!system\\.)"}})
['coll', 'time', 'view']
```