### PR TITLE
PYTHON-4663 Fix coverity warnings in datetime decoding change

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -387,6 +387,9 @@ static PyObject* decode_datetime(PyObject* self, long long millis, const codec_o
     PyObject* kwargs = NULL;
     PyObject* value = NULL;
     struct module_state *state = GETSTATE(self);
+    if (!state) {
+        goto invalid;
+    }
     if (options->datetime_conversion == DATETIME_MS){
         return datetime_ms_from_millis(self, millis);
     }
@@ -414,8 +417,8 @@ static PyObject* decode_datetime(PyObject* self, long long millis, const codec_o
                     Py_DECREF(utcoffset);
                     return 0;
                 }
-                min_millis_offset = (PyDateTime_DELTA_GET_DAYS(utcoffset) * 86400 +
-                                     PyDateTime_DELTA_GET_SECONDS(utcoffset)) * 1000 +
+                min_millis_offset = (PyDateTime_DELTA_GET_DAYS(utcoffset) * (int64_t)86400 +
+                                     PyDateTime_DELTA_GET_SECONDS(utcoffset)) * (int64_t)1000 +
                                      (PyDateTime_DELTA_GET_MICROSECONDS(utcoffset) / 1000);
             }
             Py_DECREF(utcoffset);
@@ -433,8 +436,8 @@ static PyObject* decode_datetime(PyObject* self, long long millis, const codec_o
                     Py_DECREF(utcoffset);
                     return 0;
                 }
-                max_millis_offset = (PyDateTime_DELTA_GET_DAYS(utcoffset) * 86400 +
-                                     PyDateTime_DELTA_GET_SECONDS(utcoffset)) * 1000 +
+                max_millis_offset = (PyDateTime_DELTA_GET_DAYS(utcoffset) * (int64_t)86400 +
+                                     PyDateTime_DELTA_GET_SECONDS(utcoffset)) * (int64_t)1000 +
                                      (PyDateTime_DELTA_GET_MICROSECONDS(utcoffset) / 1000);
             }
             Py_DECREF(utcoffset);

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -383,8 +383,6 @@ static int millis_from_datetime_ms(PyObject* dt, long long* out){
 static PyObject* decode_datetime(PyObject* self, long long millis, const codec_options_t* options){
     PyObject* naive = NULL;
     PyObject* replace = NULL;
-    PyObject* args = NULL;
-    PyObject* kwargs = NULL;
     PyObject* value = NULL;
     struct module_state *state = GETSTATE(self);
     if (!state) {
@@ -490,8 +488,6 @@ static PyObject* decode_datetime(PyObject* self, long long millis, const codec_o
 invalid:
     Py_XDECREF(naive);
     Py_XDECREF(replace);
-    Py_XDECREF(args);
-    Py_XDECREF(kwargs);
     return value;
 }
 


### PR DESCRIPTION
PYTHON-4663

First warning:
```
1. returned_null: PyModule_GetState returns NULL (checked 18 out of 19 times).
     	2. var_assigned: Assigning: state = NULL return value from PyModule_GetState.
389    struct module_state *state = GETSTATE(self);
```
Second:
```    	
CID 162119: (#2 of 2): Unintentional integer overflow (OVERFLOW_BEFORE_WIDEN)
overflow_before_widen: Potentially overflowing expression ((PyDateTime_Delta *)utcoffset)->days * 86400 with type int (32 bits, signed) is evaluated using 32-bit arithmetic, and then used in a context that expects an expression of type int64_t (64 bits, signed).
     	To avoid overflow, cast either ((PyDateTime_Delta *)utcoffset)->days or 86400 to type int64_t.
417                min_millis_offset = (PyDateTime_DELTA_GET_DAYS(utcoffset) * 86400 +
418                                     PyDateTime_DELTA_GET_SECONDS(utcoffset)) * 1000 +
419                                     (PyDateTime_DELTA_GET_MICROSECONDS(utcoffset) / 1000);
```