### PR TITLE
PYTHON-4482 Improve performance by making _ServerSessionPool lock-free (#1660)

### DIFF
--- a/pymongo/client_session.py
+++ b/pymongo/client_session.py
@@ -515,9 +515,6 @@ class ClientSession:
 
         It is an error to use the session after the session has ended.
         """
-        self._end_session(lock=True)
-
-    def _end_session(self, lock: bool) -> None:
         if self._server_session is not None:
             try:
                 if self.in_transaction:
@@ -526,7 +523,7 @@ class ClientSession:
                 # is in the committed state when the session is discarded.
                 self._unpin()
             finally:
-                self._client._return_server_session(self._server_session, lock)
+                self._client._return_server_session(self._server_session)
                 self._server_session = None
 
     def _check_ended(self) -> None:
@@ -537,7 +534,7 @@ class ClientSession:
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self._end_session(lock=True)
+        self.end_session()
 
     @property
     def client(self) -> MongoClient:
@@ -1097,7 +1094,7 @@ class _ServerSession:
 class _ServerSessionPool(collections.deque):
     """Pool of _ServerSession objects.
 
-    This class is not thread-safe, access it while holding the Topology lock.
+    This class is thread-safe.
     """
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -1110,8 +1107,11 @@ class _ServerSessionPool(collections.deque):
 
     def pop_all(self) -> list[_ServerSession]:
         ids = []
-        while self:
-            ids.append(self.pop().session_id)
+        while True:
+            try:
+                ids.append(self.pop().session_id)
+            except IndexError:
+                break
         return ids
 
     def get_server_session(self, session_timeout_minutes: Optional[int]) -> _ServerSession:
@@ -1123,23 +1123,17 @@ class _ServerSessionPool(collections.deque):
         self._clear_stale(session_timeout_minutes)
 
         # The most recently used sessions are on the left.
-        while self:
-            s = self.popleft()
+        while True:
+            try:
+                s = self.popleft()
+            except IndexError:
+                break
             if not s.timed_out(session_timeout_minutes):
                 return s
 
         return _ServerSession(self.generation)
 
-    def return_server_session(
-        self, server_session: _ServerSession, session_timeout_minutes: Optional[int]
-    ) -> None:
-        if session_timeout_minutes is not None:
-            self._clear_stale(session_timeout_minutes)
-            if server_session.timed_out(session_timeout_minutes):
-                return
-        self.return_server_session_no_lock(server_session)
-
-    def return_server_session_no_lock(self, server_session: _ServerSession) -> None:
+    def return_server_session(self, server_session: _ServerSession) -> None:
         # Discard sessions from an old pool to avoid duplicate sessions in the
         # child process after a fork.
         if server_session.generation == self.generation and not server_session.dirty:
@@ -1147,9 +1141,12 @@ class _ServerSessionPool(collections.deque):
 
     def _clear_stale(self, session_timeout_minutes: Optional[int]) -> None:
         # Clear stale sessions. The least recently used are on the right.
-        while self:
-            if self[-1].timed_out(session_timeout_minutes):
-                self.pop()
-            else:
+        while True:
+            try:
+                s = self.pop()
+            except IndexError:
+                break
+            if not s.timed_out(session_timeout_minutes):
+                self.append(s)
                 # The remaining sessions also haven't timed out.
                 break

--- a/pymongo/command_cursor.py
+++ b/pymongo/command_cursor.py
@@ -73,7 +73,7 @@ class CommandCursor(Generic[_DocumentType]):
         self.__killed = self.__id == 0
         self.__comment = comment
         if self.__killed:
-            self.__end_session(True)
+            self.__end_session()
 
         if "ns" in cursor_info:  # noqa: SIM401
             self.__ns = cursor_info["ns"]
@@ -112,9 +112,9 @@ class CommandCursor(Generic[_DocumentType]):
             self.__session = None
         self.__sock_mgr = None
 
-    def __end_session(self, synchronous: bool) -> None:
+    def __end_session(self) -> None:
         if self.__session and not self.__explicit_session:
-            self.__session._end_session(lock=synchronous)
+            self.__session.end_session()
             self.__session = None
 
     def close(self) -> None:

--- a/pymongo/topology.py
+++ b/pymongo/topology.py
@@ -669,23 +669,14 @@ class Topology:
 
     def pop_all_sessions(self) -> list[_ServerSession]:
         """Pop all session ids from the pool."""
-        with self._lock:
-            return self._session_pool.pop_all()
+        return self._session_pool.pop_all()
 
     def get_server_session(self, session_timeout_minutes: Optional[int]) -> _ServerSession:
         """Start or resume a server session, or raise ConfigurationError."""
-        with self._lock:
-            return self._session_pool.get_server_session(session_timeout_minutes)
+        return self._session_pool.get_server_session(session_timeout_minutes)
 
-    def return_server_session(self, server_session: _ServerSession, lock: bool) -> None:
-        if lock:
-            with self._lock:
-                self._session_pool.return_server_session(
-                    server_session, self._description.logical_session_timeout_minutes
-                )
-        else:
-            # Called from a __del__ method, can't use a lock.
-            self._session_pool.return_server_session_no_lock(server_session)
+    def return_server_session(self, server_session: _ServerSession) -> None:
+        self._session_pool.return_server_session(server_session)
 
     def _new_selection(self) -> Selection:
         """A Selection object, initially including all known servers.


### PR DESCRIPTION
(cherry picked from commit 8c35d1e481ed9e2990ac9fbc42d2fa2a0d8e8c44)

Backporting to 4.8 so this can get out sooner. 

https://jira.mongodb.org/browse/PYTHON-4482