### PR TITLE
PYTHON-2052 Truncate client metadata document to 512 bytes

### DIFF
--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -403,7 +403,7 @@ def _truncate_metadata(metadata: MutableMapping[str, Any]) -> None:
     if driver:
         # Truncate driver version.
         driver_version = driver.get("version")[:-overflow]
-        if driver_version:
+        if len(driver_version) >= len(_METADATA["driver"]["version"]):
             metadata["driver"]["version"] = driver_version
         else:
             metadata["driver"]["version"] = _METADATA["driver"]["version"]
@@ -413,7 +413,10 @@ def _truncate_metadata(metadata: MutableMapping[str, Any]) -> None:
         # Truncate driver name.
         overflow = encoded_size - _MAX_METADATA_SIZE
         driver_name = driver.get("name")[:-overflow]
-        metadata["driver"]["name"] = driver_name
+        if len(driver_name) >= len(_METADATA["driver"]["name"]):
+            metadata["driver"]["name"] = driver_name
+        else:
+            metadata["driver"]["name"] = _METADATA["driver"]["name"]
 
 
 # If the first getaddrinfo call of this interpreter's life is on a thread,

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -403,7 +403,7 @@ def _truncate_metadata(metadata: MutableMapping[str, Any]) -> None:
     if driver:
         # Truncate driver version.
         driver_version = driver.get("version")[:-overflow]
-        if driver_version:
+        if len(driver_version) >= len(_METADATA["driver"]["version"]):
             metadata["driver"]["version"] = driver_version
         else:
             metadata["driver"]["version"] = _METADATA["driver"]["version"]
@@ -413,7 +413,10 @@ def _truncate_metadata(metadata: MutableMapping[str, Any]) -> None:
         # Truncate driver name.
         overflow = encoded_size - _MAX_METADATA_SIZE
         driver_name = driver.get("name")[:-overflow]
-        metadata["driver"]["name"] = driver_name
+        if len(driver_name) >= len(_METADATA["driver"]["name"]):
+            metadata["driver"]["name"] = driver_name
+        else:
+            metadata["driver"]["name"] = _METADATA["driver"]["name"]
 
 
 # If the first getaddrinfo call of this interpreter's life is on a thread,

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -364,14 +364,18 @@ class ClientUnitTest(unittest.TestCase):
         options = client.options
         self.assertEqual(options.pool_options.metadata, metadata)
         # Test truncating driver info metadata.
-        client = MongoClient(driver=DriverInfo(name="s" * _MAX_METADATA_SIZE))
+        client = MongoClient(
+            driver=DriverInfo(name="s" * _MAX_METADATA_SIZE),
+            connect=False,
+        )
         options = client.options
         self.assertLessEqual(
             len(bson.encode(options.pool_options.metadata)),
             _MAX_METADATA_SIZE,
         )
         client = MongoClient(
-            driver=DriverInfo(name="s" * _MAX_METADATA_SIZE, version="s" * _MAX_METADATA_SIZE)
+            driver=DriverInfo(name="s" * _MAX_METADATA_SIZE, version="s" * _MAX_METADATA_SIZE),
+            connect=False,
         )
         options = client.options
         self.assertLessEqual(

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -72,6 +72,7 @@ from test.utils import (
     wait_until,
 )
 
+import bson
 import pymongo
 from bson import encode
 from bson.codec_options import (
@@ -106,6 +107,7 @@ from pymongo.synchronous.database import Database
 from pymongo.synchronous.mongo_client import MongoClient
 from pymongo.synchronous.monitoring import ServerHeartbeatListener, ServerHeartbeatStartedEvent
 from pymongo.synchronous.pool import (
+    _MAX_METADATA_SIZE,
     _METADATA,
     ENV_VAR_K8S,
     Connection,
@@ -362,24 +364,20 @@ class ClientUnitTest(unittest.TestCase):
         options = client.options
         self.assertEqual(options.pool_options.metadata, metadata)
         # Test truncating driver info metadata.
-        client = MongoClient(driver=DriverInfo(name="s" * 512))
+        client = MongoClient(driver=DriverInfo(name="s" * _MAX_METADATA_SIZE))
         options = client.options
-        self.assertLess(
-            len(options.pool_options.metadata["driver"]["name"]),
-            len(_METADATA["driver"]["name"]) + 514,
+        self.assertLessEqual(
+            len(bson.encode(options.pool_options.metadata)),
+            _MAX_METADATA_SIZE,
         )
-        client.admin.command("isMaster")
-        client = MongoClient(driver=DriverInfo(name="s" * 512, version="s" * 512))
+        client = MongoClient(
+            driver=DriverInfo(name="s" * _MAX_METADATA_SIZE, version="s" * _MAX_METADATA_SIZE)
+        )
         options = client.options
-        self.assertLess(
-            len(options.pool_options.metadata["driver"]["name"]),
-            len(_METADATA["driver"]["name"]) + 514,
+        self.assertLessEqual(
+            len(bson.encode(options.pool_options.metadata)),
+            _MAX_METADATA_SIZE,
         )
-        self.assertLess(
-            len(options.pool_options.metadata["driver"]["version"]),
-            len(_METADATA["driver"]["version"]) + 514,
-        )
-        client.admin.command("isMaster")
 
     @mock.patch.dict("os.environ", {ENV_VAR_K8S: "1"})
     def test_container_metadata(self):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -361,6 +361,25 @@ class ClientUnitTest(unittest.TestCase):
         )
         options = client.options
         self.assertEqual(options.pool_options.metadata, metadata)
+        # Test truncating driver info metadata.
+        client = MongoClient(driver=DriverInfo(name="s" * 512))
+        options = client.options
+        self.assertLess(
+            len(options.pool_options.metadata["driver"]["name"]),
+            len(_METADATA["driver"]["name"]) + 514,
+        )
+        client.admin.command("isMaster")
+        client = MongoClient(driver=DriverInfo(name="s" * 512, version="s" * 512))
+        options = client.options
+        self.assertLess(
+            len(options.pool_options.metadata["driver"]["name"]),
+            len(_METADATA["driver"]["name"]) + 514,
+        )
+        self.assertLess(
+            len(options.pool_options.metadata["driver"]["version"]),
+            len(_METADATA["driver"]["version"]) + 514,
+        )
+        client.admin.command("isMaster")
 
     @mock.patch.dict("os.environ", {ENV_VAR_K8S: "1"})
     def test_container_metadata(self):


### PR DESCRIPTION
This PR adds to the existing pymongo client metadata truncation logic by truncating the `DriverInfo` name and version fields. It also introduces tests to validate this metadata truncation.