### PR TITLE
PYTHON-4659 Fix async with TLS

### DIFF
--- a/pymongo/network_layer.py
+++ b/pymongo/network_layer.py
@@ -54,7 +54,6 @@ except ImportError:
 _UNPACK_HEADER = struct.Struct("<iiii").unpack
 _UNPACK_COMPRESSION_HEADER = struct.Struct("<iiB").unpack
 _POLL_TIMEOUT = 0.5
-_SSL_RECORD_SIZE = 0x4000
 # Errors raised by sockets (and TLS sockets) when in non-blocking mode.
 BLOCKING_IO_ERRORS = (BlockingIOError, BLOCKING_IO_LOOKUP_ERROR, *ssl_support.BLOCKING_IO_ERRORS)
 
@@ -91,7 +90,7 @@ async def _async_sendall_ssl(
 
     while sent < len(buf):
         try:
-            sent += sock.send(view[sent : sent + _SSL_RECORD_SIZE])
+            sent += sock.send(view[sent:])
         except BLOCKING_IO_ERRORS as exc:
             fd = sock.fileno()
             # Check for closed socket.
@@ -119,7 +118,7 @@ async def _async_sendall_ssl_windows(sock: Union[socket.socket, _sslConn], buf: 
     total_sent = 0
     while total_sent < total_length:
         try:
-            sent = sock.send(view[total_sent : total_sent + _SSL_RECORD_SIZE])
+            sent = sock.send(view[total_sent:])
         except BLOCKING_IO_ERRORS:
             await asyncio.sleep(0.5)
             sent = 0

--- a/pymongo/pyopenssl_context.py
+++ b/pymongo/pyopenssl_context.py
@@ -94,8 +94,6 @@ BLOCKING_IO_READ_ERROR = _SSL.WantReadError
 BLOCKING_IO_WRITE_ERROR = _SSL.WantWriteError
 BLOCKING_IO_LOOKUP_ERROR = _SSL.WantX509LookupError
 
-_SSL_RECORD_SIZE = 0x4000
-
 
 def _ragged_eof(exc: BaseException) -> bool:
     """Return True if the OpenSSL.SSL.SysCallError is a ragged EOF."""
@@ -167,9 +165,7 @@ class _sslConn(_SSL.Connection):
         total_sent = 0
         while total_sent < total_length:
             try:
-                sent = self._call(
-                    super().send, view[total_sent : total_sent + _SSL_RECORD_SIZE], flags
-                )
+                sent = self._call(super().send, view[total_sent:], flags)
             # XXX: It's not clear if this can actually happen. PyOpenSSL
             # doesn't appear to have any interrupt handling, nor any interrupt
             # errors for OpenSSL connections.

--- a/pymongo/pyopenssl_context.py
+++ b/pymongo/pyopenssl_context.py
@@ -94,6 +94,8 @@ BLOCKING_IO_READ_ERROR = _SSL.WantReadError
 BLOCKING_IO_WRITE_ERROR = _SSL.WantWriteError
 BLOCKING_IO_LOOKUP_ERROR = _SSL.WantX509LookupError
 
+_SSL_RECORD_SIZE = 0x4000
+
 
 def _ragged_eof(exc: BaseException) -> bool:
     """Return True if the OpenSSL.SSL.SysCallError is a ragged EOF."""
@@ -165,7 +167,9 @@ class _sslConn(_SSL.Connection):
         total_sent = 0
         while total_sent < total_length:
             try:
-                sent = self._call(super().send, view[total_sent:], flags)
+                sent = self._call(
+                    super().send, view[total_sent : total_sent + _SSL_RECORD_SIZE], flags
+                )
             # XXX: It's not clear if this can actually happen. PyOpenSSL
             # doesn't appear to have any interrupt handling, nor any interrupt
             # errors for OpenSSL connections.


### PR DESCRIPTION
PYTHON-4659 

Previously the async code path was resending the first 16KB bytes (the max TLS record size) of the buffer over and over. 