### PR TITLE
PYTHON-4649 Skip CSOT tests on slow Windows and macOS hosts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -435,6 +435,9 @@ functions:
           if [ -n "${TEST_INDEX_MANAGEMENT}" ]; then
             export TEST_INDEX_MANAGEMENT=1
           fi
+          if [ -n "${SKIP_CSOT_TESTS}" ]; then
+            export SKIP_CSOT_TESTS=1
+          fi
 
           GREEN_FRAMEWORK=${GREEN_FRAMEWORK} \
             PYTHON_BINARY=${PYTHON_BINARY} \
@@ -2224,6 +2227,8 @@ axes:
           skip_EC2_auth_test: true
           skip_ECS_auth_test: true
           skip_web_identity_auth_test: true
+          # CSOT tests are unreliable on our slow macOS hosts.
+          SKIP_CSOT_TESTS: true
       - id: macos-arm64
         display_name: "macOS Arm64"
         run_on: macos-14-arm64
@@ -2231,6 +2236,8 @@ axes:
           skip_EC2_auth_test: true
           skip_ECS_auth_test: true
           skip_web_identity_auth_test: true
+          # CSOT tests are unreliable on our slow macOS hosts.
+          SKIP_CSOT_TESTS: true
       - id: rhel7
         display_name: "RHEL 7.x"
         run_on: rhel79-small
@@ -2273,6 +2280,8 @@ axes:
           skip_EC2_auth_test: true
           skip_web_identity_auth_test: true
           venv_bin_dir: "Scripts"
+          # CSOT tests are unreliable on our slow Windows hosts.
+          SKIP_CSOT_TESTS: true
 
   # Test with authentication?
   - id: auth

--- a/test/test_csot.py
+++ b/test/test_csot.py
@@ -77,6 +77,7 @@ class TestCSOT(IntegrationTest):
     @client_context.require_change_streams
     def test_change_stream_can_resume_after_timeouts(self):
         coll = self.db.test
+        coll.insert_one({})
         with coll.watch() as stream:
             with pymongo.timeout(0.1):
                 with self.assertRaises(PyMongoError) as ctx:

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -145,6 +145,8 @@ from pymongo.topology_description import TopologyDescription
 from pymongo.typings import _Address
 from pymongo.write_concern import WriteConcern
 
+SKIP_CSOT_TESTS = os.getenv("SKIP_CSOT_TESTS")
+
 JSON_OPTS = json_util.JSONOptions(tz_aware=False)
 
 IS_INTERRUPTED = False
@@ -1953,6 +1955,9 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
                 self.assertListEqual(sorted_expected_documents, actual_documents)
 
     def run_scenario(self, spec, uri=None):
+        if "csot" in self.id().lower() and SKIP_CSOT_TESTS:
+            raise unittest.SkipTest("SKIP_CSOT_TESTS is set, skipping...")
+
         # Kill all sessions before and after each test to prevent an open
         # transaction (from a test failure) from blocking collection/database
         # operations during test set up and tear down.


### PR DESCRIPTION
PYTHON-4649