### PR TITLE
PYTHON-4348 Reinstate fork warning because network I/O and threads are not fork safe

### DIFF
--- a/pymongo/topology.py
+++ b/pymongo/topology.py
@@ -20,9 +20,11 @@ import logging
 import os
 import queue
 import random
+import sys
 import time
 import warnings
 import weakref
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, cast
 
 from pymongo import _csot, common, helpers, periodic_executor
@@ -68,6 +70,9 @@ if TYPE_CHECKING:
     from bson import ObjectId
     from pymongo.settings import TopologySettings
     from pymongo.typings import ClusterTime, _Address
+
+
+_pymongo_dir = str(Path(__file__).parent)
 
 
 def process_events_queue(queue_ref: weakref.ReferenceType[queue.Queue]) -> bool:
@@ -187,12 +192,17 @@ class Topology:
             self._pid = pid
         elif pid != self._pid:
             self._pid = pid
-            warnings.warn(
+            if sys.version_info[:2] >= (3, 12):
+                kwargs = {"skip_file_prefixes": (_pymongo_dir,)}
+            else:
+                kwargs = {"stacklevel": 6}
+            # Ignore B028 warning for missing stacklevel.
+            warnings.warn(  # noqa: B028
                 "MongoClient opened before fork. May not be entirely fork-safe, "
                 "proceed with caution. See PyMongo's documentation for details: "
                 "https://pymongo.readthedocs.io/en/stable/faq.html#"
                 "is-pymongo-fork-safe",
-                stacklevel=2,
+                **kwargs,
             )
             with self._lock:
                 # Close servers and clear the pools.

--- a/test/test_fork.py
+++ b/test/test_fork.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+import warnings
 from multiprocessing import Pipe
 
 sys.path[0:0] = [""]
@@ -72,7 +73,11 @@ class TestFork(IntegrationTest):
         parent_cursor_exc = self.client._kill_cursors_executor
 
         def target():
-            self.client.admin.command("ping")
+            # Catch the fork warning and send to the parent for assertion.
+            with warnings.catch_warnings(record=True) as ctx:
+                warnings.simplefilter("always")
+                self.client.admin.command("ping")
+                child_conn.send(str(ctx[0]))
             child_conn.send(self.client._topology._pid)
             child_conn.send(
                 (
@@ -83,6 +88,8 @@ class TestFork(IntegrationTest):
 
         with self.fork(target):
             self.assertEqual(self.client._topology._pid, init_id)
+            fork_warning = parent_conn.recv()
+            self.assertIn("MongoClient opened before fork", fork_warning)
             child_id = parent_conn.recv()
             self.assertNotEqual(child_id, init_id)
             passed, msg = parent_conn.recv()


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4348