### PR TITLE
PYTHON-4372 & PYTHON-4378 [v4.8] Deprecate Python 3.7 and Update supported PyPy Versions to 3.9 and 3.10

### DIFF
--- a/.evergreen/build-manylinux-internal.sh
+++ b/.evergreen/build-manylinux-internal.sh
@@ -11,7 +11,7 @@ mv dist/* validdist || true
 
 # Compile wheels
 for PYTHON in /opt/python/*/bin/python; do
-    if [[ ! $PYTHON =~ (cp37|cp38|cp39|cp310|cp311|cp312) ]]; then
+    if [[ ! $PYTHON =~ (cp38|cp39|cp310|cp311|cp312) ]]; then
         continue
     fi
     # https://github.com/pypa/manylinux/issues/49

--- a/.evergreen/build-manylinux.sh
+++ b/.evergreen/build-manylinux.sh
@@ -39,7 +39,6 @@ ls dist
 
 # Check for any unexpected files.
 unexpected=$(find dist \! \( -iname dist -or \
-                             -iname '*cp37*' -or \
                              -iname '*cp38*' -or \
                              -iname '*cp39*' -or \
                              -iname '*cp310*' -or \

--- a/.evergreen/build-windows.sh
+++ b/.evergreen/build-windows.sh
@@ -8,7 +8,7 @@ rm -rf validdist
 mkdir -p validdist
 mv dist/* validdist || true
 
-for VERSION in 37 38 39 310 311 312; do
+for VERSION in 38 39 310 311 312; do
     _pythons=("C:/Python/Python${VERSION}/python.exe" \
               "C:/Python/32/Python${VERSION}/python.exe")
     for PYTHON in "${_pythons[@]}"; do

--- a/.evergreen/combine-coverage.sh
+++ b/.evergreen/combine-coverage.sh
@@ -13,9 +13,9 @@ if [ -z "$PYTHON_BINARY" ]; then
 fi
 
 createvirtualenv "$PYTHON_BINARY" covenv
-# coverage 7.3 dropped support for Python 3.7, keep in sync with run-tests.sh
+# Keep in sync with run-tests.sh
 # coverage >=5 is needed for relative_files=true.
-pip install -q "coverage>=5,<7.3"
+pip install -q "coverage>=5,<=7.5"
 
 pip list
 ls -la coverage/

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -834,8 +834,8 @@ functions:
           done
           # Build source distribution.
           cd src/
-          /opt/python/3.7/bin/python3 -m pip install build
-          /opt/python/3.7/bin/python3 -m build --sdist .
+          /opt/python/3.8/bin/python3 -m pip install build
+          /opt/python/3.8/bin/python3 -m build --sdist .
           cp dist/* ../releases
     - command: archive.targz_pack
       params:
@@ -1127,7 +1127,7 @@ tasks:
       commands:
         - func: "build release"
           vars:
-              VERSION: "3.7"
+              VERSION: "3.8"
         - func: "upload release"
 
     - name: "release-windows"
@@ -2375,10 +2375,6 @@ axes:
     values:
       # Note: always display platform with python-version to avoid ambiguous display names.
       # Linux
-      - id: "3.7"
-        display_name: "Python 3.7"
-        variables:
-          PYTHON_BINARY: "/opt/python/3.7/bin/python3"
       - id: "3.8"
         display_name: "Python 3.8"
         variables:
@@ -2399,10 +2395,10 @@ axes:
         display_name: "Python 3.12"
         variables:
           PYTHON_BINARY: "/opt/python/3.12/bin/python3"
-      - id: "pypy3.8"
-        display_name: "PyPy 3.8"
+      - id: "pypy3.9"
+        display_name: "PyPy 3.9"
         variables:
-           PYTHON_BINARY: "/opt/python/pypy3.8/bin/pypy3"
+           PYTHON_BINARY: "/opt/python/pypy3.9/bin/pypy3"
       - id: "pypy3.10"
         display_name: "PyPy 3.10"
         variables:
@@ -2411,10 +2407,6 @@ axes:
   - id: python-version-windows
     display_name: "Python"
     values:
-      - id: "3.7"
-        display_name: "Python 3.7"
-        variables:
-          PYTHON_BINARY: "C:/python/Python37/python.exe"
       - id: "3.8"
         display_name: "Python 3.8"
         variables:
@@ -2439,10 +2431,6 @@ axes:
   - id: python-version-windows-32
     display_name: "Python"
     values:
-      - id: "3.7"
-        display_name: "32-bit Python 3.7"
-        variables:
-          PYTHON_BINARY: "C:/python/32/Python37/python.exe"
       - id: "3.8"
         display_name: "32-bit Python 3.8"
         variables:
@@ -2730,10 +2718,10 @@ buildvariants:
     auth: "*"
     ssl: "ssl"
     pyopenssl: "*"
-  # Only test "noauth" with Python 3.7.
+  # Only test "noauth" with Python 3.8.
   exclude_spec:
     platform: rhel8
-    python-version: ["3.8", "3.9", "3.10", "pypy3.8", "pypy3.10"]
+    python-version: ["3.9", "3.10", "pypy3.9", "pypy3.10"]
     auth: "noauth"
     ssl: "ssl"
     pyopenssl: "*"
@@ -2794,7 +2782,7 @@ buildvariants:
   exclude_spec:
    # These interpreters are always tested without extensions.
    - platform: rhel8
-     python-version: ["pypy3.8", "pypy3.10"]
+     python-version: ["pypy3.9", "pypy3.10"]
      c-extensions: "*"
      auth-ssl: "*"
      coverage: "*"
@@ -2810,7 +2798,7 @@ buildvariants:
   exclude_spec:
    # These interpreters are always tested without extensions.
    - platform: rhel8
-     python-version: ["pypy3.8", "pypy3.10"]
+     python-version: ["pypy3.9", "pypy3.10"]
      c-extensions: "with-c-extensions"
      compression: "*"
   display_name: "${compression} ${c-extensions} ${python-version} ${platform}"
@@ -2839,7 +2827,7 @@ buildvariants:
   exclude_spec:
    # Don't test green frameworks on these Python versions.
    - platform: rhel8
-     python-version: ["pypy3.8", "pypy3.10"]
+     python-version: ["pypy3.9", "pypy3.10"]
      green-framework: "*"
      auth-ssl: "*"
   display_name: "${green-framework} ${python-version} ${platform} ${auth-ssl}"
@@ -2865,7 +2853,7 @@ buildvariants:
   matrix_spec:
     platform: rhel7
     # Python 3.10+ requires OpenSSL 1.1.1+
-    python-version: ["3.7", "3.8", "3.9", "pypy3.8", "pypy3.10"]
+    python-version: ["3.8", "3.9", "pypy3.9", "pypy3.10"]
     auth-ssl: "*"
   display_name: "OpenSSL 1.0.2 ${python-version} ${platform} ${auth-ssl}"
   tasks:
@@ -2888,12 +2876,12 @@ buildvariants:
       then:
         add_tasks: *encryption-server-versions
 
-# Storage engine tests on RHEL 8.4 (x86_64) with Python 3.7.
+# Storage engine tests on RHEL 8.4 (x86_64) with Python 3.8.
 - matrix_name: "tests-storage-engines"
   matrix_spec:
     platform: rhel8
     storage-engine: "*"
-    python-version: 3.7
+    python-version: 3.8
   display_name: "Storage ${storage-engine} ${python-version} ${platform}"
   rules:
     - if:
@@ -2923,12 +2911,12 @@ buildvariants:
           - "test-3.6-standalone"
           - "test-3.6-replica_set"
 
-# enableTestCommands=0 tests on RHEL 8.4 (x86_64) with Python 3.7.
+# enableTestCommands=0 tests on RHEL 8.4 (x86_64) with Python 3.8.
 - matrix_name: "test-disableTestCommands"
   matrix_spec:
     platform: rhel8
     disableTestCommands: "*"
-    python-version: "3.7"
+    python-version: "3.8"
   display_name: "Disable test commands ${python-version} ${platform}"
   tasks:
      - ".latest"
@@ -2962,7 +2950,7 @@ buildvariants:
 - matrix_name: "tests-mod-wsgi"
   matrix_spec:
     platform: ubuntu-22.04
-    python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+    python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     mod-wsgi-version: "*"
   display_name: "${mod-wsgi-version} ${python-version} ${platform}"
   tasks:
@@ -2974,7 +2962,7 @@ buildvariants:
 - matrix_name: "mockupdb-tests"
   matrix_spec:
     platform: rhel8
-    python-version: 3.7
+    python-version: 3.8
   display_name: "MockupDB Tests"
   tasks:
      - name: "mockupdb"
@@ -3022,7 +3010,7 @@ buildvariants:
 - matrix_name: "serverless_proxy"
   matrix_spec:
     platform: rhel8
-    python-version: ["3.7", "3.10"]
+    python-version: ["3.8", "3.10"]
     auth-ssl: auth-ssl
     serverless: "proxy"
   display_name: "${serverless} ${python-version} ${platform}"
@@ -3032,7 +3020,7 @@ buildvariants:
 - matrix_name: "data-lake-spec-tests"
   matrix_spec:
     platform: ubuntu-22.04
-    python-version: ["3.7", "3.10"]
+    python-version: ["3.8", "3.10"]
     auth: "auth"
     c-extensions: "*"
   display_name: "Atlas Data Lake ${python-version} ${c-extensions}"
@@ -3042,7 +3030,7 @@ buildvariants:
 - matrix_name: "stable-api-tests"
   matrix_spec:
     platform: rhel8
-    python-version: ["3.7", "3.10"]
+    python-version: ["3.8", "3.10"]
     auth: "auth"
     versionedApi: "*"
   display_name: "Versioned API ${versionedApi} ${python-version}"
@@ -3055,7 +3043,7 @@ buildvariants:
 - matrix_name: "ocsp-test"
   matrix_spec:
     platform: rhel8
-    python-version: ["3.7", "3.10", "pypy3.8", "pypy3.10"]
+    python-version: ["3.8", "3.10", "pypy3.9", "pypy3.10"]
     mongodb-version: ["4.4", "5.0", "6.0", "7.0", "8.0", "latest"]
     auth: "noauth"
     ssl: "ssl"
@@ -3067,7 +3055,7 @@ buildvariants:
 - matrix_name: "ocsp-test-windows"
   matrix_spec:
     platform: windows-64-vsMulti-small
-    python-version-windows: ["3.7", "3.10"]
+    python-version-windows: ["3.8", "3.10"]
     mongodb-version: ["4.4", "5.0", "6.0", "7.0", "8.0", "latest"]
     auth: "noauth"
     ssl: "ssl"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -247,9 +247,9 @@ python -c 'import sys; print(sys.version)'
 # Only cover CPython. PyPy reports suspiciously low coverage.
 PYTHON_IMPL=$($PYTHON -c "import platform; print(platform.python_implementation())")
 if [ -n "$COVERAGE" ] && [ "$PYTHON_IMPL" = "CPython" ]; then
-    # coverage 7.3 dropped support for Python 3.7, keep in sync with combine-coverage.sh.
+    # Keep in sync with combine-coverage.sh.
     # coverage >=5 is needed for relative_files=true.
-    python -m pip install pytest-cov "coverage>=5,<7.3"
+    python -m pip install pytest-cov "coverage>=5,<=7.5"
     TEST_ARGS="$TEST_ARGS --cov"
 fi
 

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -4,8 +4,8 @@ set -o xtrace
 
 find_python3() {
     PYTHON=""
-    # Add a fallback system python3 if it is available and Python 3.7+.
-    if is_python_37 "$(command -v python3)"; then
+    # Add a fallback system python3 if it is available and Python 3.8+.
+    if is_python_38 "$(command -v python3)"; then
         PYTHON="$(command -v python3)"
     fi
     # Find a suitable toolchain version, if available.
@@ -14,23 +14,23 @@ find_python3() {
         if [ -d "/Library/Frameworks/Python.Framework/Versions/3.10" ]; then
             PYTHON="/Library/Frameworks/Python.Framework/Versions/3.10/bin/python3"
         # macos 10.14
-        elif [ -d "/Library/Frameworks/Python.Framework/Versions/3.7" ]; then
-            PYTHON="/Library/Frameworks/Python.Framework/Versions/3.7/bin/python3"
+        elif [ -d "/Library/Frameworks/Python.Framework/Versions/3.8" ]; then
+            PYTHON="/Library/Frameworks/Python.Framework/Versions/3.8/bin/python3"
         fi
     elif [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
-        PYTHON="C:/python/Python37/python.exe"
+        PYTHON="C:/python/Python38/python.exe"
     else
-        # Prefer our own toolchain, fall back to mongodb toolchain if it has Python 3.7+.
-        if [ -f "/opt/python/3.7/bin/python3" ]; then
-            PYTHON="/opt/python/3.7/bin/python3"
-        elif is_python_37 "$(command -v /opt/mongodbtoolchain/v4/bin/python3)"; then
+        # Prefer our own toolchain, fall back to mongodb toolchain if it has Python 3.8+.
+        if [ -f "/opt/python/3.8/bin/python3" ]; then
+            PYTHON="/opt/python/3.8/bin/python3"
+        elif is_python_38 "$(command -v /opt/mongodbtoolchain/v4/bin/python3)"; then
             PYTHON="/opt/mongodbtoolchain/v4/bin/python3"
-        elif is_python_37 "$(command -v /opt/mongodbtoolchain/v3/bin/python3)"; then
+        elif is_python_38 "$(command -v /opt/mongodbtoolchain/v3/bin/python3)"; then
             PYTHON="/opt/mongodbtoolchain/v3/bin/python3"
         fi
     fi
     if [ -z "$PYTHON" ]; then
-        echo "Cannot test without python3.7+ installed!"
+        echo "Cannot test without python3.8+ installed!"
         exit 1
     fi
     echo "$PYTHON"
@@ -96,15 +96,15 @@ testinstall () {
     fi
 }
 
-# Function that returns success if the provided Python binary is version 3.7 or later
+# Function that returns success if the provided Python binary is version 3.8 or later
 # Usage:
-# is_python_37 /path/to/python
+# is_python_38 /path/to/python
 # * param1: Python binary
-is_python_37() {
+is_python_38() {
     if [ -z "$1" ]; then
         return 1
-    elif $1 -c "import sys; exit(sys.version_info[:2] < (3, 7))"; then
-        # runs when sys.version_info[:2] >= (3, 7)
+    elif $1 -c "import sys; exit(sys.version_info[:2] < (3, 8))"; then
+        # runs when sys.version_info[:2] >= (3, 8)
         return 0
     else
         return 1

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -73,13 +73,12 @@ jobs:
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          CIBW_BUILD: "cp37-${{ matrix.buildplat[1] }} cp38-${{ matrix.buildplat[1] }} cp39-${{ matrix.buildplat[1] }}"
+          CIBW_BUILD: "cp38-${{ matrix.buildplat[1] }} cp39-${{ matrix.buildplat[1] }}"
         run: python -m cibuildwheel --output-dir wheelhouse
 
       - name: Assert all versions in wheelhouse
         if: ${{ ! startsWith(matrix.buildplat[1], 'macos') }}
         run: |
-          ls wheelhouse/*cp37*.whl
           ls wheelhouse/*cp38*.whl
           ls wheelhouse/*cp39*.whl
           ls wheelhouse/*cp310*.whl
@@ -103,7 +102,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           # Build sdist on lowest supported Python
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Build SDist
         run: |

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["3.7", "3.11", "pypy-3.9"]
+        python-version: ["3.8", "3.11", "pypy-3.9"]
     name: CPython ${{ matrix.python-version }}-${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -162,7 +162,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
           # Build sdist on lowest supported Python
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Build SDist
         shell: bash
         run: |
@@ -194,7 +194,7 @@ jobs:
             cache: 'pip'
             cache-dependency-path: 'sdist/test/pyproject.toml'
             # Test sdist on lowest supported Python
-            python-version: '3.7'
+            python-version: '3.8'
         - name: Start MongoDB
           uses: supercharge/mongodb-github-action@1.10.0
         - name: Run Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ be of interest or that has already been addressed.
 
 ## Supported Interpreters
 
-PyMongo supports CPython 3.7+ and PyPy3.8+. Language features not
+PyMongo supports CPython 3.8+ and PyPy3.9+. Language features not
 supported by all interpreters can not be used.
 
 ## Style Guide

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ package that is incompatible with PyMongo.
 
 ## Dependencies
 
-PyMongo supports CPython 3.7+ and PyPy3.7+.
+PyMongo supports CPython 3.8+ and PyPy3.9+.
 
 Required dependencies:
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Changes in Version 4.8.0
+-------------------------
+
+.. warning:: PyMongo 4.8 drops support for Python 3.7 and PyPy 3.8: Python 3.8+ or PyPy 3.9+ is now required.
+
 Changes in Version 4.7.3
 -------------------------
 
@@ -32,7 +37,6 @@ See the `PyMongo 4.7.2 release notes in JIRA`_ for the list of resolved issues
 in this release.
 
 .. _PyMongo 4.7.2 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=39710
-
 
 Changes in Version 4.7.1
 -------------------------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -166,7 +166,7 @@ they are returned to the pool.
 Does PyMongo support Python 3?
 ------------------------------
 
-PyMongo supports CPython 3.7+ and PyPy3.8+. See the :doc:`python3` for details.
+PyMongo supports CPython 3.8+ and PyPy3.9+. See the :doc:`python3` for details.
 
 Does PyMongo support asynchronous frameworks like Gevent, asyncio, Tornado, or Twisted?
 ---------------------------------------------------------------------------------------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -28,7 +28,7 @@ To upgrade using pip::
 Dependencies
 ------------
 
-PyMongo supports CPython 3.7+ and PyPy3.7+.
+PyMongo supports CPython 3.8+ and PyPy3.9+.
 
 Required dependencies
 .....................
@@ -140,7 +140,7 @@ See `http://bugs.python.org/issue11623 <http://bugs.python.org/issue11623>`_
 for a more detailed explanation.
 
 **Lion (10.7) and newer** - PyMongo's C extensions can be built against
-versions of Python 3.7+ downloaded from python.org. In all cases Xcode must be
+versions of Python 3.8+ downloaded from python.org. In all cases Xcode must be
 installed with 'UNIX Development Support'.
 
 **Xcode 5.1**: Starting with version 5.1 the version of clang that ships with

--- a/doc/python3.rst
+++ b/doc/python3.rst
@@ -4,7 +4,7 @@ Python 3 FAQ
 What Python 3 versions are supported?
 -------------------------------------
 
-PyMongo supports CPython 3.7+ and PyPy3.8+.
+PyMongo supports CPython 3.8+ and PyPy3.9+.
 
 Are there any PyMongo behavior changes with Python 3?
 -----------------------------------------------------

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -539,7 +539,7 @@ class PoolOptions:
         #        'name': 'PyMongo|MyDriver',
         #        'version': '4.2.0|1.2.3',
         #    },
-        #    'platform': 'CPython 3.7.0|MyPlatform'
+        #    'platform': 'CPython 3.8.0|MyPlatform'
         # }
         if driver:
             if driver.name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 description = "Python driver for MongoDB <http://www.mongodb.org>"
 readme = "README.md"
 license = {file="LICENSE"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "The MongoDB Python Team" },
 ]
@@ -30,7 +30,6 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
(cherry picked from commit 42f45034f387280840fecb54b1260d80d464024a)