### PR TITLE
PYTHON-4363 Add dependabot config for Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
       actions:
         patterns:
           - "*"
+  # Python
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot will check all of our requirements*.txt files once a week and raise PRs if it sees any CVEs that need to be addressed.  The PR description will show the linked vulnerability for authenticated, and just the version bump publicly.