### PR TITLE
PYTHON-1714 Add c extension use to client metadata

### DIFF
--- a/pymongo/__init__.py
+++ b/pymongo/__init__.py
@@ -88,7 +88,7 @@ TEXT = "text"
 
 from pymongo import _csot
 from pymongo._version import __version__, get_version_string, version_tuple
-from pymongo.common import MAX_SUPPORTED_WIRE_VERSION, MIN_SUPPORTED_WIRE_VERSION
+from pymongo.common import MAX_SUPPORTED_WIRE_VERSION, MIN_SUPPORTED_WIRE_VERSION, has_c
 from pymongo.cursor import CursorType
 from pymongo.operations import (
     DeleteMany,
@@ -114,16 +114,6 @@ except Exception as e:
 
 version = __version__
 """Current version of PyMongo."""
-
-
-def has_c() -> bool:
-    """Is the C extension installed?"""
-    try:
-        from pymongo import _cmessage  # type: ignore[attr-defined] # noqa: F401
-
-        return True
-    except ImportError:
-        return False
 
 
 def timeout(seconds: Optional[float]) -> ContextManager[None]:

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -1060,3 +1060,13 @@ class _CaseInsensitiveDictionary(MutableMapping[str, Any]):
 
     def cased_key(self, key: str) -> Any:
         return self.__casedkeys[key.lower()]
+
+
+def has_c() -> bool:
+    """Is the C extension installed?"""
+    try:
+        from pymongo import _cmessage  # type: ignore[attr-defined] # noqa: F401
+
+        return True
+    except ImportError:
+        return False

--- a/pymongo/pool_options.py
+++ b/pymongo/pool_options.py
@@ -33,6 +33,7 @@ from pymongo.common import (
     MAX_POOL_SIZE,
     MIN_POOL_SIZE,
     WAIT_QUEUE_TIMEOUT,
+    has_c,
 )
 
 if TYPE_CHECKING:
@@ -363,6 +364,11 @@ class PoolOptions:
         #    },
         #    'platform': 'CPython 3.8.0|MyPlatform'
         # }
+        if has_c():
+            self.__metadata["driver"]["name"] = "{}|{}".format(
+                self.__metadata["driver"]["name"],
+                "c",
+            )
         if not is_sync:
             self.__metadata["driver"]["name"] = "{}|{}".format(
                 self.__metadata["driver"]["name"],

--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -95,7 +95,7 @@ from pymongo.asynchronous.pool import (
 from pymongo.asynchronous.settings import TOPOLOGY_TYPE
 from pymongo.asynchronous.topology import _ErrorContext
 from pymongo.client_options import ClientOptions
-from pymongo.common import _UUID_REPRESENTATIONS, CONNECT_TIMEOUT
+from pymongo.common import _UUID_REPRESENTATIONS, CONNECT_TIMEOUT, has_c
 from pymongo.compression_support import _have_snappy, _have_zstd
 from pymongo.driver_info import DriverInfo
 from pymongo.errors import (
@@ -343,7 +343,10 @@ class AsyncClientUnitTest(AsyncUnitTest):
 
     async def test_metadata(self):
         metadata = copy.deepcopy(_METADATA)
-        metadata["driver"]["name"] = "PyMongo|async"
+        if has_c():
+            metadata["driver"]["name"] = "PyMongo|c|async"
+        else:
+            metadata["driver"]["name"] = "PyMongo|async"
         metadata["application"] = {"name": "foobar"}
         client = self.simple_client("mongodb://foo:27017/?appname=foobar&connect=false")
         options = client.options
@@ -366,7 +369,10 @@ class AsyncClientUnitTest(AsyncUnitTest):
         with self.assertRaises(TypeError):
             self.simple_client(driver=("Foo", "1", "a"))
         # Test appending to driver info.
-        metadata["driver"]["name"] = "PyMongo|async|FooDriver"
+        if has_c():
+            metadata["driver"]["name"] = "PyMongo|c|async|FooDriver"
+        else:
+            metadata["driver"]["name"] = "PyMongo|async|FooDriver"
         metadata["driver"]["version"] = "{}|1.2.3".format(_METADATA["driver"]["version"])
         client = self.simple_client(
             "foo",
@@ -1927,7 +1933,10 @@ class TestClient(AsyncIntegrationTest):
     async def _test_handshake(self, env_vars, expected_env):
         with patch.dict("os.environ", env_vars):
             metadata = copy.deepcopy(_METADATA)
-            metadata["driver"]["name"] = "PyMongo|async"
+            if has_c():
+                metadata["driver"]["name"] = "PyMongo|c|async"
+            else:
+                metadata["driver"]["name"] = "PyMongo|async"
             if expected_env is not None:
                 metadata["env"] = expected_env
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -83,7 +83,7 @@ from bson.son import SON
 from bson.tz_util import utc
 from pymongo import event_loggers, message, monitoring
 from pymongo.client_options import ClientOptions
-from pymongo.common import _UUID_REPRESENTATIONS, CONNECT_TIMEOUT
+from pymongo.common import _UUID_REPRESENTATIONS, CONNECT_TIMEOUT, has_c
 from pymongo.compression_support import _have_snappy, _have_zstd
 from pymongo.driver_info import DriverInfo
 from pymongo.errors import (
@@ -335,7 +335,10 @@ class ClientUnitTest(UnitTest):
 
     def test_metadata(self):
         metadata = copy.deepcopy(_METADATA)
-        metadata["driver"]["name"] = "PyMongo"
+        if has_c():
+            metadata["driver"]["name"] = "PyMongo|c"
+        else:
+            metadata["driver"]["name"] = "PyMongo"
         metadata["application"] = {"name": "foobar"}
         client = self.simple_client("mongodb://foo:27017/?appname=foobar&connect=false")
         options = client.options
@@ -358,7 +361,10 @@ class ClientUnitTest(UnitTest):
         with self.assertRaises(TypeError):
             self.simple_client(driver=("Foo", "1", "a"))
         # Test appending to driver info.
-        metadata["driver"]["name"] = "PyMongo|FooDriver"
+        if has_c():
+            metadata["driver"]["name"] = "PyMongo|c|FooDriver"
+        else:
+            metadata["driver"]["name"] = "PyMongo|FooDriver"
         metadata["driver"]["version"] = "{}|1.2.3".format(_METADATA["driver"]["version"])
         client = self.simple_client(
             "foo",
@@ -1885,7 +1891,10 @@ class TestClient(IntegrationTest):
     def _test_handshake(self, env_vars, expected_env):
         with patch.dict("os.environ", env_vars):
             metadata = copy.deepcopy(_METADATA)
-            metadata["driver"]["name"] = "PyMongo"
+            if has_c():
+                metadata["driver"]["name"] = "PyMongo|c"
+            else:
+                metadata["driver"]["name"] = "PyMongo"
             if expected_env is not None:
                 metadata["env"] = expected_env
 

--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -101,6 +101,7 @@ replacements = {
     "default_async": "default",
     "aclose": "close",
     "PyMongo|async": "PyMongo",
+    "PyMongo|c|async": "PyMongo|c",
     "AsyncTestGridFile": "TestGridFile",
     "AsyncTestGridFileNoConnect": "TestGridFileNoConnect",
 }


### PR DESCRIPTION
- Move `has_c` to common
- If `has_c` in pool_options update driver metadata
- If `has_c` in tests update driver metadata
- Add c replacement string to synchro