### PR TITLE
PYTHON-4589 - Add async API docs

### DIFF
--- a/doc/api/pymongo/asynchronous/change_stream.rst
+++ b/doc/api/pymongo/asynchronous/change_stream.rst
@@ -1,0 +1,5 @@
+:mod:`change_stream` -- Watch changes on a collection, database, or cluster
+===========================================================================
+
+.. automodule:: pymongo.asynchronous.change_stream
+   :members:

--- a/doc/api/pymongo/asynchronous/client_session.rst
+++ b/doc/api/pymongo/asynchronous/client_session.rst
@@ -1,0 +1,5 @@
+:mod:`client_session` -- Logical sessions for sequential operations
+===================================================================
+
+.. automodule:: pymongo.asynchronous.client_session
+   :members:

--- a/doc/api/pymongo/asynchronous/collection.rst
+++ b/doc/api/pymongo/asynchronous/collection.rst
@@ -1,0 +1,61 @@
+:mod:`collection` -- Collection level operations
+================================================
+
+.. automodule:: pymongo.asynchronous.collection
+   :synopsis: Collection level operations
+
+   .. autoclass:: pymongo.asynchronous.collection.ReturnDocument
+
+   .. autoclass:: pymongo.asynchronous.collection.AsyncCollection(database, name, create=False, **kwargs)
+
+      .. describe:: c[name] || c.name
+
+         Get the `name` sub-collection of :class:`AsyncCollection` `c`.
+
+         Raises :class:`~pymongo.asynchronous.errors.InvalidName` if an invalid
+         collection name is used.
+
+      .. autoattribute:: full_name
+      .. autoattribute:: name
+      .. autoattribute:: database
+      .. autoattribute:: codec_options
+      .. autoattribute:: read_preference
+      .. autoattribute:: write_concern
+      .. autoattribute:: read_concern
+      .. automethod:: with_options
+      .. automethod:: bulk_write
+      .. automethod:: insert_one
+      .. automethod:: insert_many
+      .. automethod:: replace_one
+      .. automethod:: update_one
+      .. automethod:: update_many
+      .. automethod:: delete_one
+      .. automethod:: delete_many
+      .. automethod:: aggregate
+      .. automethod:: aggregate_raw_batches
+      .. automethod:: watch
+      .. automethod:: find(filter=None, projection=None, skip=0, limit=0, no_cursor_timeout=False, cursor_type=CursorType.NON_TAILABLE, sort=None, allow_partial_results=False, oplog_replay=False, batch_size=0, collation=None, hint=None, max_scan=None, max_time_ms=None, max=None, min=None, return_key=False, show_record_id=False, snapshot=False, comment=None, session=None, allow_disk_use=None)
+      .. automethod:: find_raw_batches(filter=None, projection=None, skip=0, limit=0, no_cursor_timeout=False, cursor_type=CursorType.NON_TAILABLE, sort=None, allow_partial_results=False, oplog_replay=False, batch_size=0, collation=None, hint=None, max_scan=None, max_time_ms=None, max=None, min=None, return_key=False, show_record_id=False, snapshot=False, comment=None, session=None, allow_disk_use=None)
+      .. automethod:: find_one(filter=None, *args, **kwargs)
+      .. automethod:: find_one_and_delete
+      .. automethod:: find_one_and_replace(filter, replacement, projection=None, sort=None, return_document=ReturnDocument.BEFORE, hint=None, session=None, **kwargs)
+      .. automethod:: find_one_and_update(filter, update, projection=None, sort=None, return_document=ReturnDocument.BEFORE, array_filters=None, hint=None, session=None, **kwargs)
+      .. automethod:: count_documents
+      .. automethod:: estimated_document_count
+      .. automethod:: distinct
+      .. automethod:: create_index
+      .. automethod:: create_indexes
+      .. automethod:: drop_index
+      .. automethod:: drop_indexes
+      .. automethod:: list_indexes
+      .. automethod:: index_information
+      .. automethod:: create_search_index
+      .. automethod:: create_search_indexes
+      .. automethod:: drop_search_index
+      .. automethod:: list_search_indexes
+      .. automethod:: update_search_index
+      .. automethod:: drop
+      .. automethod:: rename
+      .. automethod:: options
+      .. automethod:: __getitem__
+      .. automethod:: __getattr__

--- a/doc/api/pymongo/asynchronous/command_cursor.rst
+++ b/doc/api/pymongo/asynchronous/command_cursor.rst
@@ -1,0 +1,6 @@
+:mod:`command_cursor` -- Tools for iterating over MongoDB command results
+=========================================================================
+
+.. automodule:: pymongo.asynchronous.command_cursor
+   :synopsis: Tools for iterating over MongoDB command results
+   :members:

--- a/doc/api/pymongo/asynchronous/cursor.rst
+++ b/doc/api/pymongo/asynchronous/cursor.rst
@@ -1,0 +1,16 @@
+:mod:`cursor` -- Tools for iterating over MongoDB query results
+===============================================================
+
+.. automodule:: pymongo.asynchronous.cursor
+   :synopsis: Tools for iterating over MongoDB query results
+
+   .. autoclass:: pymongo.asynchronous.cursor.AsyncCursor(collection, filter=None, projection=None, skip=0, limit=0, no_cursor_timeout=False, cursor_type=CursorType.NON_TAILABLE, sort=None, allow_partial_results=False, oplog_replay=False, batch_size=0, collation=None, hint=None, max_scan=None, max_time_ms=None, max=None, min=None, return_key=False, show_record_id=False, snapshot=False, comment=None, session=None, allow_disk_use=None)
+      :members:
+
+      .. describe:: c[index]
+
+         See :meth:`__getitem__` and read the warning.
+
+      .. automethod:: __getitem__
+
+   .. autoclass:: pymongo.asynchronous.cursor.AsyncRawBatchCursor(collection, filter=None, projection=None, skip=0, limit=0, no_cursor_timeout=False, cursor_type=CursorType.NON_TAILABLE, sort=None, allow_partial_results=False, oplog_replay=False, batch_size=0, collation=None, hint=None, max_scan=None, max_time_ms=None, max=None, min=None, return_key=False, show_record_id=False, snapshot=False, comment=None, allow_disk_use=None)

--- a/doc/api/pymongo/asynchronous/database.rst
+++ b/doc/api/pymongo/asynchronous/database.rst
@@ -1,0 +1,26 @@
+:mod:`database` -- Database level operations
+============================================
+
+.. automodule:: pymongo.asynchronous.database
+   :synopsis: Database level operations
+
+   .. autoclass:: pymongo.asynchronous.database.AsyncDatabase
+      :members:
+
+      .. describe:: db[collection_name] || db.collection_name
+
+         Get the `collection_name` :class:`~pymongo.asynchronous.collection.AsyncCollection` of
+         :class:`AsyncDatabase` `db`.
+
+         Raises :class:`~pymongo.errors.InvalidName` if an invalid collection
+         name is used.
+
+         .. note::  Use dictionary style access if `collection_name` is an
+            attribute of the :class:`AsyncDatabase` class eg: db[`collection_name`].
+
+      .. automethod:: __getitem__
+      .. automethod:: __getattr__
+      .. autoattribute:: codec_options
+      .. autoattribute:: read_preference
+      .. autoattribute:: write_concern
+      .. autoattribute:: read_concern

--- a/doc/api/pymongo/asynchronous/index.rst
+++ b/doc/api/pymongo/asynchronous/index.rst
@@ -1,0 +1,22 @@
+:mod:`pymongo async` -- Async Python driver for MongoDB
+=======================================================
+
+.. automodule:: pymongo.asynchronous
+   :synopsis: Asynchronous Python driver for MongoDB
+
+   .. data:: AsyncMongoClient
+
+      Alias for :class:`pymongo.asynchronous.mongo_client.MongoClient`.
+
+Sub-modules:
+
+.. toctree::
+   :maxdepth: 2
+
+   change_stream
+   client_session
+   collection
+   command_cursor
+   cursor
+   database
+   mongo_client

--- a/doc/api/pymongo/asynchronous/mongo_client.rst
+++ b/doc/api/pymongo/asynchronous/mongo_client.rst
@@ -1,0 +1,39 @@
+:mod:`mongo_client` -- Tools for connecting to MongoDB
+======================================================
+
+.. automodule:: pymongo.asynchronous.mongo_client
+   :synopsis: Tools for connecting to MongoDB
+
+   .. autoclass:: pymongo.asynchronous.mongo_client.AsyncMongoClient(host='localhost', port=27017, document_class=dict, tz_aware=False, connect=True, **kwargs)
+
+      .. automethod:: aclose
+
+      .. describe:: c[db_name] || c.db_name
+
+         Get the `db_name` :class:`~pymongo.asynchronous.database.AsyncDatabase` on :class:`AsyncMongoClient` `c`.
+
+         Raises :class:`~pymongo.errors.InvalidName` if an invalid database name is used.
+
+      .. autoattribute:: topology_description
+      .. autoattribute:: address
+      .. autoattribute:: primary
+      .. autoattribute:: secondaries
+      .. autoattribute:: arbiters
+      .. autoattribute:: is_primary
+      .. autoattribute:: is_mongos
+      .. autoattribute:: nodes
+      .. autoattribute:: codec_options
+      .. autoattribute:: read_preference
+      .. autoattribute:: write_concern
+      .. autoattribute:: read_concern
+      .. autoattribute:: options
+      .. automethod:: start_session
+      .. automethod:: list_databases
+      .. automethod:: list_database_names
+      .. automethod:: drop_database
+      .. automethod:: get_default_database
+      .. automethod:: get_database
+      .. automethod:: server_info
+      .. automethod:: watch
+      .. automethod:: __getitem__
+      .. automethod:: __getattr__

--- a/doc/api/pymongo/index.rst
+++ b/doc/api/pymongo/index.rst
@@ -9,6 +9,10 @@
 
       Alias for :class:`pymongo.mongo_client.MongoClient`.
 
+   .. data:: AsyncMongoClient
+
+      Alias for :class:`pymongo.asynchronous.mongo_client.AsyncMongoClient`.
+
    .. data:: ReadPreference
 
       Alias for :class:`pymongo.read_preferences.ReadPreference`.
@@ -27,8 +31,9 @@
 Sub-modules:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
+   asynchronous/index
    auth_oidc
    change_stream
    client_options

--- a/pymongo/asynchronous/change_stream.py
+++ b/pymongo/asynchronous/change_stream.py
@@ -87,7 +87,7 @@ def _resumable(exc: PyMongoError) -> bool:
     return False
 
 
-class ChangeStream(Generic[_DocumentType]):
+class AsyncChangeStream(Generic[_DocumentType]):
     """The internal abstract base class for change stream cursors.
 
     Should not be called directly by application developers. Use
@@ -276,7 +276,7 @@ class ChangeStream(Generic[_DocumentType]):
         self._closed = True
         await self._cursor.close()
 
-    def __aiter__(self) -> ChangeStream[_DocumentType]:
+    def __aiter__(self) -> AsyncChangeStream[_DocumentType]:
         return self
 
     @property
@@ -436,14 +436,14 @@ class ChangeStream(Generic[_DocumentType]):
             return _bson_to_dict(change.raw, self._orig_codec_options)
         return change
 
-    async def __aenter__(self) -> ChangeStream[_DocumentType]:
+    async def __aenter__(self) -> AsyncChangeStream[_DocumentType]:
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         await self.close()
 
 
-class CollectionChangeStream(ChangeStream[_DocumentType]):
+class AsyncCollectionChangeStream(AsyncChangeStream[_DocumentType]):
     """A change stream that watches changes on a single collection.
 
     Should not be called directly by application developers. Use
@@ -463,7 +463,7 @@ class CollectionChangeStream(ChangeStream[_DocumentType]):
         return self._target.database.client
 
 
-class DatabaseChangeStream(ChangeStream[_DocumentType]):
+class AsyncDatabaseChangeStream(AsyncChangeStream[_DocumentType]):
     """A change stream that watches changes on all collections in a database.
 
     Should not be called directly by application developers. Use
@@ -483,7 +483,7 @@ class DatabaseChangeStream(ChangeStream[_DocumentType]):
         return self._target.client
 
 
-class ClusterChangeStream(DatabaseChangeStream[_DocumentType]):
+class AsyncClusterChangeStream(AsyncDatabaseChangeStream[_DocumentType]):
     """A change stream that watches changes on all collections in the cluster.
 
     Should not be called directly by application developers. Use

--- a/pymongo/asynchronous/client_session.py
+++ b/pymongo/asynchronous/client_session.py
@@ -36,7 +36,7 @@ guaranteed monotonic reads, even when reading from replica set secondaries.
 
 .. seealso:: The MongoDB documentation on `causal-consistency <https://dochub.mongodb.org/core/causal-consistency>`_.
 
-.. _transactions-ref:
+.. _async-transactions-ref:
 
 Transactions
 ============
@@ -93,7 +93,7 @@ running either commitTransaction or abortTransaction, the session is unpinned.
 
 .. seealso:: The MongoDB documentation on `transactions <https://dochub.mongodb.org/core/transactions>`_.
 
-.. _snapshot-reads-ref:
+.. _async-snapshot-reads-ref:
 
 Snapshot Reads
 ==============

--- a/pymongo/asynchronous/collection.py
+++ b/pymongo/asynchronous/collection.py
@@ -48,7 +48,7 @@ from pymongo.asynchronous.aggregation import (
     _CollectionRawAggregationCommand,
 )
 from pymongo.asynchronous.bulk import _AsyncBulk
-from pymongo.asynchronous.change_stream import CollectionChangeStream
+from pymongo.asynchronous.change_stream import AsyncCollectionChangeStream
 from pymongo.asynchronous.command_cursor import (
     AsyncCommandCursor,
     AsyncRawBatchCommandCursor,
@@ -417,12 +417,12 @@ class AsyncCollection(common.BaseObject, Generic[_DocumentType]):
         comment: Optional[Any] = None,
         full_document_before_change: Optional[str] = None,
         show_expanded_events: Optional[bool] = None,
-    ) -> CollectionChangeStream[_DocumentType]:
+    ) -> AsyncCollectionChangeStream[_DocumentType]:
         """Watch changes on this collection.
 
         Performs an aggregation with an implicit initial ``$changeStream``
         stage and returns a
-        :class:`~pymongo.change_stream.CollectionChangeStream` cursor which
+        :class:`~pymongo.asynchronous.change_stream.AsyncCollectionChangeStream` cursor which
         iterates over changes on this collection.
 
         .. code-block:: python
@@ -431,10 +431,10 @@ class AsyncCollection(common.BaseObject, Generic[_DocumentType]):
                async for change in stream:
                    print(change)
 
-        The :class:`~pymongo.change_stream.CollectionChangeStream` iterable
+        The :class:`~pymongo.asynchronous.change_stream.AsyncCollectionChangeStream` iterable
         blocks until the next change document is returned or an error is
         raised. If the
-        :meth:`~pymongo.change_stream.CollectionChangeStream.next` method
+        :meth:`~pymongo.asynchronous.change_stream.AsyncCollectionChangeStream.next` method
         encounters a network error when retrieving a batch from the server,
         it will automatically attempt to recreate the cursor such that no
         change events are missed. Any error encountered during the resume
@@ -501,7 +501,7 @@ class AsyncCollection(common.BaseObject, Generic[_DocumentType]):
             command.
         :param show_expanded_events: Include expanded events such as DDL events like `dropIndexes`.
 
-        :return: A :class:`~pymongo.change_stream.CollectionChangeStream` cursor.
+        :return: A :class:`~pymongo.asynchronous.change_stream.AsyncCollectionChangeStream` cursor.
 
         .. versionchanged:: 4.3
            Added `show_expanded_events` parameter.
@@ -525,7 +525,7 @@ class AsyncCollection(common.BaseObject, Generic[_DocumentType]):
         .. _change streams specification:
             https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md
         """
-        change_stream = CollectionChangeStream(
+        change_stream = AsyncCollectionChangeStream(
             self,
             pipeline,
             full_document,

--- a/pymongo/asynchronous/database.py
+++ b/pymongo/asynchronous/database.py
@@ -35,7 +35,7 @@ from bson.dbref import DBRef
 from bson.timestamp import Timestamp
 from pymongo import _csot, common
 from pymongo.asynchronous.aggregation import _DatabaseAggregationCommand
-from pymongo.asynchronous.change_stream import DatabaseChangeStream
+from pymongo.asynchronous.change_stream import AsyncDatabaseChangeStream
 from pymongo.asynchronous.collection import AsyncCollection
 from pymongo.asynchronous.command_cursor import AsyncCommandCursor
 from pymongo.common import _ecoc_coll_name, _esc_coll_name
@@ -332,12 +332,12 @@ class AsyncDatabase(common.BaseObject, Generic[_DocumentType]):
         comment: Optional[Any] = None,
         full_document_before_change: Optional[str] = None,
         show_expanded_events: Optional[bool] = None,
-    ) -> DatabaseChangeStream[_DocumentType]:
+    ) -> AsyncDatabaseChangeStream[_DocumentType]:
         """Watch changes on this database.
 
         Performs an aggregation with an implicit initial ``$changeStream``
         stage and returns a
-        :class:`~pymongo.change_stream.DatabaseChangeStream` cursor which
+        :class:`~pymongo.asynchronous.change_stream.AsyncDatabaseChangeStream` cursor which
         iterates over changes on all collections in this database.
 
         Introduced in MongoDB 4.0.
@@ -348,10 +348,10 @@ class AsyncDatabase(common.BaseObject, Generic[_DocumentType]):
                async for change in stream:
                    print(change)
 
-        The :class:`~pymongo.change_stream.DatabaseChangeStream` iterable
+        The :class:`~pymongo.asynchronous.change_stream.AsyncDatabaseChangeStream` iterable
         blocks until the next change document is returned or an error is
         raised. If the
-        :meth:`~pymongo.change_stream.DatabaseChangeStream.next` method
+        :meth:`~pymongo.asynchronous.change_stream.AsyncDatabaseChangeStream.next` method
         encounters a network error when retrieving a batch from the server,
         it will automatically attempt to recreate the cursor such that no
         change events are missed. Any error encountered during the resume
@@ -409,7 +409,7 @@ class AsyncDatabase(common.BaseObject, Generic[_DocumentType]):
             command.
         :param show_expanded_events: Include expanded events such as DDL events like `dropIndexes`.
 
-        :return: A :class:`~pymongo.change_stream.DatabaseChangeStream` cursor.
+        :return: A :class:`~pymongo.asynchronous.change_stream.AsyncDatabaseChangeStream` cursor.
 
         .. versionchanged:: 4.3
            Added `show_expanded_events` parameter.
@@ -430,7 +430,7 @@ class AsyncDatabase(common.BaseObject, Generic[_DocumentType]):
         .. _change streams specification:
             https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md
         """
-        change_stream = DatabaseChangeStream(
+        change_stream = AsyncDatabaseChangeStream(
             self,
             pipeline,
             full_document,

--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -60,7 +60,7 @@ from bson.codec_options import DEFAULT_CODEC_OPTIONS, CodecOptions, TypeRegistry
 from bson.timestamp import Timestamp
 from pymongo import _csot, common, helpers_shared, uri_parser
 from pymongo.asynchronous import client_session, database, periodic_executor
-from pymongo.asynchronous.change_stream import ChangeStream, ClusterChangeStream
+from pymongo.asynchronous.change_stream import AsyncChangeStream, AsyncClusterChangeStream
 from pymongo.asynchronous.client_session import _EmptyServerSession
 from pymongo.asynchronous.command_cursor import AsyncCommandCursor
 from pymongo.asynchronous.settings import TopologySettings
@@ -919,7 +919,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
         comment: Optional[Any] = None,
         full_document_before_change: Optional[str] = None,
         show_expanded_events: Optional[bool] = None,
-    ) -> ChangeStream[_DocumentType]:
+    ) -> AsyncChangeStream[_DocumentType]:
         """Watch changes on this cluster.
 
         Performs an aggregation with an implicit initial ``$changeStream``
@@ -1017,7 +1017,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
         .. _change streams specification:
             https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md
         """
-        change_stream = ClusterChangeStream(
+        change_stream = AsyncClusterChangeStream(
             self.admin,
             pipeline,
             full_document,

--- a/pymongo/client_options.py
+++ b/pymongo/client_options.py
@@ -12,7 +12,10 @@
 # implied.  See the License for the specific language governing
 # permissions and limitations under the License.
 
-"""Tools to parse mongo client options."""
+"""Tools to parse mongo client options.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, cast

--- a/pymongo/collation.py
+++ b/pymongo/collation.py
@@ -15,6 +15,8 @@
 """Tools for working with `collations`_.
 
 .. _collations: https://www.mongodb.com/docs/manual/reference/collation/
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
 """
 from __future__ import annotations
 

--- a/pymongo/driver_info.py
+++ b/pymongo/driver_info.py
@@ -12,7 +12,10 @@
 # implied.  See the License for the specific language governing
 # permissions and limitations under the License.
 
-"""Advanced options for MongoDB drivers implemented on top of PyMongo."""
+"""Advanced options for MongoDB drivers implemented on top of PyMongo.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 from collections import namedtuple

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Support for automatic client-side field level encryption."""
+"""Support for automatic client-side field level encryption.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping, Optional

--- a/pymongo/errors.py
+++ b/pymongo/errors.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Exceptions raised by PyMongo."""
+"""Exceptions raised by PyMongo.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 from ssl import SSLCertVerificationError as _CertificateError  # noqa: F401

--- a/pymongo/event_loggers.py
+++ b/pymongo/event_loggers.py
@@ -25,6 +25,9 @@ These loggers can be registered using :func:`register` or
 or
 
 ``MongoClient(event_listeners=[CommandLogger()])``
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+
 """
 from __future__ import annotations
 

--- a/pymongo/monitoring.py
+++ b/pymongo/monitoring.py
@@ -20,6 +20,9 @@
     are included in the PyMongo distribution under the
     :mod:`~pymongo.event_loggers` submodule.
 
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+
+
 Use :func:`register` to register global listeners for specific events.
 Listeners must inherit from one of the abstract classes below and implement
 the correct functions for that class.

--- a/pymongo/operations.py
+++ b/pymongo/operations.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Operation class definitions."""
+"""Operation class definitions.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 import enum

--- a/pymongo/pool_options.py
+++ b/pymongo/pool_options.py
@@ -12,7 +12,10 @@
 # implied.  See the License for the specific language governing
 # permissions and limitations under the License.
 
-"""AsyncConnection pool options for AsyncMongoClient/MongoClient."""
+"""Pool options for AsyncMongoClient/MongoClient.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 import copy

--- a/pymongo/read_concern.py
+++ b/pymongo/read_concern.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tools for working with read concerns."""
+"""Tools for working with read concerns.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 from typing import Any, Optional

--- a/pymongo/read_preferences.py
+++ b/pymongo/read_preferences.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Utilities for choosing which member of a replica set to read from."""
+"""Utilities for choosing which member of a replica set to read from.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 
 from __future__ import annotations
 

--- a/pymongo/results.py
+++ b/pymongo/results.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Result class definitions."""
+"""Result class definitions.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 from typing import Any, Mapping, Optional, cast

--- a/pymongo/server_description.py
+++ b/pymongo/server_description.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Represent one server the driver is connected to."""
+"""Represent one server the driver is connected to.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 import time

--- a/pymongo/synchronous/collection.py
+++ b/pymongo/synchronous/collection.py
@@ -423,7 +423,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
 
         Performs an aggregation with an implicit initial ``$changeStream``
         stage and returns a
-        :class:`~pymongo.change_stream.CollectionChangeStream` cursor which
+        :class:`~pymongo.synchronous.change_stream.CollectionChangeStream` cursor which
         iterates over changes on this collection.
 
         .. code-block:: python
@@ -432,10 +432,10 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
                async for change in stream:
                    print(change)
 
-        The :class:`~pymongo.change_stream.CollectionChangeStream` iterable
+        The :class:`~pymongo.synchronous.change_stream.CollectionChangeStream` iterable
         blocks until the next change document is returned or an error is
         raised. If the
-        :meth:`~pymongo.change_stream.CollectionChangeStream.next` method
+        :meth:`~pymongo.synchronous.change_stream.CollectionChangeStream.next` method
         encounters a network error when retrieving a batch from the server,
         it will automatically attempt to recreate the cursor such that no
         change events are missed. Any error encountered during the resume
@@ -502,7 +502,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
             command.
         :param show_expanded_events: Include expanded events such as DDL events like `dropIndexes`.
 
-        :return: A :class:`~pymongo.change_stream.CollectionChangeStream` cursor.
+        :return: A :class:`~pymongo.synchronous.change_stream.CollectionChangeStream` cursor.
 
         .. versionchanged:: 4.3
            Added `show_expanded_events` parameter.

--- a/pymongo/synchronous/database.py
+++ b/pymongo/synchronous/database.py
@@ -337,7 +337,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
 
         Performs an aggregation with an implicit initial ``$changeStream``
         stage and returns a
-        :class:`~pymongo.change_stream.DatabaseChangeStream` cursor which
+        :class:`~pymongo.synchronous.change_stream.DatabaseChangeStream` cursor which
         iterates over changes on all collections in this database.
 
         Introduced in MongoDB 4.0.
@@ -348,10 +348,10 @@ class Database(common.BaseObject, Generic[_DocumentType]):
                async for change in stream:
                    print(change)
 
-        The :class:`~pymongo.change_stream.DatabaseChangeStream` iterable
+        The :class:`~pymongo.synchronous.change_stream.DatabaseChangeStream` iterable
         blocks until the next change document is returned or an error is
         raised. If the
-        :meth:`~pymongo.change_stream.DatabaseChangeStream.next` method
+        :meth:`~pymongo.synchronous.change_stream.DatabaseChangeStream.next` method
         encounters a network error when retrieving a batch from the server,
         it will automatically attempt to recreate the cursor such that no
         change events are missed. Any error encountered during the resume
@@ -409,7 +409,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
             command.
         :param show_expanded_events: Include expanded events such as DDL events like `dropIndexes`.
 
-        :return: A :class:`~pymongo.change_stream.DatabaseChangeStream` cursor.
+        :return: A :class:`~pymongo.synchronous.change_stream.DatabaseChangeStream` cursor.
 
         .. versionchanged:: 4.3
            Added `show_expanded_events` parameter.

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -12,7 +12,10 @@
 # implied.  See the License for the specific language governing
 # permissions and limitations under the License.
 
-"""Represent a deployment of MongoDB servers."""
+"""Represent a deployment of MongoDB servers.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 from random import sample

--- a/pymongo/uri_parser.py
+++ b/pymongo/uri_parser.py
@@ -13,7 +13,10 @@
 # permissions and limitations under the License.
 
 
-"""Tools to parse and validate a MongoDB URI."""
+"""Tools to parse and validate a MongoDB URI.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 import re

--- a/pymongo/write_concern.py
+++ b/pymongo/write_concern.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tools for working with write concerns."""
+"""Tools for working with write concerns.
+
+.. seealso:: This module is compatible with both the synchronous and asynchronous PyMongo APIs.
+"""
 from __future__ import annotations
 
 from typing import Any, Optional, Union

--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -34,6 +34,10 @@ replacements = {
     "AsyncRawBatchCursor": "RawBatchCursor",
     "AsyncRawBatchCommandCursor": "RawBatchCommandCursor",
     "AsyncClientSession": "ClientSession",
+    "AsyncChangeStream": "ChangeStream",
+    "AsyncCollectionChangeStream": "CollectionChangeStream",
+    "AsyncDatabaseChangeStream": "DatabaseChangeStream",
+    "AsyncClusterChangeStream": "ClusterChangeStream",
     "_AsyncBulk": "_Bulk",
     "AsyncConnection": "Connection",
     "async_command": "command",
@@ -88,6 +92,8 @@ replacements = {
     "get_async_mock_client": "get_mock_client",
     "aconnect": "_connect",
     "aclose": "close",
+    "async-transactions-ref": "transactions-ref",
+    "async-snapshot-reads-ref": "snapshot-reads-ref",
 }
 
 docstring_replacements: dict[tuple[str, str], str] = {


### PR DESCRIPTION
Many of the inline docstrings and examples are incorrect: there are async class links in the synchronous API and sync class links + examples in the asynchronous API. These will all be fixed in [PYTHON-4592](https://jira.mongodb.org/browse/PYTHON-4592).