### PR TITLE
PYTHON-4529 Require pymongocrypt>=1.10

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,6 +7,7 @@ Changes in Version 4.9.0
 PyMongo 4.9 brings a number of improvements including:
 
 - A new asynchronous API with full asyncio support.
+- pymongocrypt>=1.10 is now required for :ref:`In-Use Encryption` support.
 
 Issues Resolved
 ...............

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -574,7 +574,7 @@ class ClientEncryption(Generic[_DocumentType]):
             raise ConfigurationError(
                 "client-side field level encryption requires the pymongocrypt "
                 "library: install a compatible version with: "
-                "python -m pip install 'pymongo[encryption]'"
+                "python -m pip install --upgrade 'pymongo[encryption]'"
             )
 
         if not isinstance(codec_options, CodecOptions):

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -21,7 +21,7 @@ try:
     import pymongocrypt  # type:ignore[import] # noqa: F401
 
     # Check for pymongocrypt>=1.10.
-    from pymongocrypt import synchronous as _synchronous  # type:ignore[import] # noqa: F401
+    from pymongocrypt import synchronous as _  # noqa: F401
 
     _HAVE_PYMONGOCRYPT = True
 except ImportError:

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -20,6 +20,9 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional
 try:
     import pymongocrypt  # type:ignore[import] # noqa: F401
 
+    # Check for pymongocrypt>=1.10.
+    from pymongocrypt import synchronous as _synchronous  # type:ignore[import] # noqa: F401
+
     _HAVE_PYMONGOCRYPT = True
 except ImportError:
     _HAVE_PYMONGOCRYPT = False

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -572,7 +572,7 @@ class ClientEncryption(Generic[_DocumentType]):
             raise ConfigurationError(
                 "client-side field level encryption requires the pymongocrypt "
                 "library: install a compatible version with: "
-                "python -m pip install 'pymongo[encryption]'"
+                "python -m pip install --upgrade 'pymongo[encryption]'"
             )
 
         if not isinstance(codec_options, CodecOptions):

--- a/requirements/encryption.txt
+++ b/requirements/encryption.txt
@@ -1,3 +1,3 @@
 pymongo-auth-aws>=1.1.0,<2.0.0
-pymongocrypt>=1.6.0,<2.0.0
+pymongocrypt>=1.10.0,<2.0.0
 certifi;os.name=='nt' or sys_platform=='darwin'


### PR DESCRIPTION
Attempting to use pymongo with an outdated version of pymongocrypt now correctly raises this error:
```python
            raise ConfigurationError(
                "client-side field level encryption requires the pymongocrypt "
                "library: install a compatible version with: "
                "python -m pip install --upgrade 'pymongo[encryption]'"
            )
```

https://jira.mongodb.org/browse/PYTHON-4529