### PR TITLE
PYTHON-4770 Improve CPU overhead of async locks and latency on Windows TLS sendall

### DIFF
--- a/pymongo/lock.py
+++ b/pymongo/lock.py
@@ -61,7 +61,7 @@ class _ALock:
                 return False
             if not blocking:
                 return False
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.001)
 
     def release(self) -> None:
         self._lock.release()
@@ -96,7 +96,7 @@ class _ACondition:
                 return False
             if not blocking:
                 return False
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.001)
 
     async def wait(self, timeout: Optional[float] = None) -> bool:
         if timeout is not None:

--- a/pymongo/network_layer.py
+++ b/pymongo/network_layer.py
@@ -114,18 +114,26 @@ if sys.platform != "win32":
 else:
     # The default Windows asyncio event loop does not support loop.add_reader/add_writer:
     # https://docs.python.org/3/library/asyncio-platforms.html#asyncio-platform-support
+    # Note: In PYTHON-4493 we plan to replace this code with asyncio streams.
     async def _async_sendall_ssl(
         sock: Union[socket.socket, _sslConn], buf: bytes, dummy: AbstractEventLoop
     ) -> None:
         view = memoryview(buf)
         total_length = len(buf)
         total_sent = 0
+        # Backoff starts at 1ms, doubles on timeout up to 512ms, and halves on success
+        # down to 1ms.
+        backoff = 0.001
         while total_sent < total_length:
             try:
                 sent = sock.send(view[total_sent:])
             except BLOCKING_IO_ERRORS:
-                await asyncio.sleep(0.5)
+                await asyncio.sleep(backoff)
                 sent = 0
+            if sent > 0:
+                backoff = max(backoff / 2, 0.001)
+            else:
+                backoff = min(backoff * 2, 0.512)
             total_sent += sent
 
 


### PR DESCRIPTION
PYTHON-4770 Improve CPU overhead of async locks and latency on Windows TLS sendall

CPU usage baseline with the sync api:
```
$ time python bench-lock.py sync         
Python: 3.12.4, PyMongo: 4.9.0.dev0
python bench-lock.py sync  0.19s user 0.05s system 4% cpu 5.333 total
```

Before:
```
$ time python bench-lock.py async
Python: 3.12.4, PyMongo: 4.9.0.dev0
python bench-lock.py async  0.77s user 0.42s system 23% cpu 5.168 total
```

After this change (both user and system CPU are much lower):
```
$ time python bench-lock.py async
Python: 3.12.4, PyMongo: 4.9.0.dev0
python bench-lock.py async  0.34s user 0.09s system 8% cpu 5.196 total
```
