### PR TITLE
Fix incompatibility issue between OCSP dependencies

### DIFF
--- a/requirements/ocsp.txt
+++ b/requirements/ocsp.txt
@@ -1,12 +1,16 @@
-# PyOpenSSL 17.0.0 introduced support for OCSP. 17.1.0 introduced
-# a related feature we need. 17.2.0 fixes a bug
-# in set_default_verify_paths we should really avoid.
+# PyOpenSSL 17.0.0 introduced support for OCSP. 
+# 17.1.0 introduced a related feature we need.
+# 17.2.0 fixes a bug in set_default_verify_paths we should really avoid.
+#
+# PyOpenSSL < 23.2.0 is incompatible with cryptography >= 42.0.0; PyOpenSSL
+# 23.2.0 stopped referencing X509_V_FLAG_NOTIFY_POLICY that was removed in 
+# cryptography 42.0.0. Using compatible minimum versions is an easy solution.
+pyopenssl>=23.2.0
+cryptography>=42.0.0
 # service_identity 18.1.0 introduced support for IP addr matching.
 # Fallback to certifi on Windows if we can't load CA certs from the system
 # store and just use certifi on macOS.
 # https://www.pyopenssl.org/en/stable/api/ssl.html#OpenSSL.SSL.Context.set_default_verify_paths
 certifi;os.name=='nt' or sys_platform=='darwin'
-pyopenssl>=17.2.0
 requests<3.0.0
-cryptography>=2.5
 service_identity>=18.1.0


### PR DESCRIPTION
PyOpenSSL `< 23.2.0` is incompatible with cryptography `>= 42.0.0`; PyOpenSSL 23.2.0 stopped referencing `X509_V_FLAG_NOTIFY_POLICY` that was removed in cryptography 42.0.0. Using compatible minimum versions is an easy solution.

Ref. https://github.com/cve-search/cve-search/issues/1099#issuecomment-2144528101 & https://github.com/conda/conda/issues/13619#issuecomment-2075825121