### PR TITLE
PYTHON-4449 Ensure resume options aren't combined during automatic retry

### DIFF
--- a/pymongo/change_stream.py
+++ b/pymongo/change_stream.py
@@ -179,8 +179,7 @@ class ChangeStream(Generic[_DocumentType]):
                 options["startAfter"] = resume_token
             else:
                 options["resumeAfter"] = resume_token
-
-        if self._start_at_operation_time is not None:
+        elif self._start_at_operation_time is not None:
             options["startAtOperationTime"] = self._start_at_operation_time
 
         if self._show_expanded_events:


### PR DESCRIPTION
As per https://jira.mongodb.org/browse/JAVA-2987 and https://jira.mongodb.org/browse/NODE-2022

If `start_at_operation_time` was supplied to `watch` and the first event is an invalidate, or connection timeout, or anything that triggers an automatic retry - a `pymongo.errors.OperationFailure` is thrown with the message "Only one type of resume option is allowed, but multiple were found"

The solution from those other issues have been mimicked in this PR

Jira link: https://jira.mongodb.org/browse/PYTHON-4449

