### PR TITLE
PYTHON-4866 Fix test_command_cursor_to_list_csot_applied

### DIFF
--- a/test/asynchronous/test_cursor.py
+++ b/test/asynchronous/test_cursor.py
@@ -1412,12 +1412,11 @@ class TestCursor(AsyncIntegrationTest):
         self.assertEqual(len(docs), 2)
 
     async def test_to_list_csot_applied(self):
-        client = await self.async_single_client(timeoutMS=500)
+        client = await self.async_single_client(timeoutMS=500, w=1)
+        coll = client.pymongo.test
         # Initialize the client with a larger timeout to help make test less flakey
         with pymongo.timeout(10):
-            await client.admin.command("ping")
-        coll = client.pymongo.test
-        await coll.insert_many([{} for _ in range(5)])
+            await coll.insert_many([{} for _ in range(5)])
         cursor = coll.find({"$where": delay(1)})
         with self.assertRaises(PyMongoError) as ctx:
             await cursor.to_list()
@@ -1454,12 +1453,11 @@ class TestCursor(AsyncIntegrationTest):
 
     @async_client_context.require_failCommand_blockConnection
     async def test_command_cursor_to_list_csot_applied(self):
-        client = await self.async_single_client(timeoutMS=500)
+        client = await self.async_single_client(timeoutMS=500, w=1)
+        coll = client.pymongo.test
         # Initialize the client with a larger timeout to help make test less flakey
         with pymongo.timeout(10):
-            await client.admin.command("ping")
-        coll = client.pymongo.test
-        await coll.insert_many([{} for _ in range(5)])
+            await coll.insert_many([{} for _ in range(5)])
         fail_command = {
             "configureFailPoint": "failCommand",
             "mode": {"times": 5},

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -1403,12 +1403,11 @@ class TestCursor(IntegrationTest):
         self.assertEqual(len(docs), 2)
 
     def test_to_list_csot_applied(self):
-        client = self.single_client(timeoutMS=500)
+        client = self.single_client(timeoutMS=500, w=1)
+        coll = client.pymongo.test
         # Initialize the client with a larger timeout to help make test less flakey
         with pymongo.timeout(10):
-            client.admin.command("ping")
-        coll = client.pymongo.test
-        coll.insert_many([{} for _ in range(5)])
+            coll.insert_many([{} for _ in range(5)])
         cursor = coll.find({"$where": delay(1)})
         with self.assertRaises(PyMongoError) as ctx:
             cursor.to_list()
@@ -1445,12 +1444,11 @@ class TestCursor(IntegrationTest):
 
     @client_context.require_failCommand_blockConnection
     def test_command_cursor_to_list_csot_applied(self):
-        client = self.single_client(timeoutMS=500)
+        client = self.single_client(timeoutMS=500, w=1)
+        coll = client.pymongo.test
         # Initialize the client with a larger timeout to help make test less flakey
         with pymongo.timeout(10):
-            client.admin.command("ping")
-        coll = client.pymongo.test
-        coll.insert_many([{} for _ in range(5)])
+            coll.insert_many([{} for _ in range(5)])
         fail_command = {
             "configureFailPoint": "failCommand",
             "mode": {"times": 5},


### PR DESCRIPTION
PYTHON-4866 Fix test_command_cursor_to_list_csot_applied