### PR TITLE
PYTHON-4834 Add __repr__ to IndexModel, SearchIndexModel

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,8 @@ PyMongo 4.11 brings a number of changes including:
 - :attr:`~pymongo.asynchronous.mongo_client.AsyncMongoClient.address` and
   :attr:`~pymongo.mongo_client.MongoClient.address` now correctly block when called on unconnected clients
   until either connection succeeds or a server selection timeout error is raised.
+- Added :func:`repr` support to :class:`pymongo.operations.IndexModel`.
+- Added :func:`repr` support to :class:`pymongo.operations.SearchIndexModel`.
 
 Issues Resolved
 ...............

--- a/pymongo/operations.py
+++ b/pymongo/operations.py
@@ -773,6 +773,13 @@ class IndexModel:
         """
         return self.__document
 
+    def __repr__(self) -> str:
+        return "{}({}{})".format(
+            self.__class__.__name__,
+            self.document["key"],
+            "".join([f", {key}={value!r}" for key, value in self.document.items() if key != "key"]),
+        )
+
 
 class SearchIndexModel:
     """Represents a search index to create."""
@@ -812,3 +819,9 @@ class SearchIndexModel:
     def document(self) -> Mapping[str, Any]:
         """The document for this index."""
         return self.__document
+
+    def __repr__(self) -> str:
+        return "{}({})".format(
+            self.__class__.__name__,
+            ", ".join([f"{key}={value!r}" for key, value in self.document.items()]),
+        )

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1,0 +1,76 @@
+# Copyright 2009-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the operations module."""
+from __future__ import annotations
+
+from test import UnitTest, unittest
+
+from pymongo import ASCENDING, DESCENDING
+from pymongo.collation import Collation
+from pymongo.errors import OperationFailure
+from pymongo.operations import IndexModel, SearchIndexModel
+
+
+class TestOperationsBase(UnitTest):
+    """Base class for testing operations module."""
+
+    def assertRepr(self, obj):
+        new_obj = eval(repr(obj))
+        self.assertEqual(type(new_obj), type(obj))
+        self.assertEqual(repr(new_obj), repr(obj))
+
+
+class TestIndexModel(TestOperationsBase):
+    """Test IndexModel features."""
+
+    def test_repr(self):
+        # Based on examples in test_collection.py
+        self.assertRepr(IndexModel("hello"))
+        self.assertRepr(IndexModel([("hello", DESCENDING), ("world", ASCENDING)]))
+        self.assertRepr(
+            IndexModel([("hello", DESCENDING), ("world", ASCENDING)], name="hello_world")
+        )
+        # Test all the kwargs
+        self.assertRepr(IndexModel("name", name="name"))
+        self.assertRepr(IndexModel("unique", unique=False))
+        self.assertRepr(IndexModel("background", background=True))
+        self.assertRepr(IndexModel("sparse", sparse=True))
+        self.assertRepr(IndexModel("bucketSize", bucketSize=1))
+        self.assertRepr(IndexModel("min", min=1))
+        self.assertRepr(IndexModel("max", max=1))
+        self.assertRepr(IndexModel("expireAfterSeconds", expireAfterSeconds=1))
+        self.assertRepr(
+            IndexModel("partialFilterExpression", partialFilterExpression={"hello": "world"})
+        )
+        self.assertRepr(IndexModel("collation", collation=Collation(locale="en_US")))
+        self.assertRepr(IndexModel("wildcardProjection", wildcardProjection={"$**": 1}))
+        self.assertRepr(IndexModel("hidden", hidden=False))
+        # Test string literal
+        self.assertEqual(repr(IndexModel("hello")), "IndexModel({'hello': 1}, name='hello_1')")
+        self.assertEqual(
+            repr(IndexModel({"hello": 1, "world": -1})),
+            "IndexModel({'hello': 1, 'world': -1}, name='hello_1_world_-1')",
+        )
+
+
+class TestSearchIndexModel(TestOperationsBase):
+    """Test SearchIndexModel features."""
+
+    def test_repr(self):
+        self.assertRepr(SearchIndexModel("hello", key=1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1,4 +1,4 @@
-# Copyright 2009-present MongoDB, Inc.
+# Copyright 2009-2024 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,6 +70,10 @@ class TestSearchIndexModel(TestOperationsBase):
 
     def test_repr(self):
         self.assertRepr(SearchIndexModel({"hello": "hello"}, key=1))
+        self.assertEqual(
+            repr(SearchIndexModel({"hello": "hello"}, key=1)),
+            "SearchIndexModel(definition={'hello': 'hello'}, key=1)",
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -69,7 +69,7 @@ class TestSearchIndexModel(TestOperationsBase):
     """Test SearchIndexModel features."""
 
     def test_repr(self):
-        self.assertRepr(SearchIndexModel("hello", key=1))
+        self.assertRepr(SearchIndexModel({"hello": "hello"}, key=1))
 
 
 if __name__ == "__main__":

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1,4 +1,4 @@
-# Copyright 2009-2024 MongoDB, Inc.
+# Copyright 2024-present MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
For use with [django-mongodb](https://github.com/mongodb-labs/django-mongodb) e.g.

```

(.venv) alex.clark@Mac tmp.0F48BsWTyQ % python manage.py sqlmigrate auth 0001
System check identified some issues:

WARNINGS:
?: (staticfiles.W004) The directory '/private/var/folders/5t/d3llmfm54v3dg712_4pks3lm0000gn/T/tmp.0F48BsWTyQ/frontend/build' in the STATICFILES_DIRS setting does not exist.
--
-- Create model Permission
--
db.create_collection('auth_permission')
db.auth_permission.create_indexes([IndexModel({'name': 'auth_permission_content_type_id_2f476e4b', 'key': {'content_type_id': 1}})])
--
-- Create model Group
--
db.create_collection('auth_group')
db.create_collection('auth_group_permissions')
db.auth_group_permissions.create_indexes([IndexModel({'name': 'auth_group_permissions_group_id_b120cbf9', 'key': {'group_id': 1}})])
db.auth_group_permissions.create_indexes([IndexModel({'name': 'auth_group_permissions_permission_id_84c5c92e', 'key': {'permission_id': 1}})])
--
-- Create model User
--
db.create_collection('auth_user')
db.create_collection('auth_user_groups')
db.auth_user_groups.create_indexes([IndexModel({'name': 'auth_user_groups_user_id_6a12ed8b', 'key': {'user_id': 1}})])
db.auth_user_groups.create_indexes([IndexModel({'name': 'auth_user_groups_group_id_97559544', 'key': {'group_id': 1}})])
db.create_collection('auth_user_user_permissions')
db.auth_user_user_permissions.create_indexes([IndexModel({'name': 'auth_user_user_permissions_user_id_a95ead1b', 'key': {'user_id': 1}})])
db.auth_user_user_permissions.create_indexes([IndexModel({'name': 'auth_user_user_permissions_permission_id_1fbb5f2c', 'key': {'permission_id': 1}})])
```