### PR TITLE
PYTHON-4600 Handle round trip time being negative because time.monotonic() is not monotonic

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -101,3 +101,4 @@ The following is a list of people who have contributed to
 - Casey Clements (caseyclements)
 - Ivan Lukyanchikov (ilukyanchikov)
 - Terry Patterson
+- Romain Morotti

--- a/pymongo/_csot.py
+++ b/pymongo/_csot.py
@@ -149,10 +149,7 @@ class MovingMinimum:
 
     def add_sample(self, sample: float) -> None:
         if sample < 0:
-            # Likely system time change while waiting for hello response
-            # and not using time.monotonic. Ignore it, the next one will
-            # probably be valid.
-            return
+            raise ValueError(f"duration cannot be negative {sample}")
         self.samples.append(sample)
 
     def get(self) -> float:

--- a/pymongo/asynchronous/monitor.py
+++ b/pymongo/asynchronous/monitor.py
@@ -48,6 +48,15 @@ def _sanitize(error: Exception) -> None:
     error.__cause__ = None
 
 
+def _monotonic_duration(start: float) -> float:
+    """Return the duration since the given start time.
+
+    Accounts for buggy platforms where time.monotonic() is not monotonic.
+    See PYTHON-4600.
+    """
+    return max(0.0, time.monotonic() - start)
+
+
 class MonitorBase:
     def __init__(self, topology: Topology, name: str, interval: int, min_interval: float):
         """Base class to do periodic work on a background thread.
@@ -247,9 +256,7 @@ class Monitor(MonitorBase):
             _sanitize(error)
             sd = self._server_description
             address = sd.address
-            end = time.monotonic()
-            # time.monotonic() is not monotonic
-            duration = max(0.0, end - start)
+            duration = _monotonic_duration(start)
             if self._publish:
                 awaited = bool(self._stream and sd.is_server_type_known and sd.topology_version)
                 assert self._listeners is not None
@@ -319,9 +326,7 @@ class Monitor(MonitorBase):
         else:
             # New connection handshake or polling hello (MongoDB <4.4).
             response = await conn._hello(cluster_time, None, None)
-        end = time.monotonic()
-        # time.monotonic() is not monotonic
-        duration = max(0.0, end - start)
+        duration = _monotonic_duration(start)
         return response, duration
 
 
@@ -446,9 +451,7 @@ class _RttMonitor(MonitorBase):
                 raise Exception("_RttMonitor closed")
             start = time.monotonic()
             await conn.hello()
-            end = time.monotonic()
-            # time.monotonic() is not monotonic
-            duration = max(0.0, end - start)
+            duration = _monotonic_duration(start)
             return duration
 
 

--- a/pymongo/asynchronous/monitor.py
+++ b/pymongo/asynchronous/monitor.py
@@ -247,7 +247,9 @@ class Monitor(MonitorBase):
             _sanitize(error)
             sd = self._server_description
             address = sd.address
-            duration = time.monotonic() - start
+            end = time.monotonic()
+            # time.monotonic() is not monotonic
+            duration = max(0.0, end - start)
             if self._publish:
                 awaited = bool(self._stream and sd.is_server_type_known and sd.topology_version)
                 assert self._listeners is not None
@@ -317,7 +319,10 @@ class Monitor(MonitorBase):
         else:
             # New connection handshake or polling hello (MongoDB <4.4).
             response = await conn._hello(cluster_time, None, None)
-        return response, time.monotonic() - start
+        end = time.monotonic()
+        # time.monotonic() is not monotonic
+        duration = max(0.0, end - start)
+        return response, duration
 
 
 class SrvMonitor(MonitorBase):
@@ -441,7 +446,10 @@ class _RttMonitor(MonitorBase):
                 raise Exception("_RttMonitor closed")
             start = time.monotonic()
             await conn.hello()
-            return time.monotonic() - start
+            end = time.monotonic()
+            # time.monotonic() is not monotonic
+            duration = max(0.0, end - start)
+            return duration
 
 
 # Close monitors to cancel any in progress streaming checks before joining

--- a/pymongo/asynchronous/monitor.py
+++ b/pymongo/asynchronous/monitor.py
@@ -451,8 +451,7 @@ class _RttMonitor(MonitorBase):
                 raise Exception("_RttMonitor closed")
             start = time.monotonic()
             await conn.hello()
-            duration = _monotonic_duration(start)
-            return duration
+            return _monotonic_duration(start)
 
 
 # Close monitors to cancel any in progress streaming checks before joining

--- a/pymongo/read_preferences.py
+++ b/pymongo/read_preferences.py
@@ -607,10 +607,7 @@ class MovingAverage:
 
     def add_sample(self, sample: float) -> None:
         if sample < 0:
-            # Likely system time change while waiting for hello response
-            # and not using time.monotonic. Ignore it, the next one will
-            # probably be valid.
-            return
+            raise ValueError(f"duration cannot be negative {sample}")
         if self.average is None:
             self.average = sample
         else:

--- a/pymongo/synchronous/monitor.py
+++ b/pymongo/synchronous/monitor.py
@@ -247,7 +247,9 @@ class Monitor(MonitorBase):
             _sanitize(error)
             sd = self._server_description
             address = sd.address
-            duration = time.monotonic() - start
+            end = time.monotonic()
+            # time.monotonic() is not monotonic
+            duration = max(0.0, end - start)
             if self._publish:
                 awaited = bool(self._stream and sd.is_server_type_known and sd.topology_version)
                 assert self._listeners is not None
@@ -317,7 +319,10 @@ class Monitor(MonitorBase):
         else:
             # New connection handshake or polling hello (MongoDB <4.4).
             response = conn._hello(cluster_time, None, None)
-        return response, time.monotonic() - start
+        end = time.monotonic()
+        # time.monotonic() is not monotonic
+        duration = max(0.0, end - start)
+        return response, duration
 
 
 class SrvMonitor(MonitorBase):
@@ -441,7 +446,10 @@ class _RttMonitor(MonitorBase):
                 raise Exception("_RttMonitor closed")
             start = time.monotonic()
             conn.hello()
-            return time.monotonic() - start
+            end = time.monotonic()
+            # time.monotonic() is not monotonic
+            duration = max(0.0, end - start)
+            return duration
 
 
 # Close monitors to cancel any in progress streaming checks before joining

--- a/pymongo/synchronous/monitor.py
+++ b/pymongo/synchronous/monitor.py
@@ -451,8 +451,7 @@ class _RttMonitor(MonitorBase):
                 raise Exception("_RttMonitor closed")
             start = time.monotonic()
             conn.hello()
-            duration = _monotonic_duration(start)
-            return duration
+            return _monotonic_duration(start)
 
 
 # Close monitors to cancel any in progress streaming checks before joining


### PR DESCRIPTION
Hello,

This fixes this long standing issue that's been opened since 2017
https://jira.mongodb.org/browse/PYTHON-1271
https://jira.mongodb.org/browse/PYTHON-3616
https://jira.mongodb.org/browse/PYTHON-4298

We've been getting regular failures from the mongo client in CI, since updating to a more recent python and mongo client.
![image](https://github.com/user-attachments/assets/e902ce1f-b532-4d3b-9157-0186f3a14d8a)

Symptom is the client crashing with round_trip_time of None.
This is a very long standing issue as we've found bug tickets going back to 2017 regarding this problem.

Oddly enough, we did not see that frequently on older python version and older client, although the bug is present. I suspect there's a subtle side effect from python 3.11+ being noticeably faster, which makes it a lot more common to get sub millisecond measurements.

root cause:
After many days of debugging, it turns out the issue is pretty simple: time.monotonic() is in fact not monotonic!
Basic code to measure the round trip time `start = time.monotonic() ... end = time.monotonic()` doesn't work as expected, it can give a negative duration once in a while.

The build nodes run NTP. I think NTP is adjusting the time and causing the issue. As per linux documentation CLOCK_MONOTONIC is subject to time adjustments by NTP and adjtime(). https://man7.org/linux/man-pages/man2/clock_gettime.2.html

Related. The code to average round trip times had a condition to silently ignore negative durations `sample < 0`, which contributed to making the issue extremely difficult to debug. I've corrected the check to ensure that negative durations cannot be provided.

There may be other places that are using time.monotonic() incorrectly. I've corrected the ones that crashed my production systems and the ones I could find by searching the code base. There are more usage to measure timeout or deadline which I think are not affected it the clock goes backward by a millisecond.

Cheers.
