### PR TITLE
PYTHON-4021 Fix previous topologyDescription published when closing a client

### DIFF
--- a/pymongo/asynchronous/topology.py
+++ b/pymongo/asynchronous/topology.py
@@ -645,6 +645,7 @@ class Topology:
         :exc:`~.errors.InvalidOperation`.
         """
         async with self._lock:
+            old_td = self._description
             for server in self._servers.values():
                 await server.close()
 
@@ -664,7 +665,6 @@ class Topology:
         # Publish only after releasing the lock.
         if self._publish_tp:
             assert self._events is not None
-            old_td = self._description
             self._description = TopologyDescription(
                 TOPOLOGY_TYPE.Unknown,
                 {},

--- a/pymongo/synchronous/topology.py
+++ b/pymongo/synchronous/topology.py
@@ -643,6 +643,7 @@ class Topology:
         :exc:`~.errors.InvalidOperation`.
         """
         with self._lock:
+            old_td = self._description
             for server in self._servers.values():
                 server.close()
 
@@ -662,7 +663,6 @@ class Topology:
         # Publish only after releasing the lock.
         if self._publish_tp:
             assert self._events is not None
-            old_td = self._description
             self._description = TopologyDescription(
                 TOPOLOGY_TYPE.Unknown,
                 {},


### PR DESCRIPTION
Small fix for PYTHON-4021 which resolves this test failure:
```
self = <test.test_discovery_and_monitoring.TestUnifiedReplicasetEmitTopologyChangedBeforeClose testMethod=test_Topology_lifecycle>

    def test_case(self):
>       self.run_scenario(spec)

test/unified_format.py:1953: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test/unified_format.py:1897: in run_scenario
    self._run_scenario(spec, uri)
test/unified_format.py:1936: in _run_scenario
    self.check_events(expect_events)
test/unified_format.py:1801: in check_events
    self.match_evaluator.match_event(expected_event, actual_events[idx])
test/unified_format.py:940: in match_event
    self.match_event_fields(actual, spec)
test/unified_format.py:881: in match_event_fields
    self.match_topology_description(
test/unified_format.py:846: in match_topology_description
    self.test.assertEqual(getattr(actual, field), expected)
E   AssertionError: 'ReplicaSetNoPrimary' != 'ReplicaSetWithPrimary'
E   - ReplicaSetNoPrimary
E   ?           ^^
E   + ReplicaSetWithPrimary
E   ?           ^^^^
```