### PR TITLE
PYTHON-4671 Skip client.bulk_write tests on Atlas Serverless

### DIFF
--- a/test/asynchronous/test_client_bulk_write.py
+++ b/test/asynchronous/test_client_bulk_write.py
@@ -47,6 +47,7 @@ _IS_SYNC = False
 
 class TestClientBulkWrite(AsyncIntegrationTest):
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_returns_error_if_no_namespace_provided(self):
         models = [InsertOne(document={"a": "b"})]
         with self.assertRaises(InvalidOperation) as context:
@@ -57,6 +58,7 @@ class TestClientBulkWrite(AsyncIntegrationTest):
         )
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_handles_non_pymongo_error(self):
         with patch.object(
             _AsyncClientBulk, "write_command", return_value={"error": TypeError("mock type error")}
@@ -68,6 +70,7 @@ class TestClientBulkWrite(AsyncIntegrationTest):
             self.assertFalse(hasattr(context.exception.error, "details"))
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_formats_write_error_correctly(self):
         models = [
             InsertOne(namespace="db.coll", document={"_id": 1}),
@@ -90,6 +93,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.max_message_size_bytes = await async_client_context.max_message_size_bytes
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_batch_splits_if_num_operations_too_large(self):
         listener = OvertCommandListener()
         client = await async_rs_or_single_client(event_listeners=[listener])
@@ -115,6 +119,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertEqual(first_event.operation_id, second_event.operation_id)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_batch_splits_if_ops_payload_too_large(self):
         listener = OvertCommandListener()
         client = await async_rs_or_single_client(event_listeners=[listener])
@@ -147,6 +152,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertEqual(first_event.operation_id, second_event.operation_id)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     @async_client_context.require_failCommand_fail_point
     async def test_collects_write_concern_errors_across_batches(self):
         listener = OvertCommandListener()
@@ -190,6 +196,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertEqual(len(bulk_write_events), 2)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_collects_write_errors_across_batches_unordered(self):
         listener = OvertCommandListener()
         client = await async_rs_or_single_client(event_listeners=[listener])
@@ -220,6 +227,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertEqual(len(bulk_write_events), 2)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_collects_write_errors_across_batches_ordered(self):
         listener = OvertCommandListener()
         client = await async_rs_or_single_client(event_listeners=[listener])
@@ -250,6 +258,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertEqual(len(bulk_write_events), 1)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_handles_cursor_requiring_getMore(self):
         listener = OvertCommandListener()
         client = await async_rs_or_single_client(event_listeners=[listener])
@@ -290,6 +299,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertTrue(get_more_event)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     @async_client_context.require_no_standalone
     async def test_handles_cursor_requiring_getMore_within_transaction(self):
         listener = OvertCommandListener()
@@ -333,6 +343,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertTrue(get_more_event)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     @async_client_context.require_failCommand_fail_point
     async def test_handles_getMore_error(self):
         listener = OvertCommandListener()
@@ -388,6 +399,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertTrue(kill_cursors_event)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_returns_error_if_unacknowledged_too_large_insert(self):
         listener = OvertCommandListener()
         client = await async_rs_or_single_client(event_listeners=[listener])
@@ -444,6 +456,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         return num_models, models
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_no_batch_splits_if_new_namespace_is_not_too_large(self):
         listener = OvertCommandListener()
         client = await async_rs_or_single_client(event_listeners=[listener])
@@ -475,6 +488,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertEqual(event.command["nsInfo"][0]["ns"], "db.coll")
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_batch_splits_if_new_namespace_is_too_large(self):
         listener = OvertCommandListener()
         client = await async_rs_or_single_client(event_listeners=[listener])
@@ -513,6 +527,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
         self.assertEqual(second_event.command["nsInfo"][0]["ns"], namespace)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     async def test_returns_error_if_no_writes_can_be_added_to_ops(self):
         client = await async_rs_or_single_client()
         self.addAsyncCleanup(client.close)
@@ -531,6 +546,7 @@ class TestClientBulkWriteCRUD(AsyncIntegrationTest):
             await client.bulk_write(models=models)
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
     async def test_returns_error_if_auto_encryption_configured(self):
         opts = AutoEncryptionOpts(
@@ -556,6 +572,7 @@ class TestClientBulkWriteCSOT(AsyncIntegrationTest):
         self.max_message_size_bytes = await async_client_context.max_message_size_bytes
 
     @async_client_context.require_version_min(8, 0, 0, -24)
+    @async_client_context.require_no_serverless
     @async_client_context.require_failCommand_fail_point
     async def test_timeout_in_multi_batch_bulk_write(self):
         _OVERHEAD = 500

--- a/test/command_monitoring/unacknowledged-client-bulkWrite.json
+++ b/test/command_monitoring/unacknowledged-client-bulkWrite.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.7",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/crud/unified/client-bulkWrite-delete-options.json
+++ b/test/crud/unified/client-bulkWrite-delete-options.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite delete options",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/crud/unified/client-bulkWrite-errorResponse.json
+++ b/test/crud/unified/client-bulkWrite-errorResponse.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.12",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/crud/unified/client-bulkWrite-errors.json
+++ b/test/crud/unified/client-bulkWrite-errors.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.21",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/crud/unified/client-bulkWrite-mixed-namespaces.json
+++ b/test/crud/unified/client-bulkWrite-mixed-namespaces.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite with mixed namespaces",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/crud/unified/client-bulkWrite-options.json
+++ b/test/crud/unified/client-bulkWrite-options.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite top-level options",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/crud/unified/client-bulkWrite-ordered.json
+++ b/test/crud/unified/client-bulkWrite-ordered.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite with ordered option",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/crud/unified/client-bulkWrite-results.json
+++ b/test/crud/unified/client-bulkWrite-results.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite results",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/crud/unified/client-bulkWrite-update-options.json
+++ b/test/crud/unified/client-bulkWrite-update-options.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite update options",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/crud/unified/client-bulkWrite-update-pipeline.json
+++ b/test/crud/unified/client-bulkWrite-update-pipeline.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite update pipeline",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/retryable_writes/unified/client-bulkWrite-clientErrors.json
+++ b/test/retryable_writes/unified/client-bulkWrite-clientErrors.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/retryable_writes/unified/client-bulkWrite-serverErrors.json
+++ b/test/retryable_writes/unified/client-bulkWrite-serverErrors.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/retryable_writes/unified/handshakeError.json
+++ b/test/retryable_writes/unified/handshakeError.json
@@ -1,6 +1,6 @@
 {
   "description": "retryable writes handshake failures",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2",
@@ -57,7 +57,8 @@
       "description": "client.clientBulkWrite succeeds after retryable handshake network error",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -165,7 +166,8 @@
       "description": "client.clientBulkWrite succeeds after retryable handshake server error (ShutdownInProgress)",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/test/server_selection_logging/operation-id.json
+++ b/test/server_selection_logging/operation-id.json
@@ -343,7 +343,7 @@
           }
         },
         {
-          "name": "bulkWrite",
+          "name": "clientBulkWrite",
           "object": "client",
           "arguments": {
             "models": [

--- a/test/server_selection_logging/operation-id.json
+++ b/test/server_selection_logging/operation-id.json
@@ -232,7 +232,8 @@
       "description": "Successful client bulkWrite operation: log messages have operationIds",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -304,7 +305,8 @@
       "description": "Failed client bulkWrite operation: log messages have operationIds",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/test/server_selection_logging/operation-id.json
+++ b/test/server_selection_logging/operation-id.json
@@ -343,7 +343,7 @@
           }
         },
         {
-          "name": "clientBulkWrite",
+          "name": "bulkWrite",
           "object": "client",
           "arguments": {
             "models": [

--- a/test/test_client_bulk_write.py
+++ b/test/test_client_bulk_write.py
@@ -47,6 +47,7 @@ _IS_SYNC = True
 
 class TestClientBulkWrite(IntegrationTest):
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_returns_error_if_no_namespace_provided(self):
         models = [InsertOne(document={"a": "b"})]
         with self.assertRaises(InvalidOperation) as context:
@@ -57,6 +58,7 @@ class TestClientBulkWrite(IntegrationTest):
         )
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_handles_non_pymongo_error(self):
         with patch.object(
             _ClientBulk, "write_command", return_value={"error": TypeError("mock type error")}
@@ -68,6 +70,7 @@ class TestClientBulkWrite(IntegrationTest):
             self.assertFalse(hasattr(context.exception.error, "details"))
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_formats_write_error_correctly(self):
         models = [
             InsertOne(namespace="db.coll", document={"_id": 1}),
@@ -90,6 +93,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.max_message_size_bytes = client_context.max_message_size_bytes
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_batch_splits_if_num_operations_too_large(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(event_listeners=[listener])
@@ -115,6 +119,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertEqual(first_event.operation_id, second_event.operation_id)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_batch_splits_if_ops_payload_too_large(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(event_listeners=[listener])
@@ -147,6 +152,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertEqual(first_event.operation_id, second_event.operation_id)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     @client_context.require_failCommand_fail_point
     def test_collects_write_concern_errors_across_batches(self):
         listener = OvertCommandListener()
@@ -190,6 +196,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertEqual(len(bulk_write_events), 2)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_collects_write_errors_across_batches_unordered(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(event_listeners=[listener])
@@ -220,6 +227,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertEqual(len(bulk_write_events), 2)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_collects_write_errors_across_batches_ordered(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(event_listeners=[listener])
@@ -250,6 +258,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertEqual(len(bulk_write_events), 1)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_handles_cursor_requiring_getMore(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(event_listeners=[listener])
@@ -290,6 +299,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertTrue(get_more_event)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     @client_context.require_no_standalone
     def test_handles_cursor_requiring_getMore_within_transaction(self):
         listener = OvertCommandListener()
@@ -333,6 +343,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertTrue(get_more_event)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     @client_context.require_failCommand_fail_point
     def test_handles_getMore_error(self):
         listener = OvertCommandListener()
@@ -388,6 +399,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertTrue(kill_cursors_event)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_returns_error_if_unacknowledged_too_large_insert(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(event_listeners=[listener])
@@ -444,6 +456,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         return num_models, models
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_no_batch_splits_if_new_namespace_is_not_too_large(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(event_listeners=[listener])
@@ -475,6 +488,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertEqual(event.command["nsInfo"][0]["ns"], "db.coll")
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_batch_splits_if_new_namespace_is_too_large(self):
         listener = OvertCommandListener()
         client = rs_or_single_client(event_listeners=[listener])
@@ -513,6 +527,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
         self.assertEqual(second_event.command["nsInfo"][0]["ns"], namespace)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     def test_returns_error_if_no_writes_can_be_added_to_ops(self):
         client = rs_or_single_client()
         self.addCleanup(client.close)
@@ -531,6 +546,7 @@ class TestClientBulkWriteCRUD(IntegrationTest):
             client.bulk_write(models=models)
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
     def test_returns_error_if_auto_encryption_configured(self):
         opts = AutoEncryptionOpts(
@@ -556,6 +572,7 @@ class TestClientBulkWriteCSOT(IntegrationTest):
         self.max_message_size_bytes = client_context.max_message_size_bytes
 
     @client_context.require_version_min(8, 0, 0, -24)
+    @client_context.require_no_serverless
     @client_context.require_failCommand_fail_point
     def test_timeout_in_multi_batch_bulk_write(self):
         _OVERHEAD = 500

--- a/test/transactions/unified/client-bulkWrite.json
+++ b/test/transactions/unified/client-bulkWrite.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite transactions",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/versioned-api/crud-api-version-1.json
+++ b/test/versioned-api/crud-api-version-1.json
@@ -431,7 +431,8 @@
       "description": "client bulkWrite appends declared API version",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [


### PR DESCRIPTION
[PYTHON-4671](https://jira.mongodb.org/browse/PYTHON-4671)

This PR skips the `client.bulk_write` spec and prose tests from running on Atlas Serverless. 
See [this PR](https://github.com/mongodb/specifications/pull/1636) for the spec test changes.