### PR TITLE
PYTHON-4227 Unified tests: Advance cluster_time of ClientSessions after initialData creation

### DIFF
--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1883,7 +1883,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         self.entity_map.create_entities_from_spec(self.TEST_SPEC.get("createEntities", []), uri=uri)
         # process initialData
         if "initialData" in self.TEST_SPEC:
-            self.insert_initial_data(self.TEST_SPEC.get("initialData", []))
+            self.insert_initial_data(self.TEST_SPEC["initialData"])
+            self._cluster_time = self.client.admin.command("ping").get("$clusterTime")
             self.entity_map.advance_cluster_times()
 
         if "expectLogMessages" in spec:

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -428,11 +428,11 @@ class EntityMapUtil:
     """
 
     def __init__(self, test_class):
-        self._cluster_time = None
         self._entities: Dict[str, Any] = {}
         self._listeners: Dict[str, EventListenerUtil] = {}
         self._session_lsids: Dict[str, Mapping[str, Any]] = {}
         self.test: UnifiedSpecTestMixinV1 = test_class
+        self._cluster_time: Optional[ClusterTime] = None
 
     def __contains__(self, item):
         return item in self._entities
@@ -625,10 +625,9 @@ class EntityMapUtil:
             # session has been closed.
             return self._session_lsids[session_name]
 
-    def advance_cluster_times(self, cluster_time: Optional[ClusterTime] = None):
-        if cluster_time is not None:
-            self._cluster_time = cluster_time
-        elif getattr(self, "_cluster_time", None) is None:
+    def advance_cluster_times(self):
+        """Manually synchronize entities when desired"""
+        if self._cluster_time is None:
             self._cluster_time = self.test.client.admin.command("ping").get("$clusterTime")
         for entity in self._entities:
             if isinstance(entity, ClientSession):

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -629,7 +629,7 @@ class EntityMapUtil:
         """Manually synchronize entities when desired"""
         if not self._cluster_time:
             self._cluster_time = self.test.client.admin.command("ping").get("$clusterTime")
-        for entity in self._entities:
+        for entity in self._entities.values():
             if isinstance(entity, ClientSession):
                 entity.advance_cluster_time(self._cluster_time)
 

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1880,13 +1880,14 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         self.entity_map = EntityMapUtil(self)
         self.entity_map.create_entities_from_spec(self.TEST_SPEC.get("createEntities", []), uri=uri)
         # process initialData
-        self.insert_initial_data(self.TEST_SPEC.get("initialData", []))
-        # advance cluster times of any session entities
-        cluster_time = self.client.admin.command("ping").get("$clusterTime")
-        if cluster_time:
-            for entity in self.entity_map._entities.values():
-                if isinstance(entity, ClientSession):
-                    entity.advance_cluster_time(cluster_time)
+        if "initialData" in self.TEST_SPEC:
+            self.insert_initial_data(self.TEST_SPEC.get("initialData", []))
+            # advance cluster times of session entities
+            cluster_time = self.client.admin.command("ping").get("$clusterTime")
+            if cluster_time:
+                for entity in self.entity_map._entities.values():
+                    if isinstance(entity, ClientSession):
+                        entity.advance_cluster_time(cluster_time)
 
         if "expectLogMessages" in spec:
             expect_log_messages = spec["expectLogMessages"]

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1880,7 +1880,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         # process initialData
         if "initialData" in self.TEST_SPEC:
             self.insert_initial_data(self.TEST_SPEC.get("initialData", []))
-            # advance cluster times of session entities
+            # advance cluster times of session entities,
+            # to ensure consistency in transactions against a sharded deployment,
             cluster_time = self.client.admin.command("ping").get("$clusterTime")
             if cluster_time:
                 for entity in self.entity_map._entities.values():

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1062,8 +1062,6 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         if "unpin after non-transient error on abort" in spec["description"]:
             if client_context.version[0] == 8:
                 self.skipTest("Skipping TransientTransactionError pending PYTHON-4182")
-        if "unpin after TransientTransactionError error on" in spec["description"]:
-            self.skipTest("Skipping TransientTransactionError pending PYTHON-4182")
         if self.IS_SERVERLESS_PROXY is not None and (
             "errors during the initial connection hello are ignored" in spec["description"]
             or "pinned connection is released after a transient network commit error"

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1053,8 +1053,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
 
         if "unpin after TransientTransactionError error on" in spec["description"]:
             self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
-        if "withTransaction commits after callback returns" in spec["description"]:
-            self.skipTest("Skipping TransientTransactionError pending PYTHON-4303")
+        # if "withTransaction commits after callback returns" in spec["description"]:
+        #     self.skipTest("Skipping TransientTransactionError pending PYTHON-4303")
         if "unpin on successful abort" in spec["description"]:
             self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
 
@@ -1881,6 +1881,12 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         self.entity_map.create_entities_from_spec(self.TEST_SPEC.get("createEntities", []), uri=uri)
         # process initialData
         self.insert_initial_data(self.TEST_SPEC.get("initialData", []))
+        # advance cluster times of any session entities
+        cluster_time = self.client.admin.command("ping").get("$clusterTime")
+        if cluster_time:
+            for entity in self.entity_map._entities.values():
+                if isinstance(entity, ClientSession):
+                    entity.advance_cluster_time(cluster_time)
 
         if "expectLogMessages" in spec:
             expect_log_messages = spec["expectLogMessages"]

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1053,8 +1053,6 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
 
         if "unpin after TransientTransactionError error on" in spec["description"]:
             self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
-        # if "withTransaction commits after callback returns" in spec["description"]:
-        #     self.skipTest("Skipping TransientTransactionError pending PYTHON-4303")
         if "unpin on successful abort" in spec["description"]:
             self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
 

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -130,7 +130,7 @@ from pymongo.server_description import ServerDescription
 from pymongo.server_selectors import Selection, writable_server_selector
 from pymongo.server_type import SERVER_TYPE
 from pymongo.topology_description import TopologyDescription
-from pymongo.typings import ClusterTime, _Address
+from pymongo.typings import _Address
 from pymongo.write_concern import WriteConcern
 
 JSON_OPTS = json_util.JSONOptions(tz_aware=False)
@@ -432,7 +432,7 @@ class EntityMapUtil:
         self._listeners: Dict[str, EventListenerUtil] = {}
         self._session_lsids: Dict[str, Mapping[str, Any]] = {}
         self.test: UnifiedSpecTestMixinV1 = test_class
-        self._cluster_time: Optional[ClusterTime] = None
+        self._cluster_time: Mapping[str, Any] = {}
 
     def __contains__(self, item):
         return item in self._entities
@@ -625,9 +625,9 @@ class EntityMapUtil:
             # session has been closed.
             return self._session_lsids[session_name]
 
-    def advance_cluster_times(self):
+    def advance_cluster_times(self) -> None:
         """Manually synchronize entities when desired"""
-        if self._cluster_time is None:
+        if not self._cluster_time:
             self._cluster_time = self.test.client.admin.command("ping").get("$clusterTime")
         for entity in self._entities:
             if isinstance(entity, ClientSession):

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -630,7 +630,7 @@ class EntityMapUtil:
         if not self._cluster_time:
             self._cluster_time = self.test.client.admin.command("ping").get("$clusterTime")
         for entity in self._entities.values():
-            if isinstance(entity, ClientSession):
+            if isinstance(entity, ClientSession) and self._cluster_time:
                 entity.advance_cluster_time(self._cluster_time)
 
 

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1050,12 +1050,6 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             self.skipTest("Implement PYTHON-1894")
         if "timeoutMS applied to entire download" in spec["description"]:
             self.skipTest("PyMongo's open_download_stream does not cap the stream's lifetime")
-
-        if "unpin after TransientTransactionError error on" in spec["description"]:
-            self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
-        if "unpin on successful abort" in spec["description"]:
-            self.skipTest("Skipping TransientTransactionError pending PYTHON-4227")
-
         if "unpin after non-transient error on abort" in spec["description"]:
             if client_context.version[0] == 8:
                 self.skipTest("Skipping TransientTransactionError pending PYTHON-4182")

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -428,6 +428,7 @@ class EntityMapUtil:
     """
 
     def __init__(self, test_class):
+        self._cluster_time = None
         self._entities: Dict[str, Any] = {}
         self._listeners: Dict[str, EventListenerUtil] = {}
         self._session_lsids: Dict[str, Mapping[str, Any]] = {}
@@ -624,15 +625,12 @@ class EntityMapUtil:
             # session has been closed.
             return self._session_lsids[session_name]
 
-    def entities(self):
-        return self._entities
-
     def advance_cluster_times(self, cluster_time: Optional[ClusterTime] = None):
         if cluster_time is not None:
             self._cluster_time = cluster_time
         elif getattr(self, "_cluster_time", None) is None:
             self._cluster_time = self.test.client.admin.command("ping").get("$clusterTime")
-        for entity in self.entities():
+        for entity in self._entities:
             if isinstance(entity, ClientSession):
                 entity.advance_cluster_time(self._cluster_time)
 

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1062,6 +1062,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         if "unpin after non-transient error on abort" in spec["description"]:
             if client_context.version[0] == 8:
                 self.skipTest("Skipping TransientTransactionError pending PYTHON-4182")
+        if "unpin after TransientTransactionError error on" in spec["description"]:
+            self.skipTest("Skipping TransientTransactionError pending PYTHON-4182")
         if self.IS_SERVERLESS_PROXY is not None and (
             "errors during the initial connection hello are ignored" in spec["description"]
             or "pinned connection is released after a transient network commit error"


### PR DESCRIPTION
## Changes

After initialData is added in test.unified_format's run_scenario, we get the $clusterTime from the server, and add this to each of the ClientSession entities before further operations.

## Motivation for the change.

[DRIVERS-2816](https://jira.mongodb.org/browse/DRIVERS-2816)

[Here is the pertinent section of the specifications](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.md?plain=1#L2987-L2998)

