### PR TITLE
PYTHON-4690 Add repr for FixedOffset eg FixedOffset(datetime.timedelta(seconds=3600), '+60'))

### DIFF
--- a/bson/tz_util.py
+++ b/bson/tz_util.py
@@ -39,7 +39,7 @@ class FixedOffset(tzinfo):
     def __getinitargs__(self) -> Tuple[timedelta, str]:
         return self.__offset, self.__name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.__offset!r}, {self.__name!r})"
 
     def utcoffset(self, dt: Optional[datetime]) -> timedelta:

--- a/bson/tz_util.py
+++ b/bson/tz_util.py
@@ -39,6 +39,9 @@ class FixedOffset(tzinfo):
     def __getinitargs__(self) -> Tuple[timedelta, str]:
         return self.__offset, self.__name
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.__offset!r}, {self.__name!r})"
+
     def utcoffset(self, dt: Optional[datetime]) -> timedelta:
         return self.__offset
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -30,6 +30,7 @@ PyMongo 4.9 brings a number of improvements including:
   :class:`~pymongo.operations.DeleteOne`, and
   :class:`~pymongo.operations.DeleteMany` operations, so
   they can be used in the new :meth:`~pymongo.mongo_client.MongoClient.bulk_write`.
+- Added :func:`repr` support to :class:`bson.tz_util.FixedOffset`.
 
 Issues Resolved
 ...............

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -1019,6 +1019,10 @@ class TestCodecOptions(unittest.TestCase):
         tz = FixedOffset(42, "forty-two")
         self.assertRaises(ValueError, CodecOptions, tzinfo=tz)
         self.assertEqual(tz, CodecOptions(tz_aware=True, tzinfo=tz).tzinfo)
+        self.assertEqual(repr(tz), "FixedOffset(datetime.timedelta(seconds=2520), 'forty-two')")
+        self.assertEqual(
+            repr(eval(repr(tz))), "FixedOffset(datetime.timedelta(seconds=2520), 'forty-two')"
+        )
 
     def test_codec_options_repr(self):
         r = (


### PR DESCRIPTION
PYTHON-4690

Motivation:
When working with multiple timezones, this change makes it easier to see which ones are being used.

Before:
```python
>>> from bson.tz_util import FixedOffset, utc
>>> utc
<bson.tz_util.FixedOffset object at 0x104ec2840>
>>> FixedOffset(60, 'tzName')
<bson.tz_util.FixedOffset object at 0x104b0cc20>
```

After:
```python
>>> from bson.tz_util import FixedOffset, utc
>>> utc
FixedOffset(datetime.timedelta(0), 'UTC')
>>> FixedOffset(60, 'tzName')
FixedOffset(datetime.timedelta(seconds=3600), 'tzName')
```

Related to PYTHON-4663.