### PR TITLE
PYTHON-4738 - Make test_encryption.TestClientSimple.test_fork sync-only

### DIFF
--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -380,6 +380,7 @@ class TestClientSimple(AsyncEncryptionIntegrationTest):
         is_greenthread_patched(),
         "gevent and eventlet do not support POSIX-style forking.",
     )
+    @async_client_context.require_sync
     async def test_fork(self):
         opts = AutoEncryptionOpts(KMS_PROVIDERS, "keyvault.datakeys")
         client = await self.async_rs_or_single_client(auto_encryption_opts=opts)

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -380,6 +380,7 @@ class TestClientSimple(EncryptionIntegrationTest):
         is_greenthread_patched(),
         "gevent and eventlet do not support POSIX-style forking.",
     )
+    @client_context.require_sync
     def test_fork(self):
         opts = AutoEncryptionOpts(KMS_PROVIDERS, "keyvault.datakeys")
         client = self.rs_or_single_client(auto_encryption_opts=opts)


### PR DESCRIPTION
Asyncio and forking should not be mixed. I suspect the sync version was failing due to running after the async version caused a deadlock.