### PR TITLE
Remove "/" from dbase

### DIFF
--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -502,6 +502,8 @@ def parse_uri(
 
     if dbase:
         dbase = unquote_plus(dbase)
+        if "/" == dbase[0]:
+            dbase = dbase[1:]
         if "." in dbase:
             dbase, collection = dbase.split(".", 1)
         if _BAD_DB_CHARS.search(dbase):


### PR DESCRIPTION
Remove the / to avoid communication errors and thus leave only the database name in the dbase variable