### PR TITLE
PYTHON-4347 Ensure client can be opened after fork()

### DIFF
--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -896,6 +896,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
         # this closure. When the client is freed, stop the executor soon.
         self_ref: Any = weakref.ref(self, executor.close)
         self._kill_cursors_executor = executor
+        self._opened = False
 
     def _should_pin_cursor(self, session: Optional[ClientSession]) -> Optional[bool]:
         return self._options.load_balanced and not (session and session.in_transaction)

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -895,6 +895,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
         # this closure. When the client is freed, stop the executor soon.
         self_ref: Any = weakref.ref(self, executor.close)
         self._kill_cursors_executor = executor
+        self._opened = False
 
     def _should_pin_cursor(self, session: Optional[ClientSession]) -> Optional[bool]:
         return self._options.load_balanced and not (session and session.in_transaction)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4347

This regression should have been caught in the original PR but some of the fork() tests were accidentally disabled in PYTHON-4264:
```python
    @unittest.skip("testing")
    def test_topology_reset(self):
```

We'll open another PR to re-enable those tests.