### PR TITLE
PYTHON-4789 Migrate test_retryable_reads.py to async

### DIFF
--- a/test/asynchronous/test_retryable_reads.py
+++ b/test/asynchronous/test_retryable_reads.py
@@ -34,7 +34,7 @@ from test.asynchronous import (
 from test.utils import (
     CMAPListener,
     OvertCommandListener,
-    set_fail_point,
+    async_set_fail_point,
 )
 
 from pymongo.monitoring import (
@@ -167,7 +167,7 @@ class TestRetryableReads(AsyncIntegrationTest):
 
         for mongos in async_client_context.mongos_seeds().split(","):
             client = await self.async_rs_or_single_client(mongos)
-            set_fail_point(client, fail_command)
+            await async_set_fail_point(client, fail_command)
             self.addAsyncCleanup(client.close)
             mongos_clients.append(client)
 
@@ -186,7 +186,7 @@ class TestRetryableReads(AsyncIntegrationTest):
         # Disable failpoints on each mongos
         for client in mongos_clients:
             fail_command["mode"] = "off"
-            set_fail_point(client, fail_command)
+            await async_set_fail_point(client, fail_command)
 
         self.assertEqual(len(listener.failed_events), 2)
         self.assertEqual(len(listener.succeeded_events), 0)

--- a/test/asynchronous/test_retryable_reads.py
+++ b/test/asynchronous/test_retryable_reads.py
@@ -47,7 +47,16 @@ from pymongo.monitoring import (
 _IS_SYNC = False
 
 # Location of JSON test specifications.
-_TEST_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "retryable_reads", "legacy")
+if _IS_SYNC:
+    _TEST_PATH = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "retryable_reads", "legacy"
+    )
+else:
+    _TEST_PATH = os.path.join(
+        os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir)),
+        "retryable_reads",
+        "legacy",
+    )
 
 
 class TestClientOptions(AsyncPyMongoTestCase):

--- a/test/asynchronous/test_retryable_reads.py
+++ b/test/asynchronous/test_retryable_reads.py
@@ -172,7 +172,7 @@ class TestRetryableReads(AsyncIntegrationTest):
             mongos_clients.append(client)
 
         listener = OvertCommandListener()
-        client = self.async_rs_or_single_client(
+        client = await self.async_rs_or_single_client(
             async_client_context.mongos_seeds(),
             appName="retryableReadTest",
             event_listeners=[listener],

--- a/test/asynchronous/test_retryable_reads.py
+++ b/test/asynchronous/test_retryable_reads.py
@@ -97,7 +97,6 @@ class TestPoolPausedError(AsyncIntegrationTest):
         client = await self.async_rs_or_single_client(
             maxPoolSize=1, event_listeners=[cmap_listener, cmd_listener]
         )
-        self.addAsyncCleanup(client.close)
         for _ in range(10):
             cmap_listener.reset()
             cmd_listener.reset()
@@ -168,7 +167,6 @@ class TestRetryableReads(AsyncIntegrationTest):
         for mongos in async_client_context.mongos_seeds().split(","):
             client = await self.async_rs_or_single_client(mongos)
             await async_set_fail_point(client, fail_command)
-            self.addAsyncCleanup(client.close)
             mongos_clients.append(client)
 
         listener = OvertCommandListener()

--- a/test/asynchronous/test_retryable_reads.py
+++ b/test/asynchronous/test_retryable_reads.py
@@ -46,18 +46,6 @@ from pymongo.monitoring import (
 
 _IS_SYNC = False
 
-# Location of JSON test specifications.
-if _IS_SYNC:
-    _TEST_PATH = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "retryable_reads", "legacy"
-    )
-else:
-    _TEST_PATH = os.path.join(
-        os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir)),
-        "retryable_reads",
-        "legacy",
-    )
-
 
 class TestClientOptions(AsyncPyMongoTestCase):
     async def test_default(self):

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -97,7 +97,6 @@ class TestPoolPausedError(IntegrationTest):
         client = self.rs_or_single_client(
             maxPoolSize=1, event_listeners=[cmap_listener, cmd_listener]
         )
-        self.addCleanup(client.close)
         for _ in range(10):
             cmap_listener.reset()
             cmd_listener.reset()
@@ -168,7 +167,6 @@ class TestRetryableReads(IntegrationTest):
         for mongos in client_context.mongos_seeds().split(","):
             client = self.rs_or_single_client(mongos)
             set_fail_point(client, fail_command)
-            self.addCleanup(client.close)
             mongos_clients.append(client)
 
         listener = OvertCommandListener()

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -46,18 +46,6 @@ from pymongo.monitoring import (
 
 _IS_SYNC = True
 
-# Location of JSON test specifications.
-if _IS_SYNC:
-    _TEST_PATH = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "retryable_reads", "legacy"
-    )
-else:
-    _TEST_PATH = os.path.join(
-        os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir)),
-        "retryable_reads",
-        "legacy",
-    )
-
 
 class TestClientOptions(PyMongoTestCase):
     def test_default(self):

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -47,7 +47,16 @@ from pymongo.monitoring import (
 _IS_SYNC = True
 
 # Location of JSON test specifications.
-_TEST_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "retryable_reads", "legacy")
+if _IS_SYNC:
+    _TEST_PATH = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "retryable_reads", "legacy"
+    )
+else:
+    _TEST_PATH = os.path.join(
+        os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir)),
+        "retryable_reads",
+        "legacy",
+    )
 
 
 class TestClientOptions(PyMongoTestCase):

--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -193,6 +193,7 @@ converted_tests = [
     "test_logger.py",
     "test_monitoring.py",
     "test_raw_bson.py",
+    "test_retryable_reads.py",
     "test_retryable_writes.py",
     "test_session.py",
     "test_transactions.py",


### PR DESCRIPTION
Note: I made `test_pool_paused_error_is_retryable` require sync because it uses threads, we can consider changing it to tasks too though! 
