### PR TITLE
PYTHON-4347 Make _ServerSessionPool lock-free and still thread safe

### DIFF
--- a/pymongo/asynchronous/bulk.py
+++ b/pymongo/asynchronous/bulk.py
@@ -378,7 +378,7 @@ class _Bulk:
                     if retryable and not self.started_retryable_write:
                         session._start_retryable_write()
                         self.started_retryable_write = True
-                    await session._apply_to(cmd, retryable, ReadPreference.PRIMARY, conn)
+                    session._apply_to(cmd, retryable, ReadPreference.PRIMARY, conn)
                 conn.send_cluster_time(cmd, session, client)
                 conn.add_server_api(cmd)
                 # CSOT: apply timeout before encoding the command.

--- a/pymongo/asynchronous/message.py
+++ b/pymongo/asynchronous/message.py
@@ -394,7 +394,7 @@ class _Query:
         session = self.session
         conn.add_server_api(cmd)
         if session:
-            await session._apply_to(cmd, False, self.read_preference, conn)
+            session._apply_to(cmd, False, self.read_preference, conn)
             # Explain does not support readConcern.
             if not explain and not session.in_transaction:
                 session._update_read_concern(cmd, conn)
@@ -546,7 +546,7 @@ class _GetMore:
             conn,
         )
         if self.session:
-            await self.session._apply_to(cmd, False, self.read_preference, conn)
+            self.session._apply_to(cmd, False, self.read_preference, conn)
         conn.add_server_api(cmd)
         conn.send_cluster_time(cmd, self.session, self.client)
         # Support auto encryption

--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -902,6 +902,8 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
     def _after_fork(self) -> None:
         """Resets topology in a child after successfully forking."""
         self._init_background()
+        # Reset the session pool to avoid duplicate sessions in the child process.
+        self._topology._session_pool.reset()
 
     def _duplicate(self, **kwargs: Any) -> AsyncMongoClient:
         args = self._init_kwargs.copy()
@@ -1508,7 +1510,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
         .. versionchanged:: 3.6
            End all server sessions created by this client.
         """
-        session_ids = await self._topology.pop_all_sessions()
+        session_ids = self._topology.pop_all_sessions()
         if session_ids:
             await self._end_sessions(session_ids)
         # Stop the periodic task thread and then send pending killCursor
@@ -2006,13 +2008,13 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
             else:
                 helpers._handle_exception()
 
-    async def _return_server_session(
-        self, server_session: Union[_ServerSession, _EmptyServerSession], lock: bool
+    def _return_server_session(
+        self, server_session: Union[_ServerSession, _EmptyServerSession]
     ) -> None:
         """Internal: return a _ServerSession to the pool."""
         if isinstance(server_session, _EmptyServerSession):
             return None
-        return await self._topology.return_server_session(server_session, lock)
+        return self._topology.return_server_session(server_session)
 
     @contextlib.asynccontextmanager
     async def _tmp_session(

--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -982,7 +982,7 @@ class Connection:
 
         self.add_server_api(spec)
         if session:
-            await session._apply_to(spec, retryable_write, read_preference, self)
+            session._apply_to(spec, retryable_write, read_preference, self)
         self.send_cluster_time(spec, session, client)
         listeners = self.listeners if publish_events else None
         unacknowledged = bool(write_concern and not write_concern.acknowledged)

--- a/pymongo/asynchronous/topology.py
+++ b/pymongo/asynchronous/topology.py
@@ -671,25 +671,16 @@ class Topology:
     def description(self) -> TopologyDescription:
         return self._description
 
-    async def pop_all_sessions(self) -> list[_ServerSession]:
+    def pop_all_sessions(self) -> list[_ServerSession]:
         """Pop all session ids from the pool."""
-        async with self._lock:
-            return self._session_pool.pop_all()
+        return self._session_pool.pop_all()
 
-    async def get_server_session(self, session_timeout_minutes: Optional[int]) -> _ServerSession:
+    def get_server_session(self, session_timeout_minutes: Optional[int]) -> _ServerSession:
         """Start or resume a server session, or raise ConfigurationError."""
-        async with self._lock:
-            return self._session_pool.get_server_session(session_timeout_minutes)
+        return self._session_pool.get_server_session(session_timeout_minutes)
 
-    async def return_server_session(self, server_session: _ServerSession, lock: bool) -> None:
-        if lock:
-            async with self._lock:
-                self._session_pool.return_server_session(
-                    server_session, self._description.logical_session_timeout_minutes
-                )
-        else:
-            # Called from a __del__ method, can't use a lock.
-            self._session_pool.return_server_session_no_lock(server_session)
+    def return_server_session(self, server_session: _ServerSession) -> None:
+        self._session_pool.return_server_session(server_session)
 
     def _new_selection(self) -> Selection:
         """A Selection object, initially including all known servers.

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -901,6 +901,8 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
     def _after_fork(self) -> None:
         """Resets topology in a child after successfully forking."""
         self._init_background()
+        # Reset the session pool to avoid duplicate sessions in the child process.
+        self._topology._session_pool.reset()
 
     def _duplicate(self, **kwargs: Any) -> MongoClient:
         args = self._init_kwargs.copy()
@@ -2004,12 +2006,12 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
                 helpers._handle_exception()
 
     def _return_server_session(
-        self, server_session: Union[_ServerSession, _EmptyServerSession], lock: bool
+        self, server_session: Union[_ServerSession, _EmptyServerSession]
     ) -> None:
         """Internal: return a _ServerSession to the pool."""
         if isinstance(server_session, _EmptyServerSession):
             return None
-        return self._topology.return_server_session(server_session, lock)
+        return self._topology.return_server_session(server_session)
 
     @contextlib.contextmanager
     def _tmp_session(

--- a/pymongo/synchronous/topology.py
+++ b/pymongo/synchronous/topology.py
@@ -671,23 +671,14 @@ class Topology:
 
     def pop_all_sessions(self) -> list[_ServerSession]:
         """Pop all session ids from the pool."""
-        with self._lock:
-            return self._session_pool.pop_all()
+        return self._session_pool.pop_all()
 
     def get_server_session(self, session_timeout_minutes: Optional[int]) -> _ServerSession:
         """Start or resume a server session, or raise ConfigurationError."""
-        with self._lock:
-            return self._session_pool.get_server_session(session_timeout_minutes)
+        return self._session_pool.get_server_session(session_timeout_minutes)
 
-    def return_server_session(self, server_session: _ServerSession, lock: bool) -> None:
-        if lock:
-            with self._lock:
-                self._session_pool.return_server_session(
-                    server_session, self._description.logical_session_timeout_minutes
-                )
-        else:
-            # Called from a __del__ method, can't use a lock.
-            self._session_pool.return_server_session_no_lock(server_session)
+    def return_server_session(self, server_session: _ServerSession) -> None:
+        self._session_pool.return_server_session(server_session)
 
     def _new_selection(self) -> Selection:
         """A Selection object, initially including all known servers.


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4482

Still todo:

- [X] Benchmark shows a notable improvement for both single threaded and multi-threaded:

```
(pymongo-py39) ➜  mongo-python-driver git:(PYTHON-4482) python bench-command.py 1  
Python: 3.9.13, PyMongo: 4.8.0.dev0, MongoDB: 5.0.15
Running 10000 operations across 1 thread(s)
command: 1.32s
find_one: 1.93s
insert_one: 1.84s
(pymongo-py39) ➜  mongo-python-driver git:(PYTHON-4482) python bench-command.py 100
Python: 3.9.13, PyMongo: 4.8.0.dev0, MongoDB: 5.0.15
Running 10000 operations across 100 thread(s)
command: 1.22s
find_one: 1.52s
insert_one: 1.35s

```

VS master:
```
(pymongo-py39) ➜  mongo-python-driver git:(master) python bench-command.py 1
Python: 3.9.13, PyMongo: 4.8.0.dev0, MongoDB: 5.0.15
Running 10000 operations across 1 thread(s)
command: 1.36s
find_one: 1.95s
insert_one: 1.90s
(pymongo-py39) ➜  mongo-python-driver git:(master) python bench-command.py 100
Python: 3.9.13, PyMongo: 4.8.0.dev0, MongoDB: 5.0.15
Running 10000 operations across 100 thread(s)
command: 1.64s
find_one: 1.67s
insert_one: 1.49s

```