### PR TITLE
PYTHON-4607 Use LogRecord.getMessage() not LogRecord.message

### DIFF
--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -617,7 +617,7 @@ class AsyncClientUnitTest(AsyncUnitTest):
                 mock_get_hosts.return_value = [(host, 1)]
                 AsyncMongoClient(host)
             AsyncMongoClient(multi_host)
-            logs = [record.message for record in cm.records if record.name == "pymongo.client"]
+            logs = [record.getMessage() for record in cm.records if record.name == "pymongo.client"]
             self.assertEqual(len(logs), 7)
 
     @patch("pymongo.srv_resolver._SrvResolver.get_hosts")

--- a/test/asynchronous/test_logger.py
+++ b/test/asynchronous/test_logger.py
@@ -37,15 +37,15 @@ class TestLogger(AsyncIntegrationTest):
             with self.assertLogs("pymongo.command", level="DEBUG") as cm:
                 await db.test.insert_many(docs)
 
-                cmd_started_log = json_util.loads(cm.records[0].message)
+                cmd_started_log = json_util.loads(cm.records[0].getMessage())
                 self.assertEqual(len(cmd_started_log["command"]), _DEFAULT_DOCUMENT_LENGTH + 3)
 
-                cmd_succeeded_log = json_util.loads(cm.records[1].message)
+                cmd_succeeded_log = json_util.loads(cm.records[1].getMessage())
                 self.assertLessEqual(len(cmd_succeeded_log["reply"]), _DEFAULT_DOCUMENT_LENGTH + 3)
 
             with self.assertLogs("pymongo.command", level="DEBUG") as cm:
                 await db.test.find({}).to_list()
-                cmd_succeeded_log = json_util.loads(cm.records[1].message)
+                cmd_succeeded_log = json_util.loads(cm.records[1].getMessage())
                 self.assertEqual(len(cmd_succeeded_log["reply"]), _DEFAULT_DOCUMENT_LENGTH + 3)
 
     async def test_configured_truncation_limit(self):
@@ -55,14 +55,14 @@ class TestLogger(AsyncIntegrationTest):
             with self.assertLogs("pymongo.command", level="DEBUG") as cm:
                 await db.command(cmd)
 
-                cmd_started_log = json_util.loads(cm.records[0].message)
+                cmd_started_log = json_util.loads(cm.records[0].getMessage())
                 self.assertEqual(len(cmd_started_log["command"]), 5 + 3)
 
-                cmd_succeeded_log = json_util.loads(cm.records[1].message)
+                cmd_succeeded_log = json_util.loads(cm.records[1].getMessage())
                 self.assertLessEqual(len(cmd_succeeded_log["reply"]), 5 + 3)
                 with self.assertRaises(OperationFailure):
                     await db.command({"notARealCommand": True})
-                cmd_failed_log = json_util.loads(cm.records[-1].message)
+                cmd_failed_log = json_util.loads(cm.records[-1].getMessage())
                 self.assertEqual(len(cmd_failed_log["failure"]), 5 + 3)
 
     async def test_truncation_multi_byte_codepoints(self):
@@ -78,7 +78,7 @@ class TestLogger(AsyncIntegrationTest):
             with patch.dict("os.environ", {"MONGOB_LOG_MAX_DOCUMENT_LENGTH": length}):
                 with self.assertLogs("pymongo.command", level="DEBUG") as cm:
                     await self.db.test.insert_one({"x": multi_byte_char_str})
-                    cmd_started_log = json_util.loads(cm.records[0].message)["command"]
+                    cmd_started_log = json_util.loads(cm.records[0].getMessage())["command"]
 
                     cmd_started_log = cmd_started_log[:-3]
                     last_3_bytes = cmd_started_log.encode()[-3:].decode()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -611,7 +611,7 @@ class ClientUnitTest(UnitTest):
                 mock_get_hosts.return_value = [(host, 1)]
                 MongoClient(host)
             MongoClient(multi_host)
-            logs = [record.message for record in cm.records if record.name == "pymongo.client"]
+            logs = [record.getMessage() for record in cm.records if record.name == "pymongo.client"]
             self.assertEqual(len(logs), 7)
 
     @patch("pymongo.srv_resolver._SrvResolver.get_hosts")

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -36,15 +36,15 @@ class TestLogger(IntegrationTest):
             with self.assertLogs("pymongo.command", level="DEBUG") as cm:
                 db.test.insert_many(docs)
 
-                cmd_started_log = json_util.loads(cm.records[0].message)
+                cmd_started_log = json_util.loads(cm.records[0].getMessage())
                 self.assertEqual(len(cmd_started_log["command"]), _DEFAULT_DOCUMENT_LENGTH + 3)
 
-                cmd_succeeded_log = json_util.loads(cm.records[1].message)
+                cmd_succeeded_log = json_util.loads(cm.records[1].getMessage())
                 self.assertLessEqual(len(cmd_succeeded_log["reply"]), _DEFAULT_DOCUMENT_LENGTH + 3)
 
             with self.assertLogs("pymongo.command", level="DEBUG") as cm:
                 db.test.find({}).to_list()
-                cmd_succeeded_log = json_util.loads(cm.records[1].message)
+                cmd_succeeded_log = json_util.loads(cm.records[1].getMessage())
                 self.assertEqual(len(cmd_succeeded_log["reply"]), _DEFAULT_DOCUMENT_LENGTH + 3)
 
     def test_configured_truncation_limit(self):
@@ -54,14 +54,14 @@ class TestLogger(IntegrationTest):
             with self.assertLogs("pymongo.command", level="DEBUG") as cm:
                 db.command(cmd)
 
-                cmd_started_log = json_util.loads(cm.records[0].message)
+                cmd_started_log = json_util.loads(cm.records[0].getMessage())
                 self.assertEqual(len(cmd_started_log["command"]), 5 + 3)
 
-                cmd_succeeded_log = json_util.loads(cm.records[1].message)
+                cmd_succeeded_log = json_util.loads(cm.records[1].getMessage())
                 self.assertLessEqual(len(cmd_succeeded_log["reply"]), 5 + 3)
                 with self.assertRaises(OperationFailure):
                     db.command({"notARealCommand": True})
-                cmd_failed_log = json_util.loads(cm.records[-1].message)
+                cmd_failed_log = json_util.loads(cm.records[-1].getMessage())
                 self.assertEqual(len(cmd_failed_log["failure"]), 5 + 3)
 
     def test_truncation_multi_byte_codepoints(self):
@@ -77,7 +77,7 @@ class TestLogger(IntegrationTest):
             with patch.dict("os.environ", {"MONGOB_LOG_MAX_DOCUMENT_LENGTH": length}):
                 with self.assertLogs("pymongo.command", level="DEBUG") as cm:
                     self.db.test.insert_one({"x": multi_byte_char_str})
-                    cmd_started_log = json_util.loads(cm.records[0].message)["command"]
+                    cmd_started_log = json_util.loads(cm.records[0].getMessage())["command"]
 
                     cmd_started_log = cmd_started_log[:-3]
                     last_3_bytes = cmd_started_log.encode()[-3:].decode()

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -1925,7 +1925,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             for log in log_list:
                 if log.module == "ocsp_support":
                     continue
-                data = json_util.loads(log.message)
+                data = json_util.loads(log.getMessage())
                 client = data.pop("clientId") if "clientId" in data else data.pop("topologyId")
                 client_to_log[client].append(
                     {


### PR DESCRIPTION
PYTHON-4607 Use [LogRecord.getMessage()](https://docs.python.org/3/library/logging.html#logging.LogRecord.getMessage) not LogRecord.message

LogRecord.message is documented like this:

> The logged message, computed as msg % args. This is set when Formatter.format() is invoked.

It's not set until Formatter.format() or getMessage() is called which explains the `AttributeError: 'LogRecord' object has no attribute 'message'` errors we've been seeing.