### PR TITLE
PYTHON-4868 Generate server tests using shrub.py

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2403,9 +2403,9 @@ buildvariants:
 # Server Tests for RHEL8.
 - name: test-rhel8-py3.9-auth-ssl
   tasks:
-    - name: .sharded_cluster
     - name: .standalone
     - name: .replica_set
+    - name: .sharded_cluster
   display_name: Test RHEL8 py3.9 Auth SSL
   run_on:
     - rhel87-small
@@ -2413,11 +2413,23 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: test-rhel8-py3.9-noauth-nossl
+- name: test-rhel8-py3.9-noauth-ssl
   tasks:
-    - name: .sharded_cluster
     - name: .standalone
     - name: .replica_set
+    - name: .sharded_cluster
+  display_name: Test RHEL8 py3.9 NoAuth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+- name: test-rhel8-py3.9-noauth-nossl
+  tasks:
+    - name: .standalone
+    - name: .replica_set
+    - name: .sharded_cluster
   display_name: Test RHEL8 py3.9 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2425,83 +2437,11 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: test-rhel8-py3.10-auth-ssl
-  tasks:
-    - name: .sharded_cluster
-    - name: .standalone
-    - name: .replica_set
-  display_name: Test RHEL8 py3.10 Auth SSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    PYTHON_BINARY: /opt/python/3.10/bin/python3
-- name: test-rhel8-py3.10-noauth-nossl
-  tasks:
-    - name: .sharded_cluster
-    - name: .standalone
-    - name: .replica_set
-  display_name: Test RHEL8 py3.10 NoAuth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/3.10/bin/python3
-- name: test-rhel8-py3.11-auth-ssl
-  tasks:
-    - name: .sharded_cluster
-    - name: .standalone
-    - name: .replica_set
-  display_name: Test RHEL8 py3.11 Auth SSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    PYTHON_BINARY: /opt/python/3.11/bin/python3
-- name: test-rhel8-py3.11-noauth-nossl
-  tasks:
-    - name: .sharded_cluster
-    - name: .standalone
-    - name: .replica_set
-  display_name: Test RHEL8 py3.11 NoAuth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/3.11/bin/python3
-- name: test-rhel8-py3.12-auth-ssl
-  tasks:
-    - name: .sharded_cluster
-    - name: .standalone
-    - name: .replica_set
-  display_name: Test RHEL8 py3.12 Auth SSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    PYTHON_BINARY: /opt/python/3.12/bin/python3
-- name: test-rhel8-py3.12-noauth-nossl
-  tasks:
-    - name: .sharded_cluster
-    - name: .standalone
-    - name: .replica_set
-  display_name: Test RHEL8 py3.12 NoAuth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/3.12/bin/python3
 - name: test-rhel8-py3.13-auth-ssl
   tasks:
-    - name: .sharded_cluster
     - name: .standalone
     - name: .replica_set
+    - name: .sharded_cluster
   display_name: Test RHEL8 py3.13 Auth SSL
   run_on:
     - rhel87-small
@@ -2509,11 +2449,23 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: test-rhel8-py3.13-noauth-nossl
+- name: test-rhel8-py3.13-noauth-ssl
   tasks:
-    - name: .sharded_cluster
     - name: .standalone
     - name: .replica_set
+    - name: .sharded_cluster
+  display_name: Test RHEL8 py3.13 NoAuth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+- name: test-rhel8-py3.13-noauth-nossl
+  tasks:
+    - name: .standalone
+    - name: .replica_set
+    - name: .sharded_cluster
   display_name: Test RHEL8 py3.13 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2521,35 +2473,11 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: test-rhel8-pypy3.9-auth-ssl
-  tasks:
-    - name: .sharded_cluster
-    - name: .standalone
-    - name: .replica_set
-  display_name: Test RHEL8 pypy3.9 Auth SSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-- name: test-rhel8-pypy3.9-noauth-nossl
-  tasks:
-    - name: .sharded_cluster
-    - name: .standalone
-    - name: .replica_set
-  display_name: Test RHEL8 pypy3.9 NoAuth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
 - name: test-rhel8-pypy3.10-auth-ssl
   tasks:
-    - name: .sharded_cluster
     - name: .standalone
     - name: .replica_set
+    - name: .sharded_cluster
   display_name: Test RHEL8 pypy3.10 Auth SSL
   run_on:
     - rhel87-small
@@ -2557,11 +2485,23 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: test-rhel8-pypy3.10-noauth-nossl
+- name: test-rhel8-pypy3.10-noauth-ssl
   tasks:
-    - name: .sharded_cluster
     - name: .standalone
     - name: .replica_set
+    - name: .sharded_cluster
+  display_name: Test RHEL8 pypy3.10 NoAuth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
+- name: test-rhel8-pypy3.10-noauth-nossl
+  tasks:
+    - name: .standalone
+    - name: .replica_set
+    - name: .sharded_cluster
   display_name: Test RHEL8 pypy3.10 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2569,11 +2509,51 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
+- name: test-rhel8-py3.10-auth-ssl
+  tasks:
+    - name: .standalone
+  display_name: Test RHEL8 py3.10 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/3.10/bin/python3
+- name: test-rhel8-py3.11-noauth-ssl
+  tasks:
+    - name: .replica_set
+  display_name: Test RHEL8 py3.11 NoAuth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/3.11/bin/python3
+- name: test-rhel8-py3.12-noauth-nossl
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test RHEL8 py3.12 NoAuth NoSSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.12/bin/python3
+- name: test-rhel8-pypy3.9-auth-ssl
+  tasks:
+    - name: .standalone
+  display_name: Test RHEL8 pypy3.9 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
 
 # Server tests for MacOS.
 - name: test-macos-py3.9-auth-ssl-sync
   tasks:
-    - name: .sharded_cluster
+    - name: .standalone
   display_name: Test macOS py3.9 Auth SSL Sync
   run_on:
     - macos-14
@@ -2585,7 +2565,7 @@ buildvariants:
     SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.9-auth-ssl-async
   tasks:
-    - name: .sharded_cluster
+    - name: .standalone
   display_name: Test macOS py3.9 Auth SSL Async
   run_on:
     - macos-14
@@ -2594,6 +2574,30 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    SKIP_CSOT_TESTS: "true"
+- name: test-macos-py3.13-noauth-ssl-sync
+  tasks:
+    - name: .replica_set
+  display_name: Test macOS py3.13 NoAuth SSL Sync
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
+- name: test-macos-py3.13-noauth-ssl-async
+  tasks:
+    - name: .replica_set
+  display_name: Test macOS py3.13 NoAuth SSL Async
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
     SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.9-noauth-nossl-sync
   tasks:
@@ -2619,60 +2623,12 @@ buildvariants:
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     SKIP_CSOT_TESTS: "true"
-- name: test-macos-py3.13-auth-ssl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS py3.13 Auth SSL Sync
-  run_on:
-    - macos-14
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    TEST_SUITES: default
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-    SKIP_CSOT_TESTS: "true"
-- name: test-macos-py3.13-auth-ssl-async
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS py3.13 Auth SSL Async
-  run_on:
-    - macos-14
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    TEST_SUITES: default_async
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-    SKIP_CSOT_TESTS: "true"
-- name: test-macos-py3.13-noauth-nossl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS py3.13 NoAuth NoSSL Sync
-  run_on:
-    - macos-14
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-    SKIP_CSOT_TESTS: "true"
-- name: test-macos-py3.13-noauth-nossl-async
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS py3.13 NoAuth NoSSL Async
-  run_on:
-    - macos-14
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default_async
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-    SKIP_CSOT_TESTS: "true"
 
-# Server tests for macOS (arm).
-- name: test-macos-arm-py3.9-auth-ssl-sync
+# Server tests for macOS Arm64.
+- name: test-macos-arm64-py3.9-auth-ssl-sync
   tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS (arm) py3.9 Auth SSL Sync
+    - name: .standalone
+  display_name: Test macOS Arm64 py3.9 Auth SSL Sync
   run_on:
     - macos-14-arm64
   expansions:
@@ -2681,10 +2637,10 @@ buildvariants:
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     SKIP_CSOT_TESTS: "true"
-- name: test-macos-arm-py3.9-auth-ssl-async
+- name: test-macos-arm64-py3.9-auth-ssl-async
   tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS (arm) py3.9 Auth SSL Async
+    - name: .standalone
+  display_name: Test macOS Arm64 py3.9 Auth SSL Async
   run_on:
     - macos-14-arm64
   expansions:
@@ -2693,10 +2649,34 @@ buildvariants:
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     SKIP_CSOT_TESTS: "true"
-- name: test-macos-arm-py3.9-noauth-nossl-sync
+- name: test-macos-arm64-py3.13-noauth-ssl-sync
+  tasks:
+    - name: .replica_set
+  display_name: Test macOS Arm64 py3.13 NoAuth SSL Sync
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
+- name: test-macos-arm64-py3.13-noauth-ssl-async
+  tasks:
+    - name: .replica_set
+  display_name: Test macOS Arm64 py3.13 NoAuth SSL Async
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
+- name: test-macos-arm64-py3.9-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
-  display_name: Test macOS (arm) py3.9 NoAuth NoSSL Sync
+  display_name: Test macOS Arm64 py3.9 NoAuth NoSSL Sync
   run_on:
     - macos-14-arm64
   expansions:
@@ -2705,10 +2685,10 @@ buildvariants:
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     SKIP_CSOT_TESTS: "true"
-- name: test-macos-arm-py3.9-noauth-nossl-async
+- name: test-macos-arm64-py3.9-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
-  display_name: Test macOS (arm) py3.9 NoAuth NoSSL Async
+  display_name: Test macOS Arm64 py3.9 NoAuth NoSSL Async
   run_on:
     - macos-14-arm64
   expansions:
@@ -2716,61 +2696,13 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-    SKIP_CSOT_TESTS: "true"
-- name: test-macos-arm-py3.13-auth-ssl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS (arm) py3.13 Auth SSL Sync
-  run_on:
-    - macos-14-arm64
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    TEST_SUITES: default
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-    SKIP_CSOT_TESTS: "true"
-- name: test-macos-arm-py3.13-auth-ssl-async
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS (arm) py3.13 Auth SSL Async
-  run_on:
-    - macos-14-arm64
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    TEST_SUITES: default_async
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-    SKIP_CSOT_TESTS: "true"
-- name: test-macos-arm-py3.13-noauth-nossl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS (arm) py3.13 NoAuth NoSSL Sync
-  run_on:
-    - macos-14-arm64
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-    SKIP_CSOT_TESTS: "true"
-- name: test-macos-arm-py3.13-noauth-nossl-async
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS (arm) py3.13 NoAuth NoSSL Async
-  run_on:
-    - macos-14-arm64
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default_async
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
     SKIP_CSOT_TESTS: "true"
 
 # Server tests for Windows.
-- name: test-win64-py-3.9-auth-ssl-sync
+- name: test-win64-py3.9-auth-ssl-sync
   tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 py 3.9 Auth SSL Sync
+    - name: .standalone
+  display_name: Test Win64 py3.9 Auth SSL Sync
   run_on:
     - windows-64-vsMulti-small
   expansions:
@@ -2779,10 +2711,10 @@ buildvariants:
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
-- name: test-win64-py-3.9-auth-ssl-async
+- name: test-win64-py3.9-auth-ssl-async
   tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 py 3.9 Auth SSL Async
+    - name: .standalone
+  display_name: Test Win64 py3.9 Auth SSL Async
   run_on:
     - windows-64-vsMulti-small
   expansions:
@@ -2791,10 +2723,34 @@ buildvariants:
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
-- name: test-win64-py-3.9-noauth-nossl-sync
+- name: test-win64-py3.13-noauth-ssl-sync
+  tasks:
+    - name: .replica_set
+  display_name: Test Win64 py3.13 NoAuth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: C:/python/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
+- name: test-win64-py3.13-noauth-ssl-async
+  tasks:
+    - name: .replica_set
+  display_name: Test Win64 py3.13 NoAuth SSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: C:/python/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
+- name: test-win64-py3.9-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
-  display_name: Test Win64 py 3.9 NoAuth NoSSL Sync
+  display_name: Test Win64 py3.9 NoAuth NoSSL Sync
   run_on:
     - windows-64-vsMulti-small
   expansions:
@@ -2803,10 +2759,10 @@ buildvariants:
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
-- name: test-win64-py-3.9-noauth-nossl-async
+- name: test-win64-py3.9-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
-  display_name: Test Win64 py 3.9 NoAuth NoSSL Async
+  display_name: Test Win64 py3.9 NoAuth NoSSL Async
   run_on:
     - windows-64-vsMulti-small
   expansions:
@@ -2815,72 +2771,24 @@ buildvariants:
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
-- name: test-win64-py-3.13-auth-ssl-sync
+- name: test-win32-py3.9-auth-ssl-sync
   tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 py 3.13 Auth SSL Sync
+    - name: .standalone
+  display_name: Test Win32 py3.9 Auth SSL Sync
   run_on:
     - windows-64-vsMulti-small
   expansions:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default
-    PYTHON_BINARY: C:/python/Python313/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-py-3.13-auth-ssl-async
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 py 3.13 Auth SSL Async
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/Python313/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-py-3.13-noauth-nossl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 py 3.13 NoAuth NoSSL Sync
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default
-    PYTHON_BINARY: C:/python/Python313/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-py-3.13-noauth-nossl-async
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 py 3.13 NoAuth NoSSL Async
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/Python313/python.exe
+    PYTHON_BINARY: C:/python/32/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
 
-# Server tests for Windows (32-bit).
-- name: test-win64-32-bit-py3.9-auth-ssl-sync
+# Server tests for Win32.
+- name: test-win32-py3.9-auth-ssl-async
   tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 32-bit py3.9 Auth SSL Sync
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    TEST_SUITES: default
-    PYTHON_BINARY: C:/python/32/Python39/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-32-bit-py3.9-auth-ssl-async
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 32-bit py3.9 Auth SSL Async
+    - name: .standalone
+  display_name: Test Win32 py3.9 Auth SSL Async
   run_on:
     - windows-64-vsMulti-small
   expansions:
@@ -2889,10 +2797,34 @@ buildvariants:
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/32/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
-- name: test-win64-32-bit-py3.9-noauth-nossl-sync
+- name: test-win32-py3.13-noauth-ssl-sync
+  tasks:
+    - name: .replica_set
+  display_name: Test Win32 py3.13 NoAuth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
+- name: test-win32-py3.13-noauth-ssl-async
+  tasks:
+    - name: .replica_set
+  display_name: Test Win32 py3.13 NoAuth SSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
+- name: test-win32-py3.9-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
-  display_name: Test Win64 32-bit py3.9 NoAuth NoSSL Sync
+  display_name: Test Win32 py3.9 NoAuth NoSSL Sync
   run_on:
     - windows-64-vsMulti-small
   expansions:
@@ -2901,10 +2833,10 @@ buildvariants:
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/32/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
-- name: test-win64-32-bit-py3.9-noauth-nossl-async
+- name: test-win32-py3.9-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
-  display_name: Test Win64 32-bit py3.9 NoAuth NoSSL Async
+  display_name: Test Win32 py3.9 NoAuth NoSSL Async
   run_on:
     - windows-64-vsMulti-small
   expansions:
@@ -2912,54 +2844,6 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/32/Python39/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-32-bit-py3.13-auth-ssl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 32-bit py3.13 Auth SSL Sync
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    TEST_SUITES: default
-    PYTHON_BINARY: C:/python/32/Python313/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-32-bit-py3.13-auth-ssl-async
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 32-bit py3.13 Auth SSL Async
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    SSL: ssl
-    TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/32/Python313/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-32-bit-py3.13-noauth-nossl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 32-bit py3.13 NoAuth NoSSL Sync
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default
-    PYTHON_BINARY: C:/python/32/Python313/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-32-bit-py3.13-noauth-nossl-async
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 32-bit py3.13 NoAuth NoSSL Async
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/32/Python313/python.exe
     SKIP_CSOT_TESTS: "true"
 
 - matrix_name: "tests-fips"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2582,6 +2582,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.9-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2593,6 +2594,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.9-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2604,6 +2606,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.9-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2615,6 +2618,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.13-auth-ssl-sync
   tasks:
     - name: .sharded_cluster
@@ -2626,6 +2630,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.13-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2637,6 +2642,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.13-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2648,6 +2654,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.13-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2659,6 +2666,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
 
 # Server tests for macOS (arm).
 - name: test-macos-arm-py3.9-auth-ssl-sync
@@ -2672,6 +2680,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-arm-py3.9-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2683,6 +2692,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-arm-py3.9-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2694,6 +2704,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-arm-py3.9-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2705,6 +2716,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-arm-py3.13-auth-ssl-sync
   tasks:
     - name: .sharded_cluster
@@ -2716,6 +2728,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-arm-py3.13-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2727,6 +2740,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-arm-py3.13-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2738,6 +2752,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
 - name: test-macos-arm-py3.13-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2749,6 +2764,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+    SKIP_CSOT_TESTS: "true"
 
 # Server tests for Windows.
 - name: test-win64-py-3.9-auth-ssl-sync
@@ -2762,6 +2778,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/Python39/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-py-3.9-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2773,6 +2790,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/Python39/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-py-3.9-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2784,6 +2802,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/Python39/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-py-3.9-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2795,6 +2814,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/Python39/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-py-3.13-auth-ssl-sync
   tasks:
     - name: .sharded_cluster
@@ -2806,6 +2826,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-py-3.13-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2817,6 +2838,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-py-3.13-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2828,6 +2850,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-py-3.13-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2839,6 +2862,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
 
 # Server tests for Windows (32-bit).
 - name: test-win64-32-bit-py3.9-auth-ssl-sync
@@ -2852,6 +2876,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/32/Python39/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-32-bit-py3.9-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2863,6 +2888,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/32/Python39/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-32-bit-py3.9-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2874,6 +2900,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/32/Python39/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-32-bit-py3.9-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2885,6 +2912,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/32/Python39/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-32-bit-py3.13-auth-ssl-sync
   tasks:
     - name: .sharded_cluster
@@ -2896,6 +2924,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/32/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-32-bit-py3.13-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2907,6 +2936,7 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/32/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-32-bit-py3.13-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2918,6 +2948,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default
     PYTHON_BINARY: C:/python/32/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
 - name: test-win64-32-bit-py3.13-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2929,6 +2960,7 @@ buildvariants:
     SSL: nossl
     TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/32/Python313/python.exe
+    SKIP_CSOT_TESTS: "true"
 
 - matrix_name: "tests-fips"
   matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2933,7 +2933,7 @@ buildvariants:
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
 # Server tests for macOS (arm).
-- name: test-macos-(arm)-py3.9-auth-ssl
+- name: test-macos-arm-py3.9-auth-ssl
   tasks:
     - name: .4.0 .sharded_cluster
     - name: .4.4 .sharded_cluster
@@ -2950,7 +2950,7 @@ buildvariants:
     AUTH: auth
     ssl: ssl
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-- name: test-macos-(arm)-py3.10-auth-ssl
+- name: test-macos-arm-py3.10-auth-ssl
   tasks:
     - name: .4.0 .sharded_cluster
     - name: .4.4 .sharded_cluster
@@ -2967,7 +2967,7 @@ buildvariants:
     AUTH: auth
     ssl: ssl
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.10/bin/python3
-- name: test-macos-(arm)-py3.11-auth-ssl
+- name: test-macos-arm-py3.11-auth-ssl
   tasks:
     - name: .4.0 .sharded_cluster
     - name: .4.4 .sharded_cluster
@@ -2984,7 +2984,7 @@ buildvariants:
     AUTH: auth
     ssl: ssl
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.11/bin/python3
-- name: test-macos-(arm)-py3.12-auth-ssl
+- name: test-macos-arm-py3.12-auth-ssl
   tasks:
     - name: .4.0 .sharded_cluster
     - name: .4.4 .sharded_cluster
@@ -3001,7 +3001,7 @@ buildvariants:
     AUTH: auth
     ssl: ssl
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.12/bin/python3
-- name: test-macos-(arm)-py3.13-auth-ssl
+- name: test-macos-arm-py3.13-auth-ssl
   tasks:
     - name: .4.0 .sharded_cluster
     - name: .4.4 .sharded_cluster

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -409,6 +409,7 @@ functions:
             AUTH=${AUTH} \
             SSL=${SSL} \
             TEST_DATA_LAKE=${TEST_DATA_LAKE} \
+            TEST_SUITES=${TEST_SUITES} \
             MONGODB_API_VERSION=${MONGODB_API_VERSION} \
             SKIP_HATCH=${SKIP_HATCH} \
             bash ${PROJECT_DIRECTORY}/.evergreen/hatch.sh test:test-eg
@@ -2402,14 +2403,9 @@ buildvariants:
 # Server Tests for RHEL8.
 - name: test-rhel8-py3.9-auth-ssl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.9 Auth SSL
   run_on:
     - rhel87-small
@@ -2419,14 +2415,9 @@ buildvariants:
     PYTHON_BINARY: /opt/python/3.9/bin/python3
 - name: test-rhel8-py3.9-noauth-nossl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.9 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2434,33 +2425,11 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: test-rhel8-py3.9-auth-nossl
-  tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
-  display_name: Test RHEL8 py3.9 Auth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/3.9/bin/python3
 - name: test-rhel8-py3.10-auth-ssl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.10 Auth SSL
   run_on:
     - rhel87-small
@@ -2470,14 +2439,9 @@ buildvariants:
     PYTHON_BINARY: /opt/python/3.10/bin/python3
 - name: test-rhel8-py3.10-noauth-nossl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.10 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2485,33 +2449,11 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.10/bin/python3
-- name: test-rhel8-py3.10-auth-nossl
-  tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
-  display_name: Test RHEL8 py3.10 Auth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/3.10/bin/python3
 - name: test-rhel8-py3.11-auth-ssl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.11 Auth SSL
   run_on:
     - rhel87-small
@@ -2521,14 +2463,9 @@ buildvariants:
     PYTHON_BINARY: /opt/python/3.11/bin/python3
 - name: test-rhel8-py3.11-noauth-nossl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.11 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2536,33 +2473,11 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.11/bin/python3
-- name: test-rhel8-py3.11-auth-nossl
-  tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
-  display_name: Test RHEL8 py3.11 Auth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/3.11/bin/python3
 - name: test-rhel8-py3.12-auth-ssl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.12 Auth SSL
   run_on:
     - rhel87-small
@@ -2572,14 +2487,9 @@ buildvariants:
     PYTHON_BINARY: /opt/python/3.12/bin/python3
 - name: test-rhel8-py3.12-noauth-nossl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.12 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2587,33 +2497,11 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.12/bin/python3
-- name: test-rhel8-py3.12-auth-nossl
-  tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
-  display_name: Test RHEL8 py3.12 Auth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/3.12/bin/python3
 - name: test-rhel8-py3.13-auth-ssl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.13 Auth SSL
   run_on:
     - rhel87-small
@@ -2623,14 +2511,9 @@ buildvariants:
     PYTHON_BINARY: /opt/python/3.13/bin/python3
 - name: test-rhel8-py3.13-noauth-nossl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 py3.13 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2638,33 +2521,11 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: test-rhel8-py3.13-auth-nossl
-  tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
-  display_name: Test RHEL8 py3.13 Auth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/3.13/bin/python3
 - name: test-rhel8-pypy3.9-auth-ssl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 pypy3.9 Auth SSL
   run_on:
     - rhel87-small
@@ -2674,14 +2535,9 @@ buildvariants:
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
 - name: test-rhel8-pypy3.9-noauth-nossl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 pypy3.9 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2689,33 +2545,11 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-- name: test-rhel8-pypy3.9-auth-nossl
-  tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
-  display_name: Test RHEL8 pypy3.9 Auth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
 - name: test-rhel8-pypy3.10-auth-ssl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 pypy3.10 Auth SSL
   run_on:
     - rhel87-small
@@ -2725,14 +2559,9 @@ buildvariants:
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 - name: test-rhel8-pypy3.10-noauth-nossl
   tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
+    - name: .sharded_cluster
+    - name: .standalone
+    - name: .replica_set
   display_name: Test RHEL8 pypy3.10 NoAuth NoSSL
   run_on:
     - rhel87-small
@@ -2740,370 +2569,365 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: test-rhel8-pypy3.10-auth-nossl
-  tasks:
-    - name: .4.0
-    - name: .4.4
-    - name: .5.0
-    - name: .6.0
-    - name: .7.0
-    - name: .8.0
-    - name: .rapid
-    - name: .latest
-  display_name: Test RHEL8 pypy3.10 Auth NoSSL
-  run_on:
-    - rhel87-small
-  expansions:
-    AUTH: auth
-    SSL: nossl
-    PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-
-# Server Tests for Windows.
-- name: test-win64-py3.9-auth-ssl
-  tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 py3.9 Auth SSL
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: C:/python/Python39/python.exe
-- name: test-win64-py3.10-auth-ssl
-  tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 py3.10 Auth SSL
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: C:/python/Python310/python.exe
-- name: test-win64-py3.11-auth-ssl
-  tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 py3.11 Auth SSL
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: C:/python/Python311/python.exe
-- name: test-win64-py3.12-auth-ssl
-  tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 py3.12 Auth SSL
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: C:/python/Python312/python.exe
-- name: test-win64-py3.13-auth-ssl
-  tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 py3.13 Auth SSL
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: C:/python/Python313/python.exe
-- name: test-macos-py3.9-auth-ssl
-  tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS py3.9 Auth SSL
-  run_on:
-    - macos-14
-  expansions:
-    AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 
 # Server tests for MacOS.
-- name: test-macos-py3.10-auth-ssl
+- name: test-macos-py3.9-auth-ssl-sync
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS py3.10 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test macOS py3.9 Auth SSL Sync
   run_on:
     - macos-14
   expansions:
     AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.10/bin/python3
-- name: test-macos-py3.11-auth-ssl
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-py3.9-auth-ssl-async
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS py3.11 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test macOS py3.9 Auth SSL Async
   run_on:
     - macos-14
   expansions:
     AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.11/bin/python3
-- name: test-macos-py3.12-auth-ssl
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-py3.9-noauth-nossl-sync
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS py3.12 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test macOS py3.9 NoAuth NoSSL Sync
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-py3.9-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.9 NoAuth NoSSL Async
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-py3.13-auth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 Auth SSL Sync
   run_on:
     - macos-14
   expansions:
     AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.12/bin/python3
-- name: test-macos-py3.13-auth-ssl
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-py3.13-auth-ssl-async
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS py3.13 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 Auth SSL Async
   run_on:
     - macos-14
   expansions:
     AUTH: auth
-    ssl: ssl
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-py3.13-noauth-nossl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 NoAuth NoSSL Sync
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-py3.13-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 NoAuth NoSSL Async
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
 # Server tests for macOS (arm).
-- name: test-macos-arm-py3.9-auth-ssl
+- name: test-macos-arm-py3.9-auth-ssl-sync
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS (arm) py3.9 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test macOS (arm) py3.9 Auth SSL Sync
   run_on:
     - macos-14-arm64
   expansions:
     AUTH: auth
-    ssl: ssl
+    SSL: ssl
+    TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-- name: test-macos-arm-py3.10-auth-ssl
+- name: test-macos-arm-py3.9-auth-ssl-async
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS (arm) py3.10 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test macOS (arm) py3.9 Auth SSL Async
   run_on:
     - macos-14-arm64
   expansions:
     AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.10/bin/python3
-- name: test-macos-arm-py3.11-auth-ssl
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-arm-py3.9-noauth-nossl-sync
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS (arm) py3.11 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test macOS (arm) py3.9 NoAuth NoSSL Sync
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-arm-py3.9-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS (arm) py3.9 NoAuth NoSSL Async
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-arm-py3.13-auth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS (arm) py3.13 Auth SSL Sync
   run_on:
     - macos-14-arm64
   expansions:
     AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.11/bin/python3
-- name: test-macos-arm-py3.12-auth-ssl
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-arm-py3.13-auth-ssl-async
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS (arm) py3.12 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test macOS (arm) py3.13 Auth SSL Async
   run_on:
     - macos-14-arm64
   expansions:
     AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.12/bin/python3
-- name: test-macos-arm-py3.13-auth-ssl
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-arm-py3.13-noauth-nossl-sync
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test macOS (arm) py3.13 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test macOS (arm) py3.13 NoAuth NoSSL Sync
   run_on:
     - macos-14-arm64
   expansions:
-    AUTH: auth
-    ssl: ssl
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-arm-py3.13-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS (arm) py3.13 NoAuth NoSSL Async
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
+# Server tests for Windows.
+- name: test-win64-py-3.9-auth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py 3.9 Auth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: C:/python/Python 39/python.exe
+- name: test-win64-py-3.9-auth-ssl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py 3.9 Auth SSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: C:/python/Python 39/python.exe
+- name: test-win64-py-3.9-noauth-nossl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py 3.9 NoAuth NoSSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    PYTHON_BINARY: C:/python/Python 39/python.exe
+- name: test-win64-py-3.9-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py 3.9 NoAuth NoSSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: C:/python/Python 39/python.exe
+- name: test-win64-py-3.13-auth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py 3.13 Auth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: C:/python/Python 313/python.exe
+- name: test-win64-py-3.13-auth-ssl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py 3.13 Auth SSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: C:/python/Python 313/python.exe
+- name: test-win64-py-3.13-noauth-nossl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py 3.13 NoAuth NoSSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    PYTHON_BINARY: C:/python/Python 313/python.exe
+- name: test-win64-py-3.13-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py 3.13 NoAuth NoSSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: C:/python/Python 313/python.exe
+
 # Server tests for Windows (32-bit).
-- name: test-win64-32-bit-py3.9-auth-ssl
+- name: test-win64-32-bit-py3.9-auth-ssl-sync
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 32-bit py3.9 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test Win64 32-bit py3.9 Auth SSL Sync
   run_on:
     - windows-64-vsMulti-small
   expansions:
     AUTH: auth
-    ssl: ssl
+    SSL: ssl
+    TEST_SUITES: default
     PYTHON_BINARY: C:/python/32/Python39/python.exe
-- name: test-win64-32-bit-py3.10-auth-ssl
+- name: test-win64-32-bit-py3.9-auth-ssl-async
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 32-bit py3.10 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test Win64 32-bit py3.9 Auth SSL Async
   run_on:
     - windows-64-vsMulti-small
   expansions:
     AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: C:/python/32/Python310/python.exe
-- name: test-win64-32-bit-py3.11-auth-ssl
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: C:/python/32/Python39/python.exe
+- name: test-win64-32-bit-py3.9-noauth-nossl-sync
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 32-bit py3.11 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test Win64 32-bit py3.9 NoAuth NoSSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    PYTHON_BINARY: C:/python/32/Python39/python.exe
+- name: test-win64-32-bit-py3.9-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 32-bit py3.9 NoAuth NoSSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: C:/python/32/Python39/python.exe
+- name: test-win64-32-bit-py3.13-auth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 32-bit py3.13 Auth SSL Sync
   run_on:
     - windows-64-vsMulti-small
   expansions:
     AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: C:/python/32/Python311/python.exe
-- name: test-win64-32-bit-py3.12-auth-ssl
+    SSL: ssl
+    TEST_SUITES: default
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+- name: test-win64-32-bit-py3.13-auth-ssl-async
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 32-bit py3.12 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test Win64 32-bit py3.13 Auth SSL Async
   run_on:
     - windows-64-vsMulti-small
   expansions:
     AUTH: auth
-    ssl: ssl
-    PYTHON_BINARY: C:/python/32/Python312/python.exe
-- name: test-win64-32-bit-py3.13-auth-ssl
+    SSL: ssl
+    TEST_SUITES: default_async
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+- name: test-win64-32-bit-py3.13-noauth-nossl-sync
   tasks:
-    - name: .4.0 .sharded_cluster
-    - name: .4.4 .sharded_cluster
-    - name: .5.0 .sharded_cluster
-    - name: .6.0 .sharded_cluster
-    - name: .7.0 .sharded_cluster
-    - name: .8.0 .sharded_cluster
-    - name: .rapid .sharded_cluster
-    - name: .latest .sharded_cluster
-  display_name: Test Win64 32-bit py3.13 Auth SSL
+    - name: .sharded_cluster
+  display_name: Test Win64 32-bit py3.13 NoAuth NoSSL Sync
   run_on:
     - windows-64-vsMulti-small
   expansions:
-    AUTH: auth
-    ssl: ssl
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+- name: test-win64-32-bit-py3.13-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 32-bit py3.13 NoAuth NoSSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
     PYTHON_BINARY: C:/python/32/Python313/python.exe
 
 - matrix_name: "tests-fips"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2399,6 +2399,713 @@ axes:
         batchtime: 10080  # 7 days
 
 buildvariants:
+# Server Tests for RHEL8.
+- name: test-rhel8-py3.9-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.9 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+- name: test-rhel8-py3.9-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.9 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+- name: test-rhel8-py3.9-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.9 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+- name: test-rhel8-py3.10-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.10 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/3.10/bin/python3
+- name: test-rhel8-py3.10-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.10 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.10/bin/python3
+- name: test-rhel8-py3.10-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.10 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.10/bin/python3
+- name: test-rhel8-py3.11-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.11 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/3.11/bin/python3
+- name: test-rhel8-py3.11-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.11 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.11/bin/python3
+- name: test-rhel8-py3.11-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.11 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.11/bin/python3
+- name: test-rhel8-py3.12-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.12 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/3.12/bin/python3
+- name: test-rhel8-py3.12-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.12 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.12/bin/python3
+- name: test-rhel8-py3.12-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.12 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.12/bin/python3
+- name: test-rhel8-py3.13-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.13 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+- name: test-rhel8-py3.13-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.13 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+- name: test-rhel8-py3.13-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 py3.13 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+- name: test-rhel8-pypy3.9-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 pypy3.9 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
+- name: test-rhel8-pypy3.9-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 pypy3.9 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
+- name: test-rhel8-pypy3.9-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 pypy3.9 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
+- name: test-rhel8-pypy3.10-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 pypy3.10 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
+- name: test-rhel8-pypy3.10-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 pypy3.10 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
+- name: test-rhel8-pypy3.10-auth-ssl
+  tasks:
+    - name: .4.0
+    - name: .4.4
+    - name: .5.0
+    - name: .6.0
+    - name: .7.0
+    - name: .8.0
+    - name: .rapid
+    - name: .latest
+  display_name: Test RHEL8 pypy3.10 Auth SSL
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    SSL: nossl
+    PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
+
+# Server Tests for Windows.
+- name: test-win64-py3.9-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 py3.9 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/Python39/python.exe
+- name: test-win64-py3.10-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 py3.10 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/Python310/python.exe
+- name: test-win64-py3.11-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 py3.11 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/Python311/python.exe
+- name: test-win64-py3.12-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 py3.12 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/Python312/python.exe
+- name: test-win64-py3.13-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 py3.13 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/Python313/python.exe
+- name: test-macos-py3.9-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS py3.9 Auth SSL
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+
+# Server tests for MacOS.
+- name: test-macos-py3.10-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS py3.10 Auth SSL
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.10/bin/python3
+- name: test-macos-py3.11-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS py3.11 Auth SSL
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.11/bin/python3
+- name: test-macos-py3.12-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS py3.12 Auth SSL
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.12/bin/python3
+- name: test-macos-py3.13-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS py3.13 Auth SSL
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+
+# Server tests for macOS (arm).
+- name: test-macos-(arm)-py3.9-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS (arm) py3.9 Auth SSL
+  run_on:
+    - macos-14-arm65
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-(arm)-py3.10-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS (arm) py3.10 Auth SSL
+  run_on:
+    - macos-14-arm65
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.10/bin/python3
+- name: test-macos-(arm)-py3.11-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS (arm) py3.11 Auth SSL
+  run_on:
+    - macos-14-arm65
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.11/bin/python3
+- name: test-macos-(arm)-py3.12-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS (arm) py3.12 Auth SSL
+  run_on:
+    - macos-14-arm65
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.12/bin/python3
+- name: test-macos-(arm)-py3.13-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test macOS (arm) py3.13 Auth SSL
+  run_on:
+    - macos-14-arm65
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+
+# Server tests for Windows (32-bit).
+- name: test-win64-32-bit-py3.9-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 32-bit py3.9 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/32/Python39/python.exe
+- name: test-win64-32-bit-py3.10-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 32-bit py3.10 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/32/Python310/python.exe
+- name: test-win64-32-bit-py3.11-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 32-bit py3.11 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/32/Python311/python.exe
+- name: test-win64-32-bit-py3.12-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 32-bit py3.12 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/32/Python312/python.exe
+- name: test-win64-32-bit-py3.13-auth-ssl
+  tasks:
+    - name: .4.0 .sharded_cluster
+    - name: .4.4 .sharded_cluster
+    - name: .5.0 .sharded_cluster
+    - name: .6.0 .sharded_cluster
+    - name: .7.0 .sharded_cluster
+    - name: .8.0 .sharded_cluster
+    - name: .rapid .sharded_cluster
+    - name: .latest .sharded_cluster
+  display_name: Test Win64 32-bit py3.13 Auth SSL
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    ssl: ssl
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+
 - matrix_name: "tests-fips"
   matrix_spec:
     platform:
@@ -2408,44 +3115,6 @@ buildvariants:
   display_name: "${platform} ${auth} ${ssl}"
   tasks:
     - "test-fips-standalone"
-
-- matrix_name: "test-macos"
-  matrix_spec:
-    platform:
-      # MacOS introduced SSL support with MongoDB >= 3.2.
-      # Older server versions (2.6, 3.0) are supported without SSL.
-      - macos
-    auth: "*"
-    ssl: "*"
-  exclude_spec:
-    # No point testing with SSL without auth.
-    - platform: macos
-      auth: "noauth"
-      ssl: "ssl"
-  display_name: "${platform} ${auth} ${ssl}"
-  tasks:
-    - ".latest"
-    - ".8.0"
-    - ".7.0"
-    - ".6.0"
-    - ".5.0"
-    - ".4.4"
-    - ".4.2"
-    - ".4.0"
-
-- matrix_name: "test-macos-arm64"
-  matrix_spec:
-    platform:
-      - macos-arm64
-    auth-ssl: "*"
-  display_name: "${platform} ${auth-ssl}"
-  tasks:
-    - ".latest"
-    - ".8.0"
-    - ".7.0"
-    - ".6.0"
-    - ".5.0"
-    - ".4.4"
 
 - matrix_name: "test-macos-encryption"
   matrix_spec:
@@ -2485,24 +3154,6 @@ buildvariants:
   display_name: "${platform} ${auth-ssl}"
   tasks:
     - ".6.0"
-
-- matrix_name: "tests-python-version-rhel8-test-ssl"
-  matrix_spec:
-    platform: rhel8
-    python-version: "*"
-    auth-ssl: "*"
-    coverage: "*"
-  display_name: "${python-version} ${platform} ${auth-ssl} ${coverage}"
-  tasks: &all-server-versions
-    - ".rapid"
-    - ".latest"
-    - ".8.0"
-    - ".7.0"
-    - ".6.0"
-    - ".5.0"
-    - ".4.4"
-    - ".4.2"
-    - ".4.0"
 
 - matrix_name: "tests-pyopenssl"
   matrix_spec:
@@ -2580,7 +3231,16 @@ buildvariants:
      auth-ssl: "*"
      coverage: "*"
   display_name: "${c-extensions} ${python-version} ${platform} ${auth} ${ssl} ${coverage}"
-  tasks: *all-server-versions
+  tasks: &all-server-versions
+    - ".rapid"
+    - ".latest"
+    - ".8.0"
+    - ".7.0"
+    - ".6.0"
+    - ".5.0"
+    - ".4.4"
+    - ".4.2"
+    - ".4.0"
 
 - matrix_name: "tests-python-version-rhel8-compression"
   matrix_spec:
@@ -2627,22 +3287,6 @@ buildvariants:
      green-framework: "*"
      auth-ssl: "*"
   display_name: "${green-framework} ${python-version} ${platform} ${auth-ssl}"
-  tasks: *all-server-versions
-
-- matrix_name: "tests-windows-python-version"
-  matrix_spec:
-    platform: windows
-    python-version-windows: "*"
-    auth-ssl: "*"
-  display_name: "${platform} ${python-version-windows} ${auth-ssl}"
-  tasks: *all-server-versions
-
-- matrix_name: "tests-windows-python-version-32-bit"
-  matrix_spec:
-    platform: windows
-    python-version-windows-32: "*"
-    auth-ssl: "*"
-  display_name: "${platform} ${python-version-windows-32} ${auth-ssl}"
   tasks: *all-server-versions
 
 - matrix_name: "tests-python-version-supports-openssl-102-test-ssl"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2401,114 +2401,132 @@ axes:
 
 buildvariants:
 # Server Tests for RHEL8.
-- name: test-rhel8-py3.9-auth-ssl
+- name: test-rhel8-py3.9-auth-ssl-cov
   tasks:
     - name: .standalone
     - name: .replica_set
     - name: .sharded_cluster
-  display_name: Test RHEL8 py3.9 Auth SSL
+  display_name: Test RHEL8 py3.9 Auth SSL cov
   run_on:
     - rhel87-small
   expansions:
     AUTH: auth
     SSL: ssl
+    COVERAGE: coverage
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: test-rhel8-py3.9-noauth-ssl
+  tags: [coverage_tag]
+- name: test-rhel8-py3.9-noauth-ssl-cov
   tasks:
     - name: .standalone
     - name: .replica_set
     - name: .sharded_cluster
-  display_name: Test RHEL8 py3.9 NoAuth SSL
+  display_name: Test RHEL8 py3.9 NoAuth SSL cov
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: ssl
+    COVERAGE: coverage
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: test-rhel8-py3.9-noauth-nossl
+  tags: [coverage_tag]
+- name: test-rhel8-py3.9-noauth-nossl-cov
   tasks:
     - name: .standalone
     - name: .replica_set
     - name: .sharded_cluster
-  display_name: Test RHEL8 py3.9 NoAuth NoSSL
+  display_name: Test RHEL8 py3.9 NoAuth NoSSL cov
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
+    COVERAGE: coverage
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: test-rhel8-py3.13-auth-ssl
+  tags: [coverage_tag]
+- name: test-rhel8-py3.13-auth-ssl-cov
   tasks:
     - name: .standalone
     - name: .replica_set
     - name: .sharded_cluster
-  display_name: Test RHEL8 py3.13 Auth SSL
+  display_name: Test RHEL8 py3.13 Auth SSL cov
   run_on:
     - rhel87-small
   expansions:
     AUTH: auth
     SSL: ssl
+    COVERAGE: coverage
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: test-rhel8-py3.13-noauth-ssl
+  tags: [coverage_tag]
+- name: test-rhel8-py3.13-noauth-ssl-cov
   tasks:
     - name: .standalone
     - name: .replica_set
     - name: .sharded_cluster
-  display_name: Test RHEL8 py3.13 NoAuth SSL
+  display_name: Test RHEL8 py3.13 NoAuth SSL cov
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: ssl
+    COVERAGE: coverage
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: test-rhel8-py3.13-noauth-nossl
+  tags: [coverage_tag]
+- name: test-rhel8-py3.13-noauth-nossl-cov
   tasks:
     - name: .standalone
     - name: .replica_set
     - name: .sharded_cluster
-  display_name: Test RHEL8 py3.13 NoAuth NoSSL
+  display_name: Test RHEL8 py3.13 NoAuth NoSSL cov
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
+    COVERAGE: coverage
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: test-rhel8-pypy3.10-auth-ssl
+  tags: [coverage_tag]
+- name: test-rhel8-pypy3.10-auth-ssl-cov
   tasks:
     - name: .standalone
     - name: .replica_set
     - name: .sharded_cluster
-  display_name: Test RHEL8 pypy3.10 Auth SSL
+  display_name: Test RHEL8 pypy3.10 Auth SSL cov
   run_on:
     - rhel87-small
   expansions:
     AUTH: auth
     SSL: ssl
+    COVERAGE: coverage
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: test-rhel8-pypy3.10-noauth-ssl
+  tags: [coverage_tag]
+- name: test-rhel8-pypy3.10-noauth-ssl-cov
   tasks:
     - name: .standalone
     - name: .replica_set
     - name: .sharded_cluster
-  display_name: Test RHEL8 pypy3.10 NoAuth SSL
+  display_name: Test RHEL8 pypy3.10 NoAuth SSL cov
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: ssl
+    COVERAGE: coverage
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: test-rhel8-pypy3.10-noauth-nossl
+  tags: [coverage_tag]
+- name: test-rhel8-pypy3.10-noauth-nossl-cov
   tasks:
     - name: .standalone
     - name: .replica_set
     - name: .sharded_cluster
-  display_name: Test RHEL8 pypy3.10 NoAuth NoSSL
+  display_name: Test RHEL8 pypy3.10 NoAuth NoSSL cov
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
+    COVERAGE: coverage
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
+  tags: [coverage_tag]
 - name: test-rhel8-py3.10-auth-ssl
   tasks:
     - name: .standalone

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2761,7 +2761,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default
-    PYTHON_BINARY: C:/python/Python 39/python.exe
+    PYTHON_BINARY: C:/python/Python39/python.exe
 - name: test-win64-py-3.9-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2772,7 +2772,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/Python 39/python.exe
+    PYTHON_BINARY: C:/python/Python39/python.exe
 - name: test-win64-py-3.9-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2783,7 +2783,7 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     TEST_SUITES: default
-    PYTHON_BINARY: C:/python/Python 39/python.exe
+    PYTHON_BINARY: C:/python/Python39/python.exe
 - name: test-win64-py-3.9-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2794,7 +2794,7 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/Python 39/python.exe
+    PYTHON_BINARY: C:/python/Python39/python.exe
 - name: test-win64-py-3.13-auth-ssl-sync
   tasks:
     - name: .sharded_cluster
@@ -2805,7 +2805,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default
-    PYTHON_BINARY: C:/python/Python 313/python.exe
+    PYTHON_BINARY: C:/python/Python313/python.exe
 - name: test-win64-py-3.13-auth-ssl-async
   tasks:
     - name: .sharded_cluster
@@ -2816,7 +2816,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/Python 313/python.exe
+    PYTHON_BINARY: C:/python/Python313/python.exe
 - name: test-win64-py-3.13-noauth-nossl-sync
   tasks:
     - name: .sharded_cluster
@@ -2827,7 +2827,7 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     TEST_SUITES: default
-    PYTHON_BINARY: C:/python/Python 313/python.exe
+    PYTHON_BINARY: C:/python/Python313/python.exe
 - name: test-win64-py-3.13-noauth-nossl-async
   tasks:
     - name: .sharded_cluster
@@ -2838,7 +2838,7 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/Python 313/python.exe
+    PYTHON_BINARY: C:/python/Python313/python.exe
 
 # Server tests for Windows (32-bit).
 - name: test-win64-32-bit-py3.9-auth-ssl-sync

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2417,7 +2417,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: test-rhel8-py3.9-auth-ssl
+- name: test-rhel8-py3.9-noauth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2427,14 +2427,14 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.9 Auth SSL
+  display_name: Test RHEL8 py3.9 NoAuth NoSSL
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: test-rhel8-py3.9-auth-ssl
+- name: test-rhel8-py3.9-auth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2444,7 +2444,7 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.9 Auth SSL
+  display_name: Test RHEL8 py3.9 Auth NoSSL
   run_on:
     - rhel87-small
   expansions:
@@ -2468,7 +2468,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/3.10/bin/python3
-- name: test-rhel8-py3.10-auth-ssl
+- name: test-rhel8-py3.10-noauth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2478,14 +2478,14 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.10 Auth SSL
+  display_name: Test RHEL8 py3.10 NoAuth NoSSL
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.10/bin/python3
-- name: test-rhel8-py3.10-auth-ssl
+- name: test-rhel8-py3.10-auth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2495,7 +2495,7 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.10 Auth SSL
+  display_name: Test RHEL8 py3.10 Auth NoSSL
   run_on:
     - rhel87-small
   expansions:
@@ -2519,7 +2519,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/3.11/bin/python3
-- name: test-rhel8-py3.11-auth-ssl
+- name: test-rhel8-py3.11-noauth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2529,14 +2529,14 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.11 Auth SSL
+  display_name: Test RHEL8 py3.11 NoAuth NoSSL
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.11/bin/python3
-- name: test-rhel8-py3.11-auth-ssl
+- name: test-rhel8-py3.11-auth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2546,7 +2546,7 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.11 Auth SSL
+  display_name: Test RHEL8 py3.11 Auth NoSSL
   run_on:
     - rhel87-small
   expansions:
@@ -2570,7 +2570,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/3.12/bin/python3
-- name: test-rhel8-py3.12-auth-ssl
+- name: test-rhel8-py3.12-noauth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2580,14 +2580,14 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.12 Auth SSL
+  display_name: Test RHEL8 py3.12 NoAuth NoSSL
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.12/bin/python3
-- name: test-rhel8-py3.12-auth-ssl
+- name: test-rhel8-py3.12-auth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2597,7 +2597,7 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.12 Auth SSL
+  display_name: Test RHEL8 py3.12 Auth NoSSL
   run_on:
     - rhel87-small
   expansions:
@@ -2621,7 +2621,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: test-rhel8-py3.13-auth-ssl
+- name: test-rhel8-py3.13-noauth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2631,14 +2631,14 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.13 Auth SSL
+  display_name: Test RHEL8 py3.13 NoAuth NoSSL
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/3.13/bin/python3
-- name: test-rhel8-py3.13-auth-ssl
+- name: test-rhel8-py3.13-auth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2648,7 +2648,7 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 py3.13 Auth SSL
+  display_name: Test RHEL8 py3.13 Auth NoSSL
   run_on:
     - rhel87-small
   expansions:
@@ -2672,7 +2672,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-- name: test-rhel8-pypy3.9-auth-ssl
+- name: test-rhel8-pypy3.9-noauth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2682,14 +2682,14 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 pypy3.9 Auth SSL
+  display_name: Test RHEL8 pypy3.9 NoAuth NoSSL
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-- name: test-rhel8-pypy3.9-auth-ssl
+- name: test-rhel8-pypy3.9-auth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2699,7 +2699,7 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 pypy3.9 Auth SSL
+  display_name: Test RHEL8 pypy3.9 Auth NoSSL
   run_on:
     - rhel87-small
   expansions:
@@ -2723,7 +2723,7 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: test-rhel8-pypy3.10-auth-ssl
+- name: test-rhel8-pypy3.10-noauth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2733,14 +2733,14 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 pypy3.10 Auth SSL
+  display_name: Test RHEL8 pypy3.10 NoAuth NoSSL
   run_on:
     - rhel87-small
   expansions:
     AUTH: noauth
     SSL: nossl
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: test-rhel8-pypy3.10-auth-ssl
+- name: test-rhel8-pypy3.10-auth-nossl
   tasks:
     - name: .4.0
     - name: .4.4
@@ -2750,7 +2750,7 @@ buildvariants:
     - name: .8.0
     - name: .rapid
     - name: .latest
-  display_name: Test RHEL8 pypy3.10 Auth SSL
+  display_name: Test RHEL8 pypy3.10 Auth NoSSL
   run_on:
     - rhel87-small
   expansions:
@@ -2945,7 +2945,7 @@ buildvariants:
     - name: .latest .sharded_cluster
   display_name: Test macOS (arm) py3.9 Auth SSL
   run_on:
-    - macos-14-arm65
+    - macos-14-arm64
   expansions:
     AUTH: auth
     ssl: ssl
@@ -2962,7 +2962,7 @@ buildvariants:
     - name: .latest .sharded_cluster
   display_name: Test macOS (arm) py3.10 Auth SSL
   run_on:
-    - macos-14-arm65
+    - macos-14-arm64
   expansions:
     AUTH: auth
     ssl: ssl
@@ -2979,7 +2979,7 @@ buildvariants:
     - name: .latest .sharded_cluster
   display_name: Test macOS (arm) py3.11 Auth SSL
   run_on:
-    - macos-14-arm65
+    - macos-14-arm64
   expansions:
     AUTH: auth
     ssl: ssl
@@ -2996,7 +2996,7 @@ buildvariants:
     - name: .latest .sharded_cluster
   display_name: Test macOS (arm) py3.12 Auth SSL
   run_on:
-    - macos-14-arm65
+    - macos-14-arm64
   expansions:
     AUTH: auth
     ssl: ssl
@@ -3013,7 +3013,7 @@ buildvariants:
     - name: .latest .sharded_cluster
   display_name: Test macOS (arm) py3.13 Auth SSL
   run_on:
-    - macos-14-arm65
+    - macos-14-arm64
   expansions:
     AUTH: auth
     ssl: ssl

--- a/.evergreen/hatch.sh
+++ b/.evergreen/hatch.sh
@@ -34,8 +34,8 @@ else # Set up virtualenv before installing hatch
     fi
     export HATCH_CONFIG
     hatch config restore
-    hatch config set dirs.data ".hatch/data"
-    hatch config set dirs.cache ".hatch/cache"
+    hatch config set dirs.data "$(pwd)/.hatch/data"
+    hatch config set dirs.cache "$(pwd)/.hatch/cache"
 
     run_hatch() {
       python -m hatch run "$@"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -30,7 +30,7 @@ set -o xtrace
 
 AUTH=${AUTH:-noauth}
 SSL=${SSL:-nossl}
-TEST_SUITES=""
+TEST_SUITES=${TEST_SUITES:-}
 TEST_ARGS="${*:1}"
 
 export PIP_QUIET=1  # Quiet by default

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -64,7 +64,7 @@ def create_variant(
     expansions = kwargs.pop("expansions", dict()).copy()
     host = host or "rhel8"
     run_on = [HOSTS[host].run_on]
-    name = display_name.replace(" ", "-").lower()
+    name = display_name.replace(" ", "-").replace("(", "").replace(")", "").lower()
     if python:
         expansions["PYTHON_BINARY"] = get_python_binary(python, host)
     if version:

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -41,7 +41,7 @@ class Host:
 HOSTS["rhel8"] = Host("rhel8", "rhel87-small", "RHEL8")
 HOSTS["win64"] = Host("win64", "windows-64-vsMulti-small", "Win64")
 HOSTS["macos"] = Host("macos", "macos-14", "macOS")
-HOSTS["macos-arm64"] = Host("macos-arm64", "macos-14-arm65", "macOS (arm)")
+HOSTS["macos-arm64"] = Host("macos-arm64", "macos-14-arm64", "macOS (arm)")
 
 
 ##############
@@ -116,7 +116,7 @@ def get_display_name(base: str, host: str, **kwargs) -> str:
                 else:
                     name = f"py{value}"
         elif key in DISPLAY_LOOKUP:
-            name = DISPLAY_LOOKUP[key]
+            name = DISPLAY_LOOKUP[value]
         else:
             raise ValueError(f"Missing display handling for {key}")
         display_name = f"{display_name} {name}"

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -43,12 +43,17 @@ class Host:
     name: str
     run_on: str
     display_name: str
+    expansions: dict[str, str]
 
 
-HOSTS["rhel8"] = Host("rhel8", "rhel87-small", "RHEL8")
-HOSTS["win64"] = Host("win64", "windows-64-vsMulti-small", "Win64")
-HOSTS["macos"] = Host("macos", "macos-14", "macOS")
-HOSTS["macos-arm64"] = Host("macos-arm64", "macos-14-arm64", "macOS (arm)")
+_macos_expansions = dict(  # CSOT tests are unreliable on slow hosts.
+    SKIP_CSOT_TESTS="true"
+)
+
+HOSTS["rhel8"] = Host("rhel8", "rhel87-small", "RHEL8", dict())
+HOSTS["win64"] = Host("win64", "windows-64-vsMulti-small", "Win64", _macos_expansions)
+HOSTS["macos"] = Host("macos", "macos-14", "macOS", _macos_expansions)
+HOSTS["macos-arm64"] = Host("macos-arm64", "macos-14-arm64", "macOS (arm)", _macos_expansions)
 
 
 ##############
@@ -76,6 +81,7 @@ def create_variant(
         expansions["PYTHON_BINARY"] = get_python_binary(python, host)
     if version:
         expansions["VERSION"] = version
+    expansions.update(HOSTS[host].expansions)
     expansions = expansions or None
     return BuildVariant(
         name=name,

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -35,6 +35,7 @@ DISPLAY_LOOKUP = dict(
     ssl=dict(ssl="SSL", nossl="NoSSL"),
     auth=dict(auth="Auth", noauth="NoAuth"),
     test_suites=dict(default="Sync", default_async="Async"),
+    coverage=dict(coverage="cov"),
 )
 HOSTS = dict()
 
@@ -200,13 +201,14 @@ def create_server_variants() -> list[BuildVariant]:
     host = "rhel8"
     for python, (auth, ssl) in product([*MIN_MAX_PYTHON, PYPYS[-1]], AUTH_SSLS):
         display_name = f"Test {host}"
-        expansions = dict(AUTH=auth, SSL=ssl)
+        expansions = dict(AUTH=auth, SSL=ssl, COVERAGE="coverage")
         display_name = get_display_name("Test", host, python=python, **expansions)
         variant = create_variant(
             [f".{t}" for t in TOPOLOGIES],
             display_name,
             python=python,
             host=host,
+            tags=["coverage_tag"],
             expansions=expansions,
         )
         variants.append(variant)

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -217,7 +217,7 @@ def create_server_variants() -> list[BuildVariant]:
     for prefix, base, (auth, ssl), sync in product(
         ["", "32-bit "], MIN_MAX_PYTHON, AUTH_SSLS, SYNCS
     ):
-        python = f"{prefix} {base}"
+        python = f"{prefix}{base}"
         test_suite = "default" if sync == "sync" else "default_async"
         expansions = dict(AUTH=auth, SSL=ssl, TEST_SUITES=test_suite)
         display_name = get_display_name("Test", host, python=python, **expansions)


### PR DESCRIPTION
- Break up the test matrix to cover all server versions, python versions, platforms, topologies, and auth/ssl with as little repetition as possible
- Break up sync and async tests on MacOS and Windows

Before: 1026 tasks across 39 build variants
After: 495 tasks across 37 build variants

<img width="207" alt="image" src="https://github.com/user-attachments/assets/abdb79cb-c6a5-480d-8678-fc77ca0ec07d">
