### PR TITLE
PYTHON-4609 Speed up unified tests

### DIFF
--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -33,6 +33,7 @@ from collections import abc, defaultdict
 from test import (
     IntegrationTest,
     client_context,
+    client_knobs,
     unittest,
 )
 from test.helpers import (
@@ -1037,8 +1038,18 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             if "retryable-writes" in cls.TEST_SPEC["description"]:
                 raise unittest.SkipTest("MMAPv1 does not support retryWrites=True")
 
+        # Speed up the tests by decreasing the heartbeat frequency.
+        cls.knobs = client_knobs(
+            heartbeat_frequency=0.1,
+            min_heartbeat_interval=0.1,
+            kill_cursor_frequency=0.1,
+            events_queue_frequency=0.1,
+        )
+        cls.knobs.enable()
+
     @classmethod
     def tearDownClass(cls):
+        cls.knobs.disable()
         for client in cls.mongos_clients:
             client.close()
         super().tearDownClass()


### PR DESCRIPTION
PYTHON-4609

Explanation: The legacy test runner has this code:
```python
class SpecRunner(IntegrationTest):
...
    @classmethod
    def _setup_class(cls):
...
        # Speed up the tests by decreasing the heartbeat frequency.
        cls.knobs = client_knobs(heartbeat_frequency=0.1, min_heartbeat_interval=0.1)
        cls.knobs.enable()
```