### PR TITLE
PYTHON-4663 Fix compatibility with dateutil timezones

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2055,7 +2055,6 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
             PyObject* replace;
             PyObject* args;
             PyObject* kwargs;
-            PyObject* astimezone;
             int64_t millis;
             if (max < 8) {
                 goto invalid;
@@ -2133,30 +2132,22 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
                 goto invalid;
             }
             value = PyObject_Call(replace, args, kwargs);
+            Py_DECREF(replace);
+            Py_DECREF(args);
+            Py_DECREF(kwargs);
             if (!value) {
-                Py_DECREF(replace);
-                Py_DECREF(args);
-                Py_DECREF(kwargs);
                 goto invalid;
             }
 
             /* convert to local time */
             if (options->tzinfo != Py_None) {
-                astimezone = PyObject_GetAttr(value, state->_astimezone_str);
+                PyObject* temp = PyObject_CallMethodObjArgs(value, state->_astimezone_str, options->tzinfo, NULL);
                 Py_DECREF(value);
-                if (!astimezone) {
-                    Py_DECREF(replace);
-                    Py_DECREF(args);
-                    Py_DECREF(kwargs);
+                value = temp;
+                if (!value) {
                     goto invalid;
                 }
-                value = PyObject_CallFunctionObjArgs(astimezone, options->tzinfo, NULL);
-                Py_DECREF(astimezone);
             }
-
-            Py_DECREF(replace);
-            Py_DECREF(args);
-            Py_DECREF(kwargs);
             break;
         }
     case 11:

--- a/bson/datetime_ms.py
+++ b/bson/datetime_ms.py
@@ -144,9 +144,8 @@ def _millis_to_datetime(
             # Account for min/max edge cases in timezones.
             if opts.datetime_conversion == DatetimeConversion.DATETIME_CLAMP:
                 if millis < 0:
-                    return datetime.datetime.min.replace(tzinfo=opts.tzinfo)
-                # BSON truncates the microsecond field to at most 999 milliseconds.
-                return datetime.datetime.max.replace(tzinfo=opts.tzinfo, microsecond=999000)
+                    return _MIN_DATETIME.replace(tzinfo=opts.tzinfo)
+                return _MAX_DATETIME.replace(tzinfo=opts.tzinfo)
             elif opts.datetime_conversion == DatetimeConversion.DATETIME_AUTO:
                 return DatetimeMS(millis)
             raise InvalidBSON(f"{err} {_DATETIME_ERROR_SUGGESTION}") from err
@@ -167,5 +166,8 @@ def _datetime_to_millis(dtm: datetime.datetime) -> int:
 
 
 # Inclusive min and max for UTC timezones
-_MIN_DATETIME_MS = _datetime_to_millis(datetime.datetime.min.replace(tzinfo=utc))
-_MAX_DATETIME_MS = _datetime_to_millis(datetime.datetime.max.replace(tzinfo=utc))
+_MIN_DATETIME = datetime.datetime.min.replace(tzinfo=utc)
+# BSON truncates the microsecond field to at most 999 milliseconds.
+_MAX_DATETIME = datetime.datetime.max.replace(tzinfo=utc, microsecond=999000)
+_MIN_DATETIME_MS = _datetime_to_millis(_MIN_DATETIME)
+_MAX_DATETIME_MS = _datetime_to_millis(_MAX_DATETIME)

--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -926,7 +926,8 @@ def _encode_datetime(obj: datetime.datetime, json_options: JSONOptions) -> dict:
                 tz_string = "Z"
             else:
                 tz_string = obj.strftime("%z")
-            millis = int(obj.microsecond / 1000)
+            # TODO: write test case
+            millis = obj.microsecond // 1000
             fracsecs = ".%03d" % (millis,) if millis else ""
             return {
                 "$date": "{}{}{}".format(obj.strftime("%Y-%m-%dT%H:%M:%S"), fracsecs, tz_string)

--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -125,10 +125,10 @@ from bson.binary import ALL_UUID_SUBTYPES, UUID_SUBTYPE, Binary, UuidRepresentat
 from bson.code import Code
 from bson.codec_options import CodecOptions, DatetimeConversion
 from bson.datetime_ms import (
+    _MAX_DATETIME_MS,
     EPOCH_AWARE,
     DatetimeMS,
     _datetime_to_millis,
-    _max_datetime_ms,
     _millis_to_datetime,
 )
 from bson.dbref import DBRef
@@ -844,7 +844,7 @@ def _encode_binary(data: bytes, subtype: int, json_options: JSONOptions) -> Any:
 def _encode_datetimems(obj: Any, json_options: JSONOptions) -> dict:
     if (
         json_options.datetime_representation == DatetimeRepresentation.ISO8601
-        and 0 <= int(obj) <= _max_datetime_ms()
+        and 0 <= int(obj) <= _MAX_DATETIME_MS
     ):
         return _encode_datetime(obj.as_datetime(), json_options)
     elif json_options.datetime_representation == DatetimeRepresentation.LEGACY:

--- a/bson/objectid.py
+++ b/bson/objectid.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import binascii
-import calendar
 import datetime
 import os
 import struct
@@ -25,6 +24,7 @@ import time
 from random import SystemRandom
 from typing import Any, NoReturn, Optional, Type, Union
 
+from bson.datetime_ms import _datetime_to_millis
 from bson.errors import InvalidId
 from bson.tz_util import utc
 
@@ -131,11 +131,10 @@ class ObjectId:
         :param generation_time: :class:`~datetime.datetime` to be used
             as the generation time for the resulting ObjectId.
         """
-        offset = generation_time.utcoffset()
-        if offset is not None:
-            generation_time = generation_time - offset
-        timestamp = calendar.timegm(generation_time.timetuple())
-        oid = _PACK_INT(int(timestamp)) + b"\x00\x00\x00\x00\x00\x00\x00\x00"
+        oid = (
+            _PACK_INT(_datetime_to_millis(generation_time) // 1000)
+            + b"\x00\x00\x00\x00\x00\x00\x00\x00"
+        )
         return cls(oid)
 
     @classmethod

--- a/bson/timestamp.py
+++ b/bson/timestamp.py
@@ -15,11 +15,11 @@
 """Tools for representing MongoDB internal Timestamps."""
 from __future__ import annotations
 
-import calendar
 import datetime
 from typing import Any, Union
 
 from bson._helpers import _getstate_slots, _setstate_slots
+from bson.datetime_ms import _datetime_to_millis
 from bson.tz_util import utc
 
 UPPERBOUND = 4294967296
@@ -53,10 +53,7 @@ class Timestamp:
         :param inc: the incrementing counter
         """
         if isinstance(time, datetime.datetime):
-            offset = time.utcoffset()
-            if offset is not None:
-                time = time - offset
-            time = int(calendar.timegm(time.timetuple()))
+            time = _datetime_to_millis(time) // 1000
         if not isinstance(time, int):
             raise TypeError("time must be an instance of int")
         if not isinstance(inc, int):

--- a/doc/examples/datetimes.rst
+++ b/doc/examples/datetimes.rst
@@ -98,7 +98,7 @@ out of MongoDB in US/Pacific time:
    >>> aware_times = db.times.with_options(codec_options=CodecOptions(
    ...     tz_aware=True,
    ...     tzinfo=pytz.timezone('US/Pacific')))
-   >>> result = aware_times.find_one()
+   >>> result = aware_times.find_one()['date']
    datetime.datetime(2002, 10, 27, 6, 0,  # doctest: +NORMALIZE_WHITESPACE
                      tzinfo=<DstTzInfo 'US/Pacific' PST-1 day, 16:00:00 STD>)
 

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -1302,6 +1302,7 @@ class TestDatetimeConversion(unittest.TestCase):
         opts = CodecOptions(
             datetime_conversion=DatetimeConversion.DATETIME_CLAMP, tz_aware=True, tzinfo=tz
         )
+        # Min/max values in this timezone which can be represented in both BSON and datetime UTC.
         min_tz = datetime.datetime.min.replace(tzinfo=utc).astimezone(tz)
         max_tz = (
             (datetime.datetime.max - datetime.timedelta(minutes=60))
@@ -1332,6 +1333,7 @@ class TestDatetimeConversion(unittest.TestCase):
         for too_high in [
             max_tz + datetime.timedelta(microseconds=1),
             max_tz + datetime.timedelta(microseconds=999),
+            datetime.datetime.max.replace(tzinfo=tz),
             DatetimeMS(_datetime_to_millis(max_tz) + 1),  # 253402297200000
             DatetimeMS(_datetime_to_millis(max_tz) + 1000),  # 253402297200999
         ]:

--- a/test/test_json_util.py
+++ b/test/test_json_util.py
@@ -39,7 +39,7 @@ from bson.binary import (
     UuidRepresentation,
 )
 from bson.code import Code
-from bson.datetime_ms import _max_datetime_ms
+from bson.datetime_ms import _MAX_DATETIME_MS
 from bson.dbref import DBRef
 from bson.decimal128 import Decimal128
 from bson.int64 import Int64
@@ -257,7 +257,7 @@ class TestJsonUtil(unittest.TestCase):
     def test_datetime_ms(self):
         # Test ISO8601 in-range
         dat_min: dict[str, Any] = {"x": DatetimeMS(0)}
-        dat_max: dict[str, Any] = {"x": DatetimeMS(_max_datetime_ms())}
+        dat_max: dict[str, Any] = {"x": DatetimeMS(_MAX_DATETIME_MS)}
         opts = JSONOptions(datetime_representation=DatetimeRepresentation.ISO8601)
 
         self.assertEqual(
@@ -271,7 +271,7 @@ class TestJsonUtil(unittest.TestCase):
 
         # Test ISO8601 out-of-range
         dat_min = {"x": DatetimeMS(-1)}
-        dat_max = {"x": DatetimeMS(_max_datetime_ms() + 1)}
+        dat_max = {"x": DatetimeMS(_MAX_DATETIME_MS + 1)}
 
         self.assertEqual('{"x": {"$date": {"$numberLong": "-1"}}}', json_util.dumps(dat_min))
         self.assertEqual(
@@ -302,7 +302,7 @@ class TestJsonUtil(unittest.TestCase):
 
         # Test decode from datetime.datetime to DatetimeMS
         dat_min = {"x": datetime.datetime.min}
-        dat_max = {"x": DatetimeMS(_max_datetime_ms()).as_datetime(CodecOptions(tz_aware=False))}
+        dat_max = {"x": DatetimeMS(_MAX_DATETIME_MS).as_datetime(CodecOptions(tz_aware=False))}
         opts = JSONOptions(
             datetime_representation=DatetimeRepresentation.ISO8601,
             datetime_conversion=DatetimeConversion.DATETIME_MS,

--- a/test/test_objectid.py
+++ b/test/test_objectid.py
@@ -95,9 +95,6 @@ class TestObjectId(unittest.TestCase):
         self.assertTrue(d2 - d1 < datetime.timedelta(seconds=2))
 
     def test_from_datetime(self):
-        if "PyPy 1.8.0" in sys.version:
-            # See https://bugs.pypy.org/issue1092
-            raise SkipTest("datetime.timedelta is broken in pypy 1.8.0")
         d = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
         d = d - datetime.timedelta(microseconds=d.microsecond)
         oid = ObjectId.from_datetime(d)


### PR DESCRIPTION
PYTHON-4663 Fix compatibility with dateutil timezones.

Also fixes a few bugs in how we encode and decode datetimes with non-UTC timezones. I may split this PR into 2 to make it easier to review.