### PR TITLE
PYTHON-4588 Don't include invalid port in URI parsing error message

### DIFF
--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -144,6 +144,12 @@ def parse_host(entity: str, default_port: Optional[int] = DEFAULT_PORT) -> _Addr
         host, port = host.split(":", 1)
     if isinstance(port, str):
         if not port.isdigit():
+            # Special case check for mistakes like "mongodb://localhost:27017 ".
+            if all(c.isspace() or c.isdigit() for c in port):
+                for c in port:
+                    if c.isspace():
+                        raise ValueError(f"Port contains whitespace character: {c!r}")
+
             # A non-digit port indicates that the URI is invalid, likely because the password
             # or username were not escaped.
             raise ValueError(

--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -143,8 +143,15 @@ def parse_host(entity: str, default_port: Optional[int] = DEFAULT_PORT) -> _Addr
             )
         host, port = host.split(":", 1)
     if isinstance(port, str):
-        if not port.isdigit() or int(port) > 65535 or int(port) <= 0:
-            raise ValueError(f"Port must be an integer between 0 and 65535: {port!r}")
+        if not port.isdigit():
+            # A non-digit port indicates that the URI is invalid, likely because the password
+            # or username were not escaped.
+            raise ValueError(
+                "Port contains non-digit characters. Hint: username and password must be escaped according to "
+                "RFC 3986, use urllib.parse.quote_plus"
+            )
+        if int(port) > 65535 or int(port) <= 0:
+            raise ValueError("Port must be an integer between 0 and 65535")
         port = int(port)
 
     # Normalize hostname to lowercase, since DNS is case-insensitive:

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -536,6 +536,20 @@ class TestURI(unittest.TestCase):
         self.assertEqual(user, res["username"])
         self.assertEqual(pwd, res["password"])
 
+    def test_do_not_include_password_in_port_message(self):
+        with self.assertRaisesRegex(ValueError, "Port must be an integer between 0 and 65535"):
+            parse_uri("mongodb://localhost:65536")
+        with self.assertRaisesRegex(
+            ValueError, "Port contains non-digit characters. Hint: username "
+        ) as ctx:
+            parse_uri("mongodb://user:PASS/@localhost:27017")
+        self.assertNotIn("PASS", str(ctx.exception))
+
+        # This "invalid" case is technically a valid URI:
+        res = parse_uri("mongodb://user:1234/@localhost:27017")
+        self.assertEqual([("user", 1234)], res["nodelist"])
+        self.assertEqual("@localhost:27017", res["database"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-4588

An invalid port could include part of the user's password so we should avoid including it in the error message.