### PR TITLE
PYTHON-4633 Speed up TestCollectionChangeStream.test_uuid_representations

### DIFF
--- a/test/test_custom_types.py
+++ b/test/test_custom_types.py
@@ -764,9 +764,7 @@ class TestGridFileCustomType(IntegrationTest):
             db.fs,
             _id=5,
             filename="my_file",
-            contentType="text/html",
             chunkSize=1000,
-            aliases=["foo"],
             metadata={"foo": "red", "bar": "blue"},
             bar=3,
             baz="hello",
@@ -780,13 +778,10 @@ class TestGridFileCustomType(IntegrationTest):
         self.assertEqual("my_file", two.filename)
         self.assertEqual(5, two._id)
         self.assertEqual(11, two.length)
-        self.assertEqual("text/html", two.content_type)
         self.assertEqual(1000, two.chunk_size)
         self.assertTrue(isinstance(two.upload_date, datetime.datetime))
-        self.assertEqual(["foo"], two.aliases)
         self.assertEqual({"foo": "red", "bar": "blue"}, two.metadata)
         self.assertEqual(3, two.bar)
-        self.assertEqual(None, two.md5)
 
         for attr in [
             "_id",
@@ -805,7 +800,9 @@ class TestGridFileCustomType(IntegrationTest):
 class ChangeStreamsWCustomTypesTestMixin:
     @no_type_check
     def change_stream(self, *args, **kwargs):
-        return self.watched_target.watch(*args, **kwargs)
+        stream = self.watched_target.watch(*args, max_await_time_ms=1, **kwargs)
+        self.addCleanup(stream.close)
+        return stream
 
     @no_type_check
     def insert_and_check(self, change_stream, insert_doc, expected_doc):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -747,6 +747,7 @@ class TestSampleShellCommands(IntegrationTest):
         done = False
 
         def insert_docs():
+            nonlocal done
             while not done:
                 db.inventory.insert_one({"username": "alice"})
                 db.inventory.delete_one({"username": "alice"})
@@ -760,17 +761,20 @@ class TestSampleShellCommands(IntegrationTest):
             cursor = db.inventory.watch()
             next(cursor)
             # End Changestream Example 1
+            cursor.close()
 
             # Start Changestream Example 2
             cursor = db.inventory.watch(full_document="updateLookup")
             next(cursor)
             # End Changestream Example 2
+            cursor.close()
 
             # Start Changestream Example 3
             resume_token = cursor.resume_token
             cursor = db.inventory.watch(resume_after=resume_token)
             next(cursor)
             # End Changestream Example 3
+            cursor.close()
 
             # Start Changestream Example 4
             pipeline = [
@@ -780,6 +784,7 @@ class TestSampleShellCommands(IntegrationTest):
             cursor = db.inventory.watch(pipeline=pipeline)
             next(cursor)
             # End Changestream Example 4
+            cursor.close()
         finally:
             done = True
             t.join()

--- a/test/test_sdam_monitoring_spec.py
+++ b/test/test_sdam_monitoring_spec.py
@@ -179,7 +179,7 @@ class TestAllScenarios(IntegrationTest):
 
 def create_test(scenario_def):
     def run_scenario(self):
-        with client_knobs(events_queue_frequency=0.1):
+        with client_knobs(events_queue_frequency=0.05, min_heartbeat_interval=0.05):
             _run_scenario(self)
 
     def _run_scenario(self):
@@ -216,7 +216,7 @@ def create_test(scenario_def):
                 )
 
                 # Wait some time to catch possible lagging extra events.
-                time.sleep(0.5)
+                wait_until(lambda: topology._events.empty(), "publish lagging events")
 
                 i = 0
                 while i < expected_len:
@@ -273,7 +273,9 @@ class TestSdamMonitoring(IntegrationTest):
     def setUpClass(cls):
         super().setUpClass()
         # Speed up the tests by decreasing the event publish frequency.
-        cls.knobs = client_knobs(events_queue_frequency=0.1)
+        cls.knobs = client_knobs(
+            events_queue_frequency=0.1, heartbeat_frequency=0.1, min_heartbeat_interval=0.1
+        )
         cls.knobs.enable()
         cls.listener = ServerAndTopologyEventListener()
         retry_writes = client_context.supports_transactions()


### PR DESCRIPTION
PYTHON-4633 Speed up TestCollectionChangeStream.test_uuid_representations

Also speeds up a few other slow change stream and SDAM tests.