### PR TITLE
PYTHON-4838 Generate OCSP build variants using shrub.py

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2827,23 +2827,10 @@ buildvariants:
     - "test-5.0-standalone"
 
 # OCSP test matrix.
-- name: ocsp-test-rhel8-v4.0-py3.9
+- name: ocsp-test-rhel8-v4.4-py3.9
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v4.0 py3.9
-  run_on:
-    - rhel87-small
-  batchtime: 20160
-  expansions:
-    VERSION: "4.0"
-    AUTH: noauth
-    SSL: ssl
-    TOPOLOGY: server
-    PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: ocsp-test-rhel8-v4.4-py3.10
-  tasks:
-    - name: .ocsp
-  display_name: OCSP test RHEL8 v4.4 py3.10
+  display_name: OCSP test RHEL8 v4.4 py3.9
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2852,11 +2839,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /opt/python/3.10/bin/python3
-- name: ocsp-test-rhel8-v5.0-py3.11
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+- name: ocsp-test-rhel8-v5.0-py3.10
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v5.0 py3.11
+  display_name: OCSP test RHEL8 v5.0 py3.10
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2865,11 +2852,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /opt/python/3.11/bin/python3
-- name: ocsp-test-rhel8-v6.0-py3.12
+    PYTHON_BINARY: /opt/python/3.10/bin/python3
+- name: ocsp-test-rhel8-v6.0-py3.11
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v6.0 py3.12
+  display_name: OCSP test RHEL8 v6.0 py3.11
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2878,11 +2865,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /opt/python/3.12/bin/python3
-- name: ocsp-test-rhel8-v7.0-py3.13
+    PYTHON_BINARY: /opt/python/3.11/bin/python3
+- name: ocsp-test-rhel8-v7.0-py3.12
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v7.0 py3.13
+  display_name: OCSP test RHEL8 v7.0 py3.12
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2891,11 +2878,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: ocsp-test-rhel8-v8.0-pypy3.9
+    PYTHON_BINARY: /opt/python/3.12/bin/python3
+- name: ocsp-test-rhel8-v8.0-py3.13
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v8.0 pypy3.9
+  display_name: OCSP test RHEL8 v8.0 py3.13
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2904,11 +2891,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-- name: ocsp-test-rhel8-rapid-pypy3.10
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+- name: ocsp-test-rhel8-rapid-pypy3.9
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 rapid pypy3.10
+  display_name: OCSP test RHEL8 rapid pypy3.9
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2917,11 +2904,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: ocsp-test-rhel8-latest-py3.9
+    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
+- name: ocsp-test-rhel8-latest-pypy3.10
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 latest py3.9
+  display_name: OCSP test RHEL8 latest pypy3.10
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2930,11 +2917,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: ocsp-test-win64-v4.4-py3.9
+    PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
+- name: ocsp-test-win64-v4.4-py3.13
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test Win64 v4.4 py3.9
+  display_name: OCSP test Win64 v4.4 py3.13
   run_on:
     - windows-64-vsMulti-small
   batchtime: 20160
@@ -2943,11 +2930,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: C:/python/Python39/python.exe
-- name: ocsp-test-win64-v8.0-py3.9
+    PYTHON_BINARY: C:/python/Python313/python.exe
+- name: ocsp-test-win64-v8.0-py3.13
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test Win64 v8.0 py3.9
+  display_name: OCSP test Win64 v8.0 py3.13
   run_on:
     - windows-64-vsMulti-small
   batchtime: 20160
@@ -2956,11 +2943,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: C:/python/Python39/python.exe
-- name: ocsp-test-macos-v4.4-py3.9
+    PYTHON_BINARY: C:/python/Python313/python.exe
+- name: ocsp-test-macos-v4.4-py3.13
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test macOS v4.4 py3.9
+  display_name: OCSP test macOS v4.4 py3.13
   run_on:
     - macos-14
   batchtime: 20160
@@ -2969,11 +2956,11 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-- name: ocsp-test-macos-v8.0-py3.9
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: ocsp-test-macos-v8.0-py3.13
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test macOS v8.0 py3.9
+  display_name: OCSP test macOS v8.0 py3.13
   run_on:
     - macos-14
   batchtime: 20160
@@ -2982,7 +2969,7 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
 - matrix_name: "oidc-auth-test"
   matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2826,42 +2826,163 @@ buildvariants:
     - "test-6.0-standalone"
     - "test-5.0-standalone"
 
-- matrix_name: "ocsp-test"
-  matrix_spec:
-    platform: rhel8
-    python-version: ["3.9", "3.10", "pypy3.9", "pypy3.10"]
-    mongodb-version: ["4.4", "5.0", "6.0", "7.0", "8.0", "latest"]
-    auth: "noauth"
-    ssl: "ssl"
-  display_name: "OCSP test ${platform} ${python-version} ${mongodb-version}"
-  batchtime: 20160 # 14 days
+# OCSP test matrix.
+- name: ocsp-test-rhel8-v4.0
   tasks:
-    - name: ".ocsp"
-
-- matrix_name: "ocsp-test-windows"
-  matrix_spec:
-    platform: windows
-    python-version-windows: ["3.9", "3.10"]
-    mongodb-version: ["4.4", "5.0", "6.0", "7.0", "8.0", "latest"]
-    auth: "noauth"
-    ssl: "ssl"
-  display_name: "OCSP test ${platform} ${python-version-windows} ${mongodb-version}"
-  batchtime: 20160 # 14 days
+    - name: .ocsp
+  display_name: OCSP test RHEL8 v4.0
+  run_on:
+    - rhel87-small
+  batchtime: 20160
+  expansions:
+    VERSION: "4.0"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+- name: ocsp-test-rhel8-v4.4
   tasks:
-    # Windows MongoDB servers do not staple OCSP responses and only support RSA.
-    - name: ".ocsp-rsa !.ocsp-staple"
-
-- matrix_name: "ocsp-test-macos"
-  matrix_spec:
-    platform: macos
-    mongodb-version: ["4.4", "5.0", "6.0", "7.0", "8.0", "latest"]
-    auth: "noauth"
-    ssl: "ssl"
-  display_name: "OCSP test ${platform} ${mongodb-version}"
-  batchtime: 20160 # 14 days
+    - name: .ocsp
+  display_name: OCSP test RHEL8 v4.4
+  run_on:
+    - rhel87-small
+  batchtime: 20160
+  expansions:
+    VERSION: "4.4"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /opt/python/3.10/bin/python3
+- name: ocsp-test-rhel8-v5.0
   tasks:
-    # macOS MongoDB servers do not staple OCSP responses and only support RSA.
-    - name: ".ocsp-rsa !.ocsp-staple"
+    - name: .ocsp
+  display_name: OCSP test RHEL8 v5.0
+  run_on:
+    - rhel87-small
+  batchtime: 20160
+  expansions:
+    VERSION: "5.0"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /opt/python/3.11/bin/python3
+- name: ocsp-test-rhel8-v6.0
+  tasks:
+    - name: .ocsp
+  display_name: OCSP test RHEL8 v6.0
+  run_on:
+    - rhel87-small
+  batchtime: 20160
+  expansions:
+    VERSION: "6.0"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /opt/python/3.12/bin/python3
+- name: ocsp-test-rhel8-v7.0
+  tasks:
+    - name: .ocsp
+  display_name: OCSP test RHEL8 v7.0
+  run_on:
+    - rhel87-small
+  batchtime: 20160
+  expansions:
+    VERSION: "7.0"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+- name: ocsp-test-rhel8-v8.0
+  tasks:
+    - name: .ocsp
+  display_name: OCSP test RHEL8 v8.0
+  run_on:
+    - rhel87-small
+  batchtime: 20160
+  expansions:
+    VERSION: "8.0"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
+- name: ocsp-test-rhel8-rapid
+  tasks:
+    - name: .ocsp
+  display_name: OCSP test RHEL8 rapid
+  run_on:
+    - rhel87-small
+  batchtime: 20160
+  expansions:
+    VERSION: rapid
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
+- name: ocsp-test-rhel8-latest
+  tasks:
+    - name: .ocsp
+  display_name: OCSP test RHEL8 latest
+  run_on:
+    - rhel87-small
+  batchtime: 20160
+  expansions:
+    VERSION: latest
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+- name: ocsp-test-win64-v4.4
+  tasks:
+    - name: .ocsp-rsa !.ocsp-staple
+  display_name: OCSP test Win64 v4.4
+  run_on:
+    - windows-64-vsMulti-small
+  batchtime: 20160
+  expansions:
+    VERSION: "4.4"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: C:/python/Python39/python.exe
+- name: ocsp-test-win64-v8.0
+  tasks:
+    - name: .ocsp-rsa !.ocsp-staple
+  display_name: OCSP test Win64 v8.0
+  run_on:
+    - windows-64-vsMulti-small
+  batchtime: 20160
+  expansions:
+    VERSION: "8.0"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: C:/python/Python39/python.exe
+- name: ocsp-test-macos-v4.4
+  tasks:
+    - name: .ocsp-rsa !.ocsp-staple
+  display_name: OCSP test macOS v4.4
+  run_on:
+    - macos-14
+  batchtime: 20160
+  expansions:
+    VERSION: "4.4"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: ocsp-test-macos-v8.0
+  tasks:
+    - name: .ocsp-rsa !.ocsp-staple
+  display_name: OCSP test macOS v8.0
+  run_on:
+    - macos-14
+  batchtime: 20160
+  expansions:
+    VERSION: "8.0"
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 
 - matrix_name: "oidc-auth-test"
   matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2827,10 +2827,10 @@ buildvariants:
     - "test-5.0-standalone"
 
 # OCSP test matrix.
-- name: ocsp-test-rhel8-v4.0
+- name: ocsp-test-rhel8-py3.9-v4.0
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v4.0
+  display_name: OCSP test RHEL8 py3.9 v4.0
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2840,10 +2840,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: ocsp-test-rhel8-v4.4
+- name: ocsp-test-rhel8-py3.10-v4.4
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v4.4
+  display_name: OCSP test RHEL8 py3.10 v4.4
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2853,10 +2853,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.10/bin/python3
-- name: ocsp-test-rhel8-v5.0
+- name: ocsp-test-rhel8-py3.11-v5.0
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v5.0
+  display_name: OCSP test RHEL8 py3.11 v5.0
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2866,10 +2866,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.11/bin/python3
-- name: ocsp-test-rhel8-v6.0
+- name: ocsp-test-rhel8-py3.12-v6.0
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v6.0
+  display_name: OCSP test RHEL8 py3.12 v6.0
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2879,10 +2879,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.12/bin/python3
-- name: ocsp-test-rhel8-v7.0
+- name: ocsp-test-rhel8-py3.13-v7.0
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v7.0
+  display_name: OCSP test RHEL8 py3.13 v7.0
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2892,10 +2892,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: ocsp-test-rhel8-v8.0
+- name: ocsp-test-rhel8-pypy3.9-v8.0
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 v8.0
+  display_name: OCSP test RHEL8 pypy3.9 v8.0
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2905,10 +2905,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-- name: ocsp-test-rhel8-rapid
+- name: ocsp-test-rhel8-pypy3.10-rapid
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 rapid
+  display_name: OCSP test RHEL8 pypy3.10 rapid
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2918,10 +2918,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: ocsp-test-rhel8-latest
+- name: ocsp-test-rhel8-py3.9-latest
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 latest
+  display_name: OCSP test RHEL8 py3.9 latest
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2931,10 +2931,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: ocsp-test-win64-v4.4
+- name: ocsp-test-win64-py3.9-v4.4
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test Win64 v4.4
+  display_name: OCSP test Win64 py3.9 v4.4
   run_on:
     - windows-64-vsMulti-small
   batchtime: 20160
@@ -2944,10 +2944,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: C:/python/Python39/python.exe
-- name: ocsp-test-win64-v8.0
+- name: ocsp-test-win64-py3.9-v8.0
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test Win64 v8.0
+  display_name: OCSP test Win64 py3.9 v8.0
   run_on:
     - windows-64-vsMulti-small
   batchtime: 20160
@@ -2957,10 +2957,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: C:/python/Python39/python.exe
-- name: ocsp-test-macos-v4.4
+- name: ocsp-test-macos-py3.9-v4.4
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test macOS v4.4
+  display_name: OCSP test macOS py3.9 v4.4
   run_on:
     - macos-14
   batchtime: 20160
@@ -2970,10 +2970,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-- name: ocsp-test-macos-v8.0
+- name: ocsp-test-macos-py3.9-v8.0
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test macOS v8.0
+  display_name: OCSP test macOS py3.9 v8.0
   run_on:
     - macos-14
   batchtime: 20160

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2827,19 +2827,6 @@ buildvariants:
     - "test-5.0-standalone"
 
 # OCSP test matrix.
-- name: ocsp-test-rhel8-v4.4-py3.9
-  tasks:
-    - name: .ocsp
-  display_name: OCSP test RHEL8 v4.4 py3.9
-  run_on:
-    - rhel87-small
-  batchtime: 20160
-  expansions:
-    VERSION: "4.4"
-    AUTH: noauth
-    SSL: ssl
-    TOPOLOGY: server
-    PYTHON_BINARY: /opt/python/3.9/bin/python3
 - name: ocsp-test-rhel8-v5.0-py3.10
   tasks:
     - name: .ocsp
@@ -2848,10 +2835,10 @@ buildvariants:
     - rhel87-small
   batchtime: 20160
   expansions:
-    VERSION: "5.0"
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: "5.0"
     PYTHON_BINARY: /opt/python/3.10/bin/python3
 - name: ocsp-test-rhel8-v6.0-py3.11
   tasks:
@@ -2861,10 +2848,10 @@ buildvariants:
     - rhel87-small
   batchtime: 20160
   expansions:
-    VERSION: "6.0"
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: "6.0"
     PYTHON_BINARY: /opt/python/3.11/bin/python3
 - name: ocsp-test-rhel8-v7.0-py3.12
   tasks:
@@ -2874,10 +2861,10 @@ buildvariants:
     - rhel87-small
   batchtime: 20160
   expansions:
-    VERSION: "7.0"
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: "7.0"
     PYTHON_BINARY: /opt/python/3.12/bin/python3
 - name: ocsp-test-rhel8-v8.0-py3.13
   tasks:
@@ -2887,10 +2874,10 @@ buildvariants:
     - rhel87-small
   batchtime: 20160
   expansions:
-    VERSION: "8.0"
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: "8.0"
     PYTHON_BINARY: /opt/python/3.13/bin/python3
 - name: ocsp-test-rhel8-rapid-pypy3.9
   tasks:
@@ -2900,10 +2887,10 @@ buildvariants:
     - rhel87-small
   batchtime: 20160
   expansions:
-    VERSION: rapid
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: rapid
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
 - name: ocsp-test-rhel8-latest-pypy3.10
   tasks:
@@ -2913,10 +2900,10 @@ buildvariants:
     - rhel87-small
   batchtime: 20160
   expansions:
-    VERSION: latest
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: latest
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 - name: ocsp-test-win64-v4.4-py3.9
   tasks:
@@ -2926,10 +2913,10 @@ buildvariants:
     - windows-64-vsMulti-small
   batchtime: 20160
   expansions:
-    VERSION: "4.4"
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: "4.4"
     PYTHON_BINARY: C:/python/Python39/python.exe
 - name: ocsp-test-win64-v8.0-py3.13
   tasks:
@@ -2939,36 +2926,36 @@ buildvariants:
     - windows-64-vsMulti-small
   batchtime: 20160
   expansions:
-    VERSION: "8.0"
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: "8.0"
     PYTHON_BINARY: C:/python/Python313/python.exe
 - name: ocsp-test-macos-v4.4-py3.9
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test macOS v4.4 py3.9
+  display_name: OCSP test MacOS v4.4 py3.9
   run_on:
     - macos-14
   batchtime: 20160
   expansions:
-    VERSION: "4.4"
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: "4.4"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 - name: ocsp-test-macos-v8.0-py3.13
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test macOS v8.0 py3.13
+  display_name: OCSP test MacOS v8.0 py3.13
   run_on:
     - macos-14
   batchtime: 20160
   expansions:
-    VERSION: "8.0"
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
+    VERSION: "8.0"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
 - matrix_name: "oidc-auth-test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2918,10 +2918,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: ocsp-test-win64-v4.4-py3.13
+- name: ocsp-test-win64-v4.4-py3.9
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test Win64 v4.4 py3.13
+  display_name: OCSP test Win64 v4.4 py3.9
   run_on:
     - windows-64-vsMulti-small
   batchtime: 20160
@@ -2930,7 +2930,7 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: C:/python/Python313/python.exe
+    PYTHON_BINARY: C:/python/Python39/python.exe
 - name: ocsp-test-win64-v8.0-py3.13
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
@@ -2944,10 +2944,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: C:/python/Python313/python.exe
-- name: ocsp-test-macos-v4.4-py3.13
+- name: ocsp-test-macos-v4.4-py3.9
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test macOS v4.4 py3.13
+  display_name: OCSP test macOS v4.4 py3.9
   run_on:
     - macos-14
   batchtime: 20160
@@ -2956,7 +2956,7 @@ buildvariants:
     AUTH: noauth
     SSL: ssl
     TOPOLOGY: server
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 - name: ocsp-test-macos-v8.0-py3.13
   tasks:
     - name: .ocsp-rsa !.ocsp-staple

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2827,6 +2827,19 @@ buildvariants:
     - "test-5.0-standalone"
 
 # OCSP test matrix.
+- name: ocsp-test-rhel8-v4.4-py3.9
+  tasks:
+    - name: .ocsp
+  display_name: OCSP test RHEL8 v4.4 py3.9
+  run_on:
+    - rhel87-small
+  batchtime: 20160
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TOPOLOGY: server
+    VERSION: "4.4"
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
 - name: ocsp-test-rhel8-v5.0-py3.10
   tasks:
     - name: .ocsp

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2827,10 +2827,10 @@ buildvariants:
     - "test-5.0-standalone"
 
 # OCSP test matrix.
-- name: ocsp-test-rhel8-py3.9-v4.0
+- name: ocsp-test-rhel8-v4.0-py3.9
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 py3.9 v4.0
+  display_name: OCSP test RHEL8 v4.0 py3.9
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2840,10 +2840,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: ocsp-test-rhel8-py3.10-v4.4
+- name: ocsp-test-rhel8-v4.4-py3.10
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 py3.10 v4.4
+  display_name: OCSP test RHEL8 v4.4 py3.10
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2853,10 +2853,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.10/bin/python3
-- name: ocsp-test-rhel8-py3.11-v5.0
+- name: ocsp-test-rhel8-v5.0-py3.11
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 py3.11 v5.0
+  display_name: OCSP test RHEL8 v5.0 py3.11
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2866,10 +2866,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.11/bin/python3
-- name: ocsp-test-rhel8-py3.12-v6.0
+- name: ocsp-test-rhel8-v6.0-py3.12
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 py3.12 v6.0
+  display_name: OCSP test RHEL8 v6.0 py3.12
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2879,10 +2879,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.12/bin/python3
-- name: ocsp-test-rhel8-py3.13-v7.0
+- name: ocsp-test-rhel8-v7.0-py3.13
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 py3.13 v7.0
+  display_name: OCSP test RHEL8 v7.0 py3.13
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2892,10 +2892,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: ocsp-test-rhel8-pypy3.9-v8.0
+- name: ocsp-test-rhel8-v8.0-pypy3.9
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 pypy3.9 v8.0
+  display_name: OCSP test RHEL8 v8.0 pypy3.9
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2905,10 +2905,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-- name: ocsp-test-rhel8-pypy3.10-rapid
+- name: ocsp-test-rhel8-rapid-pypy3.10
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 pypy3.10 rapid
+  display_name: OCSP test RHEL8 rapid pypy3.10
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2918,10 +2918,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: ocsp-test-rhel8-py3.9-latest
+- name: ocsp-test-rhel8-latest-py3.9
   tasks:
     - name: .ocsp
-  display_name: OCSP test RHEL8 py3.9 latest
+  display_name: OCSP test RHEL8 latest py3.9
   run_on:
     - rhel87-small
   batchtime: 20160
@@ -2931,10 +2931,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: ocsp-test-win64-py3.9-v4.4
+- name: ocsp-test-win64-v4.4-py3.9
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test Win64 py3.9 v4.4
+  display_name: OCSP test Win64 v4.4 py3.9
   run_on:
     - windows-64-vsMulti-small
   batchtime: 20160
@@ -2944,10 +2944,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: C:/python/Python39/python.exe
-- name: ocsp-test-win64-py3.9-v8.0
+- name: ocsp-test-win64-v8.0-py3.9
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test Win64 py3.9 v8.0
+  display_name: OCSP test Win64 v8.0 py3.9
   run_on:
     - windows-64-vsMulti-small
   batchtime: 20160
@@ -2957,10 +2957,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: C:/python/Python39/python.exe
-- name: ocsp-test-macos-py3.9-v4.4
+- name: ocsp-test-macos-v4.4-py3.9
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test macOS py3.9 v4.4
+  display_name: OCSP test macOS v4.4 py3.9
   run_on:
     - macos-14
   batchtime: 20160
@@ -2970,10 +2970,10 @@ buildvariants:
     SSL: ssl
     TOPOLOGY: server
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-- name: ocsp-test-macos-py3.9-v8.0
+- name: ocsp-test-macos-v8.0-py3.9
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test macOS py3.9 v8.0
+  display_name: OCSP test macOS v8.0 py3.9
   run_on:
     - macos-14
   batchtime: 20160

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2934,7 +2934,7 @@ buildvariants:
 - name: ocsp-test-macos-v4.4-py3.9
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test MacOS v4.4 py3.9
+  display_name: OCSP test macOS v4.4 py3.9
   run_on:
     - macos-14
   batchtime: 20160
@@ -2947,7 +2947,7 @@ buildvariants:
 - name: ocsp-test-macos-v8.0-py3.13
   tasks:
     - name: .ocsp-rsa !.ocsp-staple
-  display_name: OCSP test MacOS v8.0 py3.13
+  display_name: OCSP test macOS v8.0 py3.13
   run_on:
     - macos-14
   batchtime: 20160

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -1,0 +1,178 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "shrub.py>=3.2.0",
+#   "pyyaml>=6.0.2"
+# ]
+# ///
+
+# Note: Run this file with `hatch run`, `pipx run`, or `uv run`.
+from __future__ import annotations
+
+import os
+import sys
+from itertools import product
+from pathlib import Path
+
+from shrub.v3.evg_build_variant import BuildVariant
+from shrub.v3.evg_command import FunctionCall
+from shrub.v3.evg_project import EvgProject
+from shrub.v3.evg_task import EvgTask, EvgTaskRef
+from shrub.v3.shrub_service import ShrubService
+
+# Top level variables.
+ALL_VERSIONS = ["4.0", "4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"]
+CPYTHONS = ["py3.9", "py3.10", "py3.11", "py3.12", "py3.13"]
+PYPYS = ["pypy3.9", "pypy3.10"]
+ALL_PYTHONS = CPYTHONS + PYPYS
+ALL_WIN_PYTHONS = CPYTHONS.copy()
+ALL_WIN_PYTHONS = ALL_WIN_PYTHONS + [f"32-bit {p}" for p in ALL_WIN_PYTHONS]
+AUTHS = ["noauth", "auth"]
+SSLS = ["nossl", "ssl"]
+AUTH_SSLS = list(product(AUTHS, SSLS))
+TOPOLOGIES = ["standalone", "replica_set", "sharded_cluster"]
+C_EXTS = ["without c extensions", "with c extensions"]
+BATCHTIME_WEEK = 10080
+HOSTS = dict(rhel8="rhel87-small", Win64="windows-64-vsMulti-small", macOS="macos-14")
+
+
+# Helper functions.
+def create_variant(task_names, display_name, *, python=None, host=None, **kwargs):
+    task_refs = [EvgTaskRef(name=n) for n in task_names]
+    kwargs.setdefault("expansions", dict())
+    expansions = kwargs.pop("expansions")
+    host = host or "rhel8"
+    run_on = [HOSTS[host]]
+    name = display_name.replace(" ", "-").lower()
+    if python:
+        expansions["PYTHON_BINARY"] = get_python_binary(python, host)
+    expansions = expansions or None
+    return BuildVariant(
+        name=name,
+        display_name=display_name,
+        tasks=task_refs,
+        expansions=expansions,
+        run_on=run_on,
+        **kwargs,
+    )
+
+
+def get_python_binary(python, host):
+    if host.lower() == "win64":
+        is_32 = python.startswith("32-bit")
+        if is_32:
+            _, python = python.split()
+            base = "C:/python/32/"
+        else:
+            base = "C:/python/"
+        middle = python.replace("py", "Python").replace(".", "")
+        return base + middle + "/python.exe"
+
+    if host.lower() == "rhel8":
+        if python.startswith("pypy"):
+            return f"/opt/python/{python}/bin/python3"
+        return f"/opt/python/{python[2:]}/bin/python3"
+
+    if host.lower() == "macos":
+        ver = python.replace("py", "")
+        return f"/Library/Frameworks/Python.Framework/Versions/{ver}/bin/python3"
+
+    raise ValueError(f"no match found for {python} on {host}")
+
+
+def write_output(project: EvgProject, target: str) -> str:
+    HERE = Path(__file__).resolve().parent
+    with open(HERE.parent / "generated_configs" / target, "w") as fid:
+        fid.write(ShrubService.generate_yaml(project))
+
+
+##############
+# OCSP
+##############
+
+
+def create_ocsp_task(file_name, server_type):
+    algo = file_name.split("-")[0]
+
+    # Create ocsp server call.
+    vars = dict(OCSP_ALGORITHM=algo, SERVER_TYPE=server_type)
+    server_func = FunctionCall(func="run-ocsp-server", vars=vars)
+
+    # Create bootstrap function call.
+    vars = dict(ORCHESTRATION_FILE=file_name)
+    bootstrap_func = FunctionCall(func="bootstrap mongo-orchestration", vars=vars)
+
+    # Create test function call.
+    should_succeed = "true" if "valid" in server_type else "false"
+    vars = dict(OCSP_ALGORITHM=algo, OCSP_TLS_SHOULD_SUCCEED=should_succeed)
+    test_func = FunctionCall(func="run tests", vars=vars)
+
+    # Handle tags.
+    tags = ["ocsp", f"ocsp-{algo}"]
+    if "mustStaple" in file_name:
+        tags.append("ocsp-staple")
+
+    # Create task.
+    name = file_name.replace(".json", "")
+    task_name = f"test-ocsp-{server_type}-{name}"
+    commands = [server_func, bootstrap_func, test_func]
+    return EvgTask(name=task_name, tags=tags, commands=commands)
+
+
+tasks = []
+
+# Create OCSP tasks.
+if not os.environ.get("DRIVERS_TOOLS"):
+    print("Set DRIVERS_TOOLS environment variable!")  # noqa: T201
+    sys.exit(1)
+config = Path(os.environ["DRIVERS_TOOLS"]) / ".evergreen/orchestration/configs/servers"
+for path in config.glob("*ocsp*"):
+    for server_type in ["valid", "revoked", "valid-delegate", "revoked-delegate"]:
+        task = create_ocsp_task(path.name, server_type)
+        tasks.append(task)
+
+# Create build variants.
+variants = []
+
+# OCSP tests on rhel8 with rotating CPython versions.
+for version in ALL_VERSIONS:
+    task_refs = [EvgTaskRef(name=".ocsp")]
+    expansions = dict(VERSION=version, AUTH="noauth", SSL="ssl", TOPOLOGY="server")
+    batchtime = BATCHTIME_WEEK * 2
+    python = ALL_PYTHONS[len(variants) % len(ALL_PYTHONS)]
+    host = "rhel8"
+    if version in ["rapid", "latest"]:
+        display_name = f"OCSP test RHEL8 {version}"
+    else:
+        display_name = f"OCSP test RHEL8 v{version}"
+    variant = create_variant(
+        [".ocsp"],
+        display_name,
+        python=python,
+        batchtime=batchtime,
+        host=host,
+        expansions=expansions,
+    )
+    variants.append(variant)
+
+# OCSP tests on Windows and MacOS with lowest CPython version.
+for host, version in product(["Win64", "macOS"], ["4.4", "8.0"]):
+    # MongoDB servers do not staple OCSP responses and only support RSA.
+    task_names = [".ocsp-rsa !.ocsp-staple"]
+    expansions = dict(VERSION=version, AUTH="noauth", SSL="ssl", TOPOLOGY="server")
+    batchtime = BATCHTIME_WEEK * 2
+    display_name = f"OCSP test {host} v{version}"
+    variant = create_variant(
+        task_names,
+        display_name,
+        python=CPYTHONS[0],
+        host=host,
+        expansions=expansions,
+        batchtime=batchtime,
+    )
+    variants.append(variant)
+
+# Generate OCSP config.
+# project = EvgProject(tasks=None, buildvariants=variants)
+# write_output(project, "ocsp.yaml")
+# print(ShrubService.generate_yaml(project))

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -43,7 +43,7 @@ class Host:
 
 HOSTS["rhel8"] = Host("rhel8", "rhel87-small", "RHEL8")
 HOSTS["win64"] = Host("win64", "windows-64-vsMulti-small", "Win64")
-HOSTS["macos"] = Host("macos", "macos-14", "MacOS")
+HOSTS["macos"] = Host("macos", "macos-14", "macOS")
 
 
 # Helper functions.

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -85,6 +85,9 @@ variants = []
 
 # OCSP tests on rhel8 with rotating CPython versions.
 for version in ALL_VERSIONS:
+    # OCSP is not supported until v4.4.
+    if version == "4.0":
+        continue
     task_refs = [EvgTaskRef(name=".ocsp")]
     expansions = dict(VERSION=version, AUTH="noauth", SSL="ssl", TOPOLOGY="server")
     batchtime = BATCHTIME_WEEK * 2
@@ -104,13 +107,16 @@ for version in ALL_VERSIONS:
     )
     variants.append(variant)
 
-# OCSP tests on Windows and MacOS with lowest CPython version.
+# OCSP tests on Windows and MacOS.
 for host, version in product(["Win64", "macOS"], ["4.4", "8.0"]):
     # MongoDB servers do not staple OCSP responses and only support RSA.
     task_names = [".ocsp-rsa !.ocsp-staple"]
     expansions = dict(VERSION=version, AUTH="noauth", SSL="ssl", TOPOLOGY="server")
     batchtime = BATCHTIME_WEEK * 2
-    python = CPYTHONS[0]
+    if version == 4.4:
+        python = CPYTHONS[0]
+    else:
+        python = CPYTHONS[-1]
     display_name = f"OCSP test {host} v{version} {python}"
     variant = create_variant(
         task_names,

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 from itertools import product
 
 from shrub.v3.evg_build_variant import BuildVariant
+from shrub.v3.evg_project import EvgProject
 from shrub.v3.evg_task import EvgTaskRef
+from shrub.v3.shrub_service import ShrubService
 
 # Top level variables.
 ALL_VERSIONS = ["4.0", "4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"]
@@ -89,9 +91,9 @@ for version in ALL_VERSIONS:
     python = ALL_PYTHONS[len(variants) % len(ALL_PYTHONS)]
     host = "rhel8"
     if version in ["rapid", "latest"]:
-        display_name = f"OCSP test RHEL8 {version}"
+        display_name = f"OCSP test RHEL8 {python} {version}"
     else:
-        display_name = f"OCSP test RHEL8 v{version}"
+        display_name = f"OCSP test RHEL8 {python} v{version}"
     variant = create_variant(
         [".ocsp"],
         display_name,
@@ -108,11 +110,12 @@ for host, version in product(["Win64", "macOS"], ["4.4", "8.0"]):
     task_names = [".ocsp-rsa !.ocsp-staple"]
     expansions = dict(VERSION=version, AUTH="noauth", SSL="ssl", TOPOLOGY="server")
     batchtime = BATCHTIME_WEEK * 2
-    display_name = f"OCSP test {host} v{version}"
+    python = CPYTHONS[0]
+    display_name = f"OCSP test {host} {python} v{version}"
     variant = create_variant(
         task_names,
         display_name,
-        python=CPYTHONS[0],
+        python=python,
         host=host,
         expansions=expansions,
         batchtime=batchtime,
@@ -120,5 +123,5 @@ for host, version in product(["Win64", "macOS"], ["4.4", "8.0"]):
     variants.append(variant)
 
 # Generate OCSP config.
-# project = EvgProject(tasks=None, buildvariants=variants)
-# print(ShrubService.generate_yaml(project))
+project = EvgProject(tasks=None, buildvariants=variants)
+print(ShrubService.generate_yaml(project))  # noqa: T201

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -113,7 +113,7 @@ for host, version in product(["Win64", "macOS"], ["4.4", "8.0"]):
     task_names = [".ocsp-rsa !.ocsp-staple"]
     expansions = dict(VERSION=version, AUTH="noauth", SSL="ssl", TOPOLOGY="server")
     batchtime = BATCHTIME_WEEK * 2
-    if version == 4.4:
+    if version == "4.4":
         python = CPYTHONS[0]
     else:
         python = CPYTHONS[-1]

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -135,9 +135,9 @@ def create_ocsp_variants() -> list[BuildVariant]:
             get_display_name(base_display, host, version, python),
             python=python,
             version=version,
-            batchtime=batchtime,
             host=host,
             expansions=expansions,
+            batchtime=batchtime,
         )
         variants.append(variant)
 

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -91,9 +91,9 @@ for version in ALL_VERSIONS:
     python = ALL_PYTHONS[len(variants) % len(ALL_PYTHONS)]
     host = "rhel8"
     if version in ["rapid", "latest"]:
-        display_name = f"OCSP test RHEL8 {python} {version}"
+        display_name = f"OCSP test RHEL8 {version} {python}"
     else:
-        display_name = f"OCSP test RHEL8 {python} v{version}"
+        display_name = f"OCSP test RHEL8 v{version} {python}"
     variant = create_variant(
         [".ocsp"],
         display_name,
@@ -111,7 +111,7 @@ for host, version in product(["Win64", "macOS"], ["4.4", "8.0"]):
     expansions = dict(VERSION=version, AUTH="noauth", SSL="ssl", TOPOLOGY="server")
     batchtime = BATCHTIME_WEEK * 2
     python = CPYTHONS[0]
-    display_name = f"OCSP test {host} {python} v{version}"
+    display_name = f"OCSP test {host} v{version} {python}"
     variant = create_variant(
         task_names,
         display_name,

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -128,12 +128,9 @@ def create_ocsp_variants() -> list[BuildVariant]:
     base_expansions = dict(AUTH="noauth", SSL="ssl", TOPOLOGY="server")
     base_display = "OCSP test"
 
-    # OCSP tests on rhel8 with all server and python versions.
+    # OCSP tests on rhel8 with all server v4.4+ and python versions.
     versions = [v for v in ALL_VERSIONS if v != "4.0"]
     for version, python in get_pairs(versions, ALL_PYTHONS):
-        # OCSP is not supported until v4.4.
-        if version == "4.0":
-            continue
         expansions = base_expansions.copy()
         expansions["VERSION"] = version
         host = "rhel8"

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -144,7 +144,7 @@ def create_ocsp_variants() -> list[BuildVariant]:
     # OCSP tests on Windows and MacOS.
     # MongoDB servers on these hosts do not staple OCSP responses and only support RSA.
     for host, version in product(["win64", "macos"], ["4.4", "8.0"]):
-        python = (CPYTHONS[0] if version == "4.4" else CPYTHONS[-1],)
+        python = CPYTHONS[0] if version == "4.4" else CPYTHONS[-1]
         variant = create_variant(
             [".ocsp-rsa !.ocsp-staple"],
             get_display_name(base_display, host, version, python),

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -126,7 +126,7 @@ def create_ocsp_variants() -> list[BuildVariant]:
     expansions = dict(AUTH="noauth", SSL="ssl", TOPOLOGY="server")
     base_display = "OCSP test"
 
-    # OCSP tests on rhel8 with all server v4.4+ and all python versions.
+    # OCSP tests on rhel8 with all servers v4.4+ and all python versions.
     versions = [v for v in ALL_VERSIONS if v != "4.0"]
     for version, python in zip_cycle(versions, ALL_PYTHONS):
         host = "rhel8"

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -148,6 +148,7 @@ def create_ocsp_variants() -> list[BuildVariant]:
             [".ocsp-rsa !.ocsp-staple"],
             get_display_name(base_display, host, version, python),
             python=CPYTHONS[0] if version == "4.4" else CPYTHONS[-1],
+            version=version,
             host=host,
             expansions=expansions,
             batchtime=batchtime,

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -129,7 +129,7 @@ def create_ocsp_variants() -> list[BuildVariant]:
     base_display = "OCSP test"
 
     # OCSP tests on rhel8 with all server and python versions.
-    versions = [v for v in ALL_VERSIONS if v != "4.4"]
+    versions = [v for v in ALL_VERSIONS if v != "4.0"]
     for version, python in get_pairs(versions, ALL_PYTHONS):
         # OCSP is not supported until v4.4.
         if version == "4.0":

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -144,10 +144,11 @@ def create_ocsp_variants() -> list[BuildVariant]:
     # OCSP tests on Windows and MacOS.
     # MongoDB servers on these hosts do not staple OCSP responses and only support RSA.
     for host, version in product(["win64", "macos"], ["4.4", "8.0"]):
+        python = (CPYTHONS[0] if version == "4.4" else CPYTHONS[-1],)
         variant = create_variant(
             [".ocsp-rsa !.ocsp-staple"],
             get_display_name(base_display, host, version, python),
-            python=CPYTHONS[0] if version == "4.4" else CPYTHONS[-1],
+            python=python,
             version=version,
             host=host,
             expansions=expansions,


### PR DESCRIPTION
Programmatically creates OCSP build variants.  We cannot use `include:` with `matrix:`, so we'll have to convert all the matrices in-place before moving on to using generated files and generated tasks.

<img width="196" alt="image" src="https://github.com/user-attachments/assets/3015c42a-4185-4cc0-a6f6-53e8bde395e6">






Before:
720 tasks across 42 build variants

After
200 tasks across 11 build variants