### PR TITLE
PYTHON-4468 Hide the value of sensitive subtype binary objects

### DIFF
--- a/bson/binary.py
+++ b/bson/binary.py
@@ -364,4 +364,7 @@ class Binary(bytes):
         return not self == other
 
     def __repr__(self) -> str:
-        return f"Binary({bytes.__repr__(self)}, {self.__subtype})"
+        if self.__subtype == SENSITIVE_SUBTYPE:
+            return f"<Binary(REDACTED, {self.__subtype})>"
+        else:
+            return f"Binary({bytes.__repr__(self)}, {self.__subtype})"

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,7 +20,7 @@ Issues Resolved
 See the `PyMongo 4.7.3 release notes in JIRA`_ for the list of resolved issues
 in this release.
 
-.. _PyMongo 4.7.3 release notes in JIRA:
+.. _PyMongo 4.7.3 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=39865
 
 Changes in Version 4.7.2
 -------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,21 +6,9 @@ Changes in Version 4.8.0
 
 The handshake metadata for "os.name" on Windows has been simplified to "Windows" to improve import time.
 
+The repr of ``bson.binary.Binary`` is now redacted when the subtype is SENSITIVE_SUBTYPE(8).
+
 .. warning:: PyMongo 4.8 drops support for Python 3.7 and PyPy 3.8: Python 3.8+ or PyPy 3.9+ is now required.
-
-Changes in Version 4.7.3
--------------------------
-
-The repr of ``bson.binary.Binary`` is now redacted when the subtype
-is SENSITIVE_SUBTYPE(8).
-
-Issues Resolved
-...............
-
-See the `PyMongo 4.7.3 release notes in JIRA`_ for the list of resolved issues
-in this release.
-
-.. _PyMongo 4.7.3 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=39865
 
 Changes in Version 4.7.2
 -------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,20 @@ The handshake metadata for "os.name" on Windows has been simplified to "Windows"
 
 .. warning:: PyMongo 4.8 drops support for Python 3.7 and PyPy 3.8: Python 3.8+ or PyPy 3.9+ is now required.
 
+Changes in Version 4.7.3
+-------------------------
+
+The repr of ``bson.binary.Binary`` is now redacted when the subtype
+is SENSITIVE_SUBTYPE(8).
+
+Issues Resolved
+...............
+
+See the `PyMongo 4.7.3 release notes in JIRA`_ for the list of resolved issues
+in this release.
+
+.. _PyMongo 4.7.3 release notes in JIRA:
+
 Changes in Version 4.7.2
 -------------------------
 

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -100,3 +100,4 @@ The following is a list of people who have contributed to
 - Stephan Hof (stephan-hof)
 - Casey Clements (caseyclements)
 - Ivan Lukyanchikov (ilukyanchikov)
+- Terry Patterson


### PR DESCRIPTION
[PYTHON-4468](https://jira.mongodb.org/browse/PYTHON-4468)

# Summary

I noticed the `bson.binary.Binary` type include it's
value even when the subtype is sensitive (8)

# Changes in this PR
This PR changes the Binary type's repr to be `<Binary ### {self.__subtype}>` when the subtype is 8.
The `< >` representation follow [general guideline](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_repr) that when a repr can't be roundtripped by `eval` it should use `< >` instead of a constructor like syntax.