### PR TITLE
backport the security patch of CVE-2024-21506

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2289,6 +2289,7 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
             uint32_t c_w_s_size;
             uint32_t code_size;
             uint32_t scope_size;
+            uint32_t len;
             PyObject* code;
             PyObject* scope;
             PyObject* code_type;
@@ -2308,7 +2309,8 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
             memcpy(&code_size, buffer + *position, 4);
             code_size = BSON_UINT32_FROM_LE(code_size);
             /* code_w_scope length + code length + code + scope length */
-            if (!code_size || max < code_size || max < 4 + 4 + code_size + 4) {
+            len = 4 + 4 + code_size + 4;
+            if (!code_size || max < code_size || max < len || len < code_size) {
                 goto invalid;
             }
             *position += 4;
@@ -2326,12 +2328,9 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
 
             memcpy(&scope_size, buffer + *position, 4);
             scope_size = BSON_UINT32_FROM_LE(scope_size);
-            if (scope_size < BSON_MIN_SIZE) {
-                Py_DECREF(code);
-                goto invalid;
-            }
             /* code length + code + scope length + scope */
-            if ((4 + code_size + 4 + scope_size) != c_w_s_size) {
+            len = 4 + 4 + code_size + scope_size;
+            if (scope_size < BSON_MIN_SIZE || len != c_w_s_size || len < scope_size) {
                 Py_DECREF(code);
                 goto invalid;
             }


### PR DESCRIPTION
Here is a vulnerability which is mentioned in https://github.com/mongodb/mongo-python-driver/pull/1564 and fixed in the [v4.6](https://github.com/mongodb/mongo-python-driver/compare/v4.6)branch https://github.com/mongodb/mongo-python-driver/commit/56b6b6dbc267d365d97c037082369dabf37405d2, but is not fixed in the branch of v4.4, maybe it should be backported?