### PR TITLE
PYTHON-4497 [v4.8] Fix handling of Python executable in run-tests

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -31,9 +31,6 @@ set -o xtrace
 AUTH=${AUTH:-noauth}
 SSL=${SSL:-nossl}
 TEST_ARGS="${*:1}"
-PYTHON=$(which python)
-# TODO: Remove when we drop PyPy 3.8 support.
-OLD_PYPY=$(python -c "import sys; print(sys.implementation.name.lower() == 'pypy' and sys.implementation.version < (7, 3, 12))")
 
 export PIP_QUIET=1  # Quiet by default
 export PIP_PREFER_BINARY=1 # Prefer binary dists by default
@@ -113,10 +110,6 @@ fi
 
 if [ "$COMPRESSORS" = "snappy" ]; then
     python -m pip install '.[snappy]'
-    if [ "$OLD_PYPY" == "True" ]; then
-        pip install "python-snappy<0.7.0"
-    fi
-    PYTHON=python
 elif [ "$COMPRESSORS" = "zstd" ]; then
     python -m pip install zstandard
 fi
@@ -237,7 +230,7 @@ if [ -n "$PERF_TEST" ]; then
     TEST_ARGS="test/performance/perf_test.py"
 fi
 
-echo "Running $AUTH tests over $SSL with python $PYTHON"
+echo "Running $AUTH tests over $SSL with python $(which python)"
 python -c 'import sys; print(sys.version)'
 
 
@@ -246,7 +239,7 @@ python -c 'import sys; print(sys.version)'
 
 # Run the tests with coverage if requested and coverage is installed.
 # Only cover CPython. PyPy reports suspiciously low coverage.
-PYTHON_IMPL=$($PYTHON -c "import platform; print(platform.python_implementation())")
+PYTHON_IMPL=$(python -c "import platform; print(platform.python_implementation())")
 if [ -n "$COVERAGE" ] && [ "$PYTHON_IMPL" = "CPython" ]; then
     # Keep in sync with combine-coverage.sh.
     # coverage >=5 is needed for relative_files=true.


### PR DESCRIPTION
(cherry picked from commit 2b03001)