### PR TITLE
PYTHON-4347 Ensure client can be opened after fork()

### DIFF
--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -904,6 +904,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
         # this closure. When the client is freed, stop the executor soon.
         self_ref: Any = weakref.ref(self, executor.close)
         self._kill_cursors_executor = executor
+        self._opened = False
 
     def _after_fork(self) -> None:
         """Resets topology in a child after successfully forking."""


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4347

Backport of https://github.com/mongodb/mongo-python-driver/pull/1681

Fixes a timeout running test_topology_reset:
```
Timeout (0:25:00)!
Thread 0x00007f06b9ffd700 (most recent call first):
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/periodic_executor.py", line 156 in _run
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/threading.py", line 870 in run
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f06baffe700 (most recent call first):
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/periodic_executor.py", line 156 in _run
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/threading.py", line 870 in run
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f06bbfff700 (most recent call first):
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/socket_checker.py", line 66 in select
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/network.py", line 375 in wait_for_read
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/network.py", line 394 in _receive_data_on_socket
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/network.py", line 317 in receive_message
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/pool.py", line 1040 in receive_message
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/pool.py", line 921 in _next_reply
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/monitor.py", line 304 in _check_with_socket
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/monitor.py", line 282 in _check_once
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/monitor.py", line 235 in _check_server
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/monitor.py", line 192 in _run
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/monitor.py", line 62 in target
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/periodic_executor.py", line 141 in _run
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/threading.py", line 870 in run
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f06d2a37740 (most recent call first):
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/multiprocessing/connection.py", line 379 in _recv
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/multiprocessing/connection.py", line 414 in _recv_bytes
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/multiprocessing/connection.py", line 250 in recv
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/test/test_fork.py", line 93 in test_topology_reset
```