### PR TITLE
PYTHON-4614 Do not test PyPy with OpenSSL 1.0.2

### DIFF
--- a/.evergreen/combine-coverage.sh
+++ b/.evergreen/combine-coverage.sh
@@ -15,7 +15,7 @@ fi
 createvirtualenv "$PYTHON_BINARY" covenv
 # Keep in sync with run-tests.sh
 # coverage >=5 is needed for relative_files=true.
-pip install -q "coverage>=5,<=7.5"
+pip install -q "coverage[toml]>=5,<=7.5"
 
 pip list
 ls -la coverage/

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2854,7 +2854,7 @@ buildvariants:
   matrix_spec:
     platform: rhel7
     # Python 3.10+ requires OpenSSL 1.1.1+
-    python-version: ["3.8", "3.9", "pypy3.9", "pypy3.10"]
+    python-version: ["3.8", "3.9"]
     auth-ssl: "*"
   display_name: "OpenSSL 1.0.2 ${python-version} ${platform} ${auth-ssl}"
   tasks:

--- a/.evergreen/hatch.sh
+++ b/.evergreen/hatch.sh
@@ -15,7 +15,7 @@ if $PYTHON_BINARY -m hatch --version; then
 else # No toolchain hatch present, set up virtualenv before installing hatch
     createvirtualenv "$PYTHON_BINARY" hatchenv
     trap "deactivate; rm -rf hatchenv" EXIT HUP
-    python -m pip install -q hatch
+    python -m pip install --prefer-binary -q hatch
     run_hatch() {
       python -m hatch run "$@"
     }

--- a/.evergreen/hatch.sh
+++ b/.evergreen/hatch.sh
@@ -15,7 +15,7 @@ if $PYTHON_BINARY -m hatch --version; then
 else # No toolchain hatch present, set up virtualenv before installing hatch
     createvirtualenv "$PYTHON_BINARY" hatchenv
     trap "deactivate; rm -rf hatchenv" EXIT HUP
-    python -m pip install --prefer-binary -q hatch
+    python -m pip install -q hatch
     run_hatch() {
       python -m hatch run "$@"
     }

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -67,7 +67,6 @@ createvirtualenv () {
 
     export PIP_QUIET=1
     python -m pip install --upgrade pip
-    python -m pip install --upgrade hatch
 }
 
 # Usage:


### PR DESCRIPTION
Since we're using hatch for testing, and hatch requires cryptography.