### PR TITLE
PYTHON-4150 Resync spec tests to bump maxWireVersion

### DIFF
--- a/test/discovery_and_monitoring/rs/discover_arbiters.json
+++ b/test/discovery_and_monitoring/rs/discover_arbiters.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_arbiters_replicaset.json
+++ b/test/discovery_and_monitoring/rs/discover_arbiters_replicaset.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_ghost.json
+++ b/test/discovery_and_monitoring/rs/discover_ghost.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": false,
             "isreplicaset": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_ghost_replicaset.json
+++ b/test/discovery_and_monitoring/rs/discover_ghost_replicaset.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": false,
             "isreplicaset": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_hidden.json
+++ b/test/discovery_and_monitoring/rs/discover_hidden.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_hidden_replicaset.json
+++ b/test/discovery_and_monitoring/rs/discover_hidden_replicaset.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_passives.json
+++ b/test/discovery_and_monitoring/rs/discover_passives.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -56,7 +56,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_passives_replicaset.json
+++ b/test/discovery_and_monitoring/rs/discover_passives_replicaset.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -56,7 +56,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_primary.json
+++ b/test/discovery_and_monitoring/rs/discover_primary.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_primary_replicaset.json
+++ b/test/discovery_and_monitoring/rs/discover_primary_replicaset.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_rsother.json
+++ b/test/discovery_and_monitoring/rs/discover_rsother.json
@@ -17,7 +17,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_rsother_replicaset.json
+++ b/test/discovery_and_monitoring/rs/discover_rsother_replicaset.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -34,7 +34,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_secondary.json
+++ b/test/discovery_and_monitoring/rs/discover_secondary.json
@@ -17,7 +17,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discover_secondary_replicaset.json
+++ b/test/discovery_and_monitoring/rs/discover_secondary_replicaset.json
@@ -17,7 +17,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/discovery.json
+++ b/test/discovery_and_monitoring/rs/discovery.json
@@ -18,7 +18,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -59,7 +59,7 @@
               "d:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -103,7 +103,7 @@
               "e:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -147,7 +147,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/equal_electionids.json
+++ b/test/discovery_and_monitoring/rs/equal_electionids.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -39,7 +39,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/hosts_differ_from_seeds.json
+++ b/test/discovery_and_monitoring/rs/hosts_differ_from_seeds.json
@@ -15,7 +15,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/incompatible_arbiter.json
+++ b/test/discovery_and_monitoring/rs/incompatible_arbiter.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/test/discovery_and_monitoring/rs/incompatible_ghost.json
+++ b/test/discovery_and_monitoring/rs/incompatible_ghost.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/test/discovery_and_monitoring/rs/incompatible_other.json
+++ b/test/discovery_and_monitoring/rs/incompatible_other.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/test/discovery_and_monitoring/rs/ls_timeout.json
+++ b/test/discovery_and_monitoring/rs/ls_timeout.json
@@ -20,7 +20,7 @@
             "setName": "rs",
             "logicalSessionTimeoutMinutes": 3,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -58,7 +58,7 @@
             "isWritablePrimary": false,
             "isreplicaset": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -104,7 +104,7 @@
             "setName": "rs",
             "arbiterOnly": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -152,7 +152,7 @@
             "setName": "rs",
             "logicalSessionTimeoutMinutes": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -194,7 +194,7 @@
             "hidden": true,
             "logicalSessionTimeoutMinutes": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -244,7 +244,7 @@
             "setName": "rs",
             "logicalSessionTimeoutMinutes": null,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/member_reconfig.json
+++ b/test/discovery_and_monitoring/rs/member_reconfig.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -49,7 +49,7 @@
               "a:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/member_standalone.json
+++ b/test/discovery_and_monitoring/rs/member_standalone.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -40,7 +40,7 @@
               "a:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/new_primary.json
+++ b/test/discovery_and_monitoring/rs/new_primary.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -50,7 +50,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/new_primary_new_electionid.json
+++ b/test/discovery_and_monitoring/rs/new_primary_new_electionid.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -67,7 +67,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -114,7 +114,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/new_primary_new_setversion.json
+++ b/test/discovery_and_monitoring/rs/new_primary_new_setversion.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -67,7 +67,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -114,7 +114,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/new_primary_wrong_set_name.json
+++ b/test/discovery_and_monitoring/rs/new_primary_wrong_set_name.json
@@ -16,7 +16,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -49,7 +49,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/non_rs_member.json
+++ b/test/discovery_and_monitoring/rs/non_rs_member.json
@@ -10,7 +10,7 @@
             "ok": 1,
             "helloOk": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/normalize_case.json
+++ b/test/discovery_and_monitoring/rs/normalize_case.json
@@ -21,7 +21,7 @@
               "C:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/normalize_case_me.json
+++ b/test/discovery_and_monitoring/rs/normalize_case_me.json
@@ -22,7 +22,7 @@
               "C:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -67,7 +67,7 @@
               "C:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/null_election_id-pre-6.0.json
+++ b/test/discovery_and_monitoring/rs/null_election_id-pre-6.0.json
@@ -18,7 +18,7 @@
             "setVersion": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -66,7 +66,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -116,7 +116,7 @@
             "setVersion": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -167,7 +167,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_becomes_ghost.json
+++ b/test/discovery_and_monitoring/rs/primary_becomes_ghost.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -41,7 +41,7 @@
             "isWritablePrimary": false,
             "isreplicaset": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_becomes_mongos.json
+++ b/test/discovery_and_monitoring/rs/primary_becomes_mongos.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -41,7 +41,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_becomes_standalone.json
+++ b/test/discovery_and_monitoring/rs/primary_becomes_standalone.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -38,7 +38,7 @@
           {
             "ok": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_changes_set_name.json
+++ b/test/discovery_and_monitoring/rs/primary_changes_set_name.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -44,7 +44,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_disconnect.json
+++ b/test/discovery_and_monitoring/rs/primary_disconnect.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_disconnect_electionid.json
+++ b/test/discovery_and_monitoring/rs/primary_disconnect_electionid.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -39,7 +39,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -115,7 +115,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -159,7 +159,7 @@
               "$oid": "000000000000000000000003"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -203,7 +203,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_disconnect_setversion.json
+++ b/test/discovery_and_monitoring/rs/primary_disconnect_setversion.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -39,7 +39,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -115,7 +115,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -159,7 +159,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -203,7 +203,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_hint_from_secondary_with_mismatched_me.json
+++ b/test/discovery_and_monitoring/rs/primary_hint_from_secondary_with_mismatched_me.json
@@ -18,7 +18,7 @@
             "setName": "rs",
             "primary": "b:27017",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -48,7 +48,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_mismatched_me.json
+++ b/test/discovery_and_monitoring/rs/primary_mismatched_me.json
@@ -31,7 +31,7 @@
             "ok": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ]

--- a/test/discovery_and_monitoring/rs/primary_reports_new_member.json
+++ b/test/discovery_and_monitoring/rs/primary_reports_new_member.json
@@ -17,7 +17,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -51,7 +51,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -86,7 +86,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -127,7 +127,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_to_no_primary_mismatched_me.json
+++ b/test/discovery_and_monitoring/rs/primary_to_no_primary_mismatched_me.json
@@ -17,7 +17,7 @@
             "me": "a:27017",
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -52,7 +52,7 @@
             "me": "c:27017",
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/primary_wrong_set_name.json
+++ b/test/discovery_and_monitoring/rs/primary_wrong_set_name.json
@@ -15,7 +15,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/repeated.json
+++ b/test/discovery_and_monitoring/rs/repeated.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -49,7 +49,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -84,7 +84,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -120,7 +120,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/replicaset_rsnp.json
+++ b/test/discovery_and_monitoring/rs/replicaset_rsnp.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/response_from_removed.json
+++ b/test/discovery_and_monitoring/rs/response_from_removed.json
@@ -15,7 +15,7 @@
               "a:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -46,7 +46,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/sec_not_auth.json
+++ b/test/discovery_and_monitoring/rs/sec_not_auth.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -32,7 +32,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/secondary_ignore_ok_0-pre-6.0.json
+++ b/test/discovery_and_monitoring/rs/secondary_ignore_ok_0-pre-6.0.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -32,7 +32,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -59,7 +59,7 @@
           {
             "ok": 0,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/secondary_ignore_ok_0.json
+++ b/test/discovery_and_monitoring/rs/secondary_ignore_ok_0.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -32,7 +32,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -59,7 +59,7 @@
           {
             "ok": 0,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/secondary_mismatched_me.json
+++ b/test/discovery_and_monitoring/rs/secondary_mismatched_me.json
@@ -32,7 +32,7 @@
             "ok": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ]

--- a/test/discovery_and_monitoring/rs/secondary_wrong_set_name.json
+++ b/test/discovery_and_monitoring/rs/secondary_wrong_set_name.json
@@ -16,7 +16,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/secondary_wrong_set_name_with_primary.json
+++ b/test/discovery_and_monitoring/rs/secondary_wrong_set_name_with_primary.json
@@ -16,7 +16,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -51,7 +51,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/setversion_without_electionid-pre-6.0.json
+++ b/test/discovery_and_monitoring/rs/setversion_without_electionid-pre-6.0.json
@@ -17,7 +17,7 @@
             "setName": "rs",
             "setVersion": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -56,7 +56,7 @@
             "setName": "rs",
             "setVersion": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/stepdown_change_set_name.json
+++ b/test/discovery_and_monitoring/rs/stepdown_change_set_name.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -45,7 +45,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/too_new.json
+++ b/test/discovery_and_monitoring/rs/too_new.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/test/discovery_and_monitoring/rs/too_old.json
+++ b/test/discovery_and_monitoring/rs/too_old.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/test/discovery_and_monitoring/rs/unexpected_mongos.json
+++ b/test/discovery_and_monitoring/rs/unexpected_mongos.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/use_setversion_without_electionid-pre-6.0.json
+++ b/test/discovery_and_monitoring/rs/use_setversion_without_electionid-pre-6.0.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -64,7 +64,7 @@
             "setName": "rs",
             "setVersion": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -108,7 +108,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],

--- a/test/discovery_and_monitoring/rs/wrong_set_name.json
+++ b/test/discovery_and_monitoring/rs/wrong_set_name.json
@@ -17,7 +17,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/sharded/discover_single_mongos.json
+++ b/test/discovery_and_monitoring/sharded/discover_single_mongos.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/sharded/ls_timeout_mongos.json
+++ b/test/discovery_and_monitoring/sharded/ls_timeout_mongos.json
@@ -13,7 +13,7 @@
             "msg": "isdbgrid",
             "logicalSessionTimeoutMinutes": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -25,7 +25,7 @@
             "msg": "isdbgrid",
             "logicalSessionTimeoutMinutes": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -56,7 +56,7 @@
             "msg": "isdbgrid",
             "logicalSessionTimeoutMinutes": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -67,7 +67,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/sharded/mongos_disconnect.json
+++ b/test/discovery_and_monitoring/sharded/mongos_disconnect.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -23,7 +23,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -76,7 +76,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/sharded/multiple_mongoses.json
+++ b/test/discovery_and_monitoring/sharded/multiple_mongoses.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -23,7 +23,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/sharded/non_mongos_removed.json
+++ b/test/discovery_and_monitoring/sharded/non_mongos_removed.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -26,7 +26,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/sharded/too_old.json
+++ b/test/discovery_and_monitoring/sharded/too_old.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 2,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/test/discovery_and_monitoring/single/direct_connection_external_ip.json
+++ b/test/discovery_and_monitoring/single/direct_connection_external_ip.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/direct_connection_mongos.json
+++ b/test/discovery_and_monitoring/single/direct_connection_mongos.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/direct_connection_replicaset.json
+++ b/test/discovery_and_monitoring/single/direct_connection_replicaset.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/direct_connection_rsarbiter.json
+++ b/test/discovery_and_monitoring/single/direct_connection_rsarbiter.json
@@ -17,7 +17,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/direct_connection_rsprimary.json
+++ b/test/discovery_and_monitoring/single/direct_connection_rsprimary.json
@@ -16,7 +16,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/direct_connection_rssecondary.json
+++ b/test/discovery_and_monitoring/single/direct_connection_rssecondary.json
@@ -17,7 +17,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/direct_connection_standalone.json
+++ b/test/discovery_and_monitoring/single/direct_connection_standalone.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/direct_connection_wrong_set_name.json
+++ b/test/discovery_and_monitoring/single/direct_connection_wrong_set_name.json
@@ -16,7 +16,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -45,7 +45,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/discover_standalone.json
+++ b/test/discovery_and_monitoring/single/discover_standalone.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/ls_timeout_standalone.json
+++ b/test/discovery_and_monitoring/single/ls_timeout_standalone.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "logicalSessionTimeoutMinutes": 7,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/not_ok_response.json
+++ b/test/discovery_and_monitoring/single/not_ok_response.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -21,7 +21,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/standalone_removed.json
+++ b/test/discovery_and_monitoring/single/standalone_removed.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/discovery_and_monitoring/single/standalone_using_legacy_hello.json
+++ b/test/discovery_and_monitoring/single/standalone_using_legacy_hello.json
@@ -10,7 +10,7 @@
             "ok": 1,
             "ismaster": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/test/max_staleness/ReplicaSetNoPrimary/DefaultNoMaxStaleness.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/DefaultNoMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -37,7 +37,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -49,7 +49,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -63,7 +63,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/test/max_staleness/ReplicaSetNoPrimary/LastUpdateTime.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/LastUpdateTime.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/test/max_staleness/ReplicaSetNoPrimary/Nearest.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/Nearest.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/test/max_staleness/ReplicaSetNoPrimary/Nearest2.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/Nearest2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/test/max_staleness/ReplicaSetNoPrimary/OneKnownTwoUnavailable.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/OneKnownTwoUnavailable.json
@@ -17,7 +17,7 @@
       {
         "address": "c:27017",
         "type": "RSSecondary",
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "avg_rtt_ms": 5,
         "lastWrite": {
           "lastWriteDate": {
@@ -35,7 +35,7 @@
     {
       "address": "c:27017",
       "type": "RSSecondary",
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "avg_rtt_ms": 5,
       "lastWrite": {
         "lastWriteDate": {
@@ -48,7 +48,7 @@
     {
       "address": "c:27017",
       "type": "RSSecondary",
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "avg_rtt_ms": 5,
       "lastWrite": {
         "lastWriteDate": {

--- a/test/max_staleness/ReplicaSetNoPrimary/PrimaryPreferred.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/PrimaryPreferred.json
@@ -8,7 +8,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -53,7 +53,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"

--- a/test/max_staleness/ReplicaSetNoPrimary/PrimaryPreferred_tags.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/PrimaryPreferred_tags.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "tokyo"
         }
@@ -28,7 +28,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "nyc"
         }
@@ -58,7 +58,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }
@@ -75,7 +75,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }

--- a/test/max_staleness/ReplicaSetNoPrimary/Secondary.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/Secondary.json
@@ -8,7 +8,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -23,7 +23,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -38,7 +38,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -53,7 +53,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -80,7 +80,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -97,7 +97,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/test/max_staleness/ReplicaSetNoPrimary/SecondaryPreferred.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/SecondaryPreferred.json
@@ -7,7 +7,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -38,7 +38,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -52,7 +52,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"

--- a/test/max_staleness/ReplicaSetNoPrimary/SecondaryPreferred_tags.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/SecondaryPreferred_tags.json
@@ -8,7 +8,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -23,7 +23,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -38,7 +38,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -53,7 +53,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -80,7 +80,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -97,7 +97,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/test/max_staleness/ReplicaSetNoPrimary/ZeroMaxStaleness.json
+++ b/test/max_staleness/ReplicaSetNoPrimary/ZeroMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/test/max_staleness/ReplicaSetWithPrimary/DefaultNoMaxStaleness.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/DefaultNoMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -37,7 +37,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -49,7 +49,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -63,7 +63,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/test/max_staleness/ReplicaSetWithPrimary/LastUpdateTime.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/LastUpdateTime.json
@@ -13,7 +13,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/test/max_staleness/ReplicaSetWithPrimary/LongHeartbeat.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/LongHeartbeat.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -51,7 +51,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -65,7 +65,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/test/max_staleness/ReplicaSetWithPrimary/LongHeartbeat2.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/LongHeartbeat2.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/test/max_staleness/ReplicaSetWithPrimary/MaxStalenessTooSmall.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/MaxStalenessTooSmall.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/test/max_staleness/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/test/max_staleness/ReplicaSetWithPrimary/Nearest.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/Nearest.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/test/max_staleness/ReplicaSetWithPrimary/Nearest2.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/Nearest2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/test/max_staleness/ReplicaSetWithPrimary/Nearest_tags.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/Nearest_tags.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "tokyo"
         }
@@ -28,7 +28,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "nyc"
         }
@@ -58,7 +58,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }
@@ -75,7 +75,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }

--- a/test/max_staleness/ReplicaSetWithPrimary/PrimaryPreferred.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/PrimaryPreferred.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -53,7 +53,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/test/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -38,7 +38,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -52,7 +52,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"

--- a/test/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred_tags.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred_tags.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -35,7 +35,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 1,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -50,7 +50,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -65,7 +65,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -92,7 +92,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -107,7 +107,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 1,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -124,7 +124,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/test/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred_tags2.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/SecondaryPreferred_tags2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "tokyo"
         }
@@ -40,7 +40,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "nyc"
         }
@@ -70,7 +70,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }
@@ -87,7 +87,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }

--- a/test/max_staleness/ReplicaSetWithPrimary/Secondary_tags.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/Secondary_tags.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -35,7 +35,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 1,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -50,7 +50,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -65,7 +65,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -92,7 +92,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -107,7 +107,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 1,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -124,7 +124,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/test/max_staleness/ReplicaSetWithPrimary/Secondary_tags2.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/Secondary_tags2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "tokyo"
         }
@@ -40,7 +40,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "nyc"
         }
@@ -70,7 +70,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }
@@ -87,7 +87,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }

--- a/test/max_staleness/ReplicaSetWithPrimary/ZeroMaxStaleness.json
+++ b/test/max_staleness/ReplicaSetWithPrimary/ZeroMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/test/max_staleness/Sharded/SmallMaxStaleness.json
+++ b/test/max_staleness/Sharded/SmallMaxStaleness.json
@@ -8,7 +8,7 @@
         "type": "Mongos",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "Mongos",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "Mongos",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -51,7 +51,7 @@
       "type": "Mongos",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -65,7 +65,7 @@
       "type": "Mongos",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/test/max_staleness/Single/SmallMaxStaleness.json
+++ b/test/max_staleness/Single/SmallMaxStaleness.json
@@ -8,7 +8,7 @@
         "type": "Standalone",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -27,7 +27,7 @@
       "type": "Standalone",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -41,7 +41,7 @@
       "type": "Standalone",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/test/max_staleness/Unknown/SmallMaxStaleness.json
+++ b/test/max_staleness/Unknown/SmallMaxStaleness.json
@@ -6,7 +6,7 @@
       {
         "address": "a:27017",
         "type": "Unknown",
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },


### PR DESCRIPTION
PYTHON-4150 Resync spec tests to bump maxWireVersion

POC for: https://github.com/mongodb/specifications/pull/1629