### PR TITLE
PYTHON-4882 Use shrub.py for enterprise auth tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3194,6 +3194,89 @@ buildvariants:
     COMPRESSORS: zstd
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
 
+# Enterprise auth tests.
+- name: enterprise-auth-rhel8-py3.9-auth
+  tasks:
+    - name: test-enterprise-auth
+  display_name: Enterprise Auth RHEL8 py3.9 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+- name: enterprise-auth-rhel8-py3.10-auth
+  tasks:
+    - name: test-enterprise-auth
+  display_name: Enterprise Auth RHEL8 py3.10 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    PYTHON_BINARY: /opt/python/3.10/bin/python3
+- name: enterprise-auth-rhel8-py3.11-auth
+  tasks:
+    - name: test-enterprise-auth
+  display_name: Enterprise Auth RHEL8 py3.11 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    PYTHON_BINARY: /opt/python/3.11/bin/python3
+- name: enterprise-auth-rhel8-py3.12-auth
+  tasks:
+    - name: test-enterprise-auth
+  display_name: Enterprise Auth RHEL8 py3.12 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    PYTHON_BINARY: /opt/python/3.12/bin/python3
+- name: enterprise-auth-rhel8-py3.13-auth
+  tasks:
+    - name: test-enterprise-auth
+  display_name: Enterprise Auth RHEL8 py3.13 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+- name: enterprise-auth-rhel8-pypy3.9-auth
+  tasks:
+    - name: test-enterprise-auth
+  display_name: Enterprise Auth RHEL8 pypy3.9 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
+- name: enterprise-auth-rhel8-pypy3.10-auth
+  tasks:
+    - name: test-enterprise-auth
+  display_name: Enterprise Auth RHEL8 pypy3.10 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
+- name: enterprise-auth-win64-py3.9-auth
+  tasks:
+    - name: test-enterprise-auth
+  display_name: Enterprise Auth Win64 py3.9 Auth
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    PYTHON_BINARY: C:/python/Python39/python.exe
+- name: enterprise-auth-win64-py3.13-auth
+  tasks:
+    - name: test-enterprise-auth
+  display_name: Enterprise Auth Win64 py3.13 Auth
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    PYTHON_BINARY: C:/python/Python313/python.exe
+
 - matrix_name: "tests-fips"
   matrix_spec:
     platform:
@@ -3349,24 +3432,6 @@ buildvariants:
   display_name: "Disable test commands ${python-version} ${platform}"
   tasks:
      - ".latest"
-
-- matrix_name: "test-linux-enterprise-auth"
-  matrix_spec:
-    platform: rhel8
-    python-version: "*"
-    auth: "auth"
-  display_name: "Enterprise ${auth} ${platform} ${python-version}"
-  tasks:
-     - name: "test-enterprise-auth"
-
-- matrix_name: "tests-windows-enterprise-auth"
-  matrix_spec:
-    platform: windows
-    python-version-windows: "*"
-    auth: "auth"
-  display_name: "Enterprise ${auth} ${platform} ${python-version-windows}"
-  tasks:
-     - name: "test-enterprise-auth"
 
 - matrix_name: "test-search-index-helpers"
   matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3195,15 +3195,15 @@ buildvariants:
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
 
 # Enterprise auth tests.
-- name: enterprise-auth-rhel8-py3.9-auth
+- name: enterprise-auth-macos-py3.9-auth
   tasks:
     - name: test-enterprise-auth
-  display_name: Enterprise Auth RHEL8 py3.9 Auth
+  display_name: Enterprise Auth macOS py3.9 Auth
   run_on:
-    - rhel87-small
+    - macos-14
   expansions:
     AUTH: auth
-    PYTHON_BINARY: /opt/python/3.9/bin/python3
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 - name: enterprise-auth-rhel8-py3.10-auth
   tasks:
     - name: test-enterprise-auth
@@ -3231,15 +3231,15 @@ buildvariants:
   expansions:
     AUTH: auth
     PYTHON_BINARY: /opt/python/3.12/bin/python3
-- name: enterprise-auth-rhel8-py3.13-auth
+- name: enterprise-auth-win64-py3.13-auth
   tasks:
     - name: test-enterprise-auth
-  display_name: Enterprise Auth RHEL8 py3.13 Auth
+  display_name: Enterprise Auth Win64 py3.13 Auth
   run_on:
-    - rhel87-small
+    - windows-64-vsMulti-small
   expansions:
     AUTH: auth
-    PYTHON_BINARY: /opt/python/3.13/bin/python3
+    PYTHON_BINARY: C:/python/Python313/python.exe
 - name: enterprise-auth-rhel8-pypy3.9-auth
   tasks:
     - name: test-enterprise-auth
@@ -3258,24 +3258,6 @@ buildvariants:
   expansions:
     AUTH: auth
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-- name: enterprise-auth-win64-py3.9-auth
-  tasks:
-    - name: test-enterprise-auth
-  display_name: Enterprise Auth Win64 py3.9 Auth
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    PYTHON_BINARY: C:/python/Python39/python.exe
-- name: enterprise-auth-win64-py3.13-auth
-  tasks:
-    - name: test-enterprise-auth
-  display_name: Enterprise Auth Win64 py3.13 Auth
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: auth
-    PYTHON_BINARY: C:/python/Python313/python.exe
 
 - matrix_name: "tests-fips"
   matrix_spec:

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -90,6 +90,8 @@ if [ -n "$TEST_ENTERPRISE_AUTH" ]; then
     export GSSAPI_HOST=${SASL_HOST}
     export GSSAPI_PORT=${SASL_PORT}
     export GSSAPI_PRINCIPAL=${PRINCIPAL}
+
+    export TEST_SUITES="auth"
 fi
 
 if [ -n "$TEST_LOADBALANCER" ]; then

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -388,22 +388,20 @@ def create_enterprise_auth_variants():
     expansions = dict(AUTH="auth")
     variants = []
 
-    # All python versions on linux, min and max on Windows.
-    host = "rhel8"
+    # All python versions across platforms.
     for python in ALL_PYTHONS:
+        if python == CPYTHONS[0]:
+            host = "macos"
+        elif python == CPYTHONS[-1]:
+            host = "win64"
+        else:
+            host = "rhel8"
         display_name = get_display_name("Enterprise Auth", host, python=python, **expansions)
         variant = create_variant(
             ["test-enterprise-auth"], display_name, host=host, python=python, expansions=expansions
         )
         variants.append(variant)
 
-    host = "win64"
-    for python in MIN_MAX_PYTHON:
-        display_name = get_display_name("Enterprise Auth", host, python=python, **expansions)
-        variant = create_variant(
-            ["test-enterprise-auth"], display_name, host=host, python=python, expansions=expansions
-        )
-        variants.append(variant)
     return variants
 
 

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -384,10 +384,33 @@ def create_compression_variants():
     return variants
 
 
+def create_enterprise_auth_variants():
+    expansions = dict(AUTH="auth")
+    variants = []
+
+    # All python versions on linux, min and max on Windows.
+    host = "rhel8"
+    for python in ALL_PYTHONS:
+        display_name = get_display_name("Enterprise Auth", host, python=python, **expansions)
+        variant = create_variant(
+            ["test-enterprise-auth"], display_name, host=host, python=python, expansions=expansions
+        )
+        variants.append(variant)
+
+    host = "win64"
+    for python in MIN_MAX_PYTHON:
+        display_name = get_display_name("Enterprise Auth", host, python=python, **expansions)
+        variant = create_variant(
+            ["test-enterprise-auth"], display_name, host=host, python=python, expansions=expansions
+        )
+        variants.append(variant)
+    return variants
+
+
 ##################
 # Generate Config
 ##################
 
-variants = create_compression_variants()
+variants = create_enterprise_auth_variants()
 # print(len(variants))
 generate_yaml(variants=variants)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ filterwarnings = [
 markers = [
     "auth_aws: tests that rely on pymongo-auth-aws",
     "auth_oidc: tests that rely on oidc auth",
+    "auth: tests that rely on authentication",
     "ocsp: tests that rely on ocsp",
     "atlas: tests that rely on atlas",
     "data_lake: tests that rely on atlas data lake",

--- a/test/asynchronous/test_auth.py
+++ b/test/asynchronous/test_auth.py
@@ -32,6 +32,8 @@ from test.asynchronous import (
 )
 from test.utils import AllowListEventListener, delay, ignore_deprecations
 
+import pytest
+
 from pymongo import AsyncMongoClient, monitoring
 from pymongo.asynchronous.auth import HAVE_KERBEROS
 from pymongo.auth_shared import _build_credentials_tuple
@@ -80,6 +82,7 @@ class AutoAuthenticateThread(threading.Thread):
 
 
 class TestGSSAPI(AsyncPyMongoTestCase):
+    pytestmark = pytest.mark.auth
     mech_properties: str
     service_realm_required: bool
 
@@ -266,6 +269,8 @@ class TestGSSAPI(AsyncPyMongoTestCase):
 
 
 class TestSASLPlain(AsyncPyMongoTestCase):
+    pytestmark = pytest.mark.auth
+
     @classmethod
     def setUpClass(cls):
         if not SASL_HOST or not SASL_USER or not SASL_PASS:
@@ -339,6 +344,8 @@ class TestSASLPlain(AsyncPyMongoTestCase):
 
 
 class TestSCRAMSHA1(AsyncIntegrationTest):
+    pytestmark = pytest.mark.auth
+
     @async_client_context.require_auth
     async def asyncSetUp(self):
         await super().asyncSetUp()
@@ -373,6 +380,8 @@ class TestSCRAMSHA1(AsyncIntegrationTest):
 
 # https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-256-and-mechanism-negotiation
 class TestSCRAM(AsyncIntegrationTest):
+    pytestmark = pytest.mark.auth
+
     @async_client_context.require_auth
     @async_client_context.require_version_min(3, 7, 2)
     async def asyncSetUp(self):
@@ -612,6 +621,8 @@ class TestSCRAM(AsyncIntegrationTest):
 
 
 class TestAuthURIOptions(AsyncIntegrationTest):
+    pytestmark = pytest.mark.auth
+
     @async_client_context.require_auth
     async def asyncSetUp(self):
         await super().asyncSetUp()

--- a/test/asynchronous/test_auth.py
+++ b/test/asynchronous/test_auth.py
@@ -44,6 +44,8 @@ from pymongo.saslprep import HAVE_STRINGPREP
 
 _IS_SYNC = False
 
+pytestmark = pytest.mark.auth
+
 # YOU MUST RUN KINIT BEFORE RUNNING GSSAPI TESTS ON UNIX.
 GSSAPI_HOST = os.environ.get("GSSAPI_HOST")
 GSSAPI_PORT = int(os.environ.get("GSSAPI_PORT", "27017"))
@@ -82,7 +84,6 @@ class AutoAuthenticateThread(threading.Thread):
 
 
 class TestGSSAPI(AsyncPyMongoTestCase):
-    pytestmark = pytest.mark.auth
     mech_properties: str
     service_realm_required: bool
 
@@ -269,8 +270,6 @@ class TestGSSAPI(AsyncPyMongoTestCase):
 
 
 class TestSASLPlain(AsyncPyMongoTestCase):
-    pytestmark = pytest.mark.auth
-
     @classmethod
     def setUpClass(cls):
         if not SASL_HOST or not SASL_USER or not SASL_PASS:
@@ -344,8 +343,6 @@ class TestSASLPlain(AsyncPyMongoTestCase):
 
 
 class TestSCRAMSHA1(AsyncIntegrationTest):
-    pytestmark = pytest.mark.auth
-
     @async_client_context.require_auth
     async def asyncSetUp(self):
         await super().asyncSetUp()
@@ -380,8 +377,6 @@ class TestSCRAMSHA1(AsyncIntegrationTest):
 
 # https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-256-and-mechanism-negotiation
 class TestSCRAM(AsyncIntegrationTest):
-    pytestmark = pytest.mark.auth
-
     @async_client_context.require_auth
     @async_client_context.require_version_min(3, 7, 2)
     async def asyncSetUp(self):
@@ -621,8 +616,6 @@ class TestSCRAM(AsyncIntegrationTest):
 
 
 class TestAuthURIOptions(AsyncIntegrationTest):
-    pytestmark = pytest.mark.auth
-
     @async_client_context.require_auth
     async def asyncSetUp(self):
         await super().asyncSetUp()

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -44,6 +44,8 @@ from pymongo.synchronous.auth import HAVE_KERBEROS
 
 _IS_SYNC = True
 
+pytestmark = pytest.mark.auth
+
 # YOU MUST RUN KINIT BEFORE RUNNING GSSAPI TESTS ON UNIX.
 GSSAPI_HOST = os.environ.get("GSSAPI_HOST")
 GSSAPI_PORT = int(os.environ.get("GSSAPI_PORT", "27017"))
@@ -82,7 +84,6 @@ class AutoAuthenticateThread(threading.Thread):
 
 
 class TestGSSAPI(PyMongoTestCase):
-    pytestmark = pytest.mark.auth
     mech_properties: str
     service_realm_required: bool
 
@@ -269,8 +270,6 @@ class TestGSSAPI(PyMongoTestCase):
 
 
 class TestSASLPlain(PyMongoTestCase):
-    pytestmark = pytest.mark.auth
-
     @classmethod
     def setUpClass(cls):
         if not SASL_HOST or not SASL_USER or not SASL_PASS:
@@ -344,8 +343,6 @@ class TestSASLPlain(PyMongoTestCase):
 
 
 class TestSCRAMSHA1(IntegrationTest):
-    pytestmark = pytest.mark.auth
-
     @client_context.require_auth
     def setUp(self):
         super().setUp()
@@ -378,8 +375,6 @@ class TestSCRAMSHA1(IntegrationTest):
 
 # https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-256-and-mechanism-negotiation
 class TestSCRAM(IntegrationTest):
-    pytestmark = pytest.mark.auth
-
     @client_context.require_auth
     @client_context.require_version_min(3, 7, 2)
     def setUp(self):
@@ -617,8 +612,6 @@ class TestSCRAM(IntegrationTest):
 
 
 class TestAuthURIOptions(IntegrationTest):
-    pytestmark = pytest.mark.auth
-
     @client_context.require_auth
     def setUp(self):
         super().setUp()

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -32,6 +32,8 @@ from test import (
 )
 from test.utils import AllowListEventListener, delay, ignore_deprecations
 
+import pytest
+
 from pymongo import MongoClient, monitoring
 from pymongo.auth_shared import _build_credentials_tuple
 from pymongo.errors import OperationFailure
@@ -80,6 +82,7 @@ class AutoAuthenticateThread(threading.Thread):
 
 
 class TestGSSAPI(PyMongoTestCase):
+    pytestmark = pytest.mark.auth
     mech_properties: str
     service_realm_required: bool
 
@@ -266,6 +269,8 @@ class TestGSSAPI(PyMongoTestCase):
 
 
 class TestSASLPlain(PyMongoTestCase):
+    pytestmark = pytest.mark.auth
+
     @classmethod
     def setUpClass(cls):
         if not SASL_HOST or not SASL_USER or not SASL_PASS:
@@ -339,6 +344,8 @@ class TestSASLPlain(PyMongoTestCase):
 
 
 class TestSCRAMSHA1(IntegrationTest):
+    pytestmark = pytest.mark.auth
+
     @client_context.require_auth
     def setUp(self):
         super().setUp()
@@ -371,6 +378,8 @@ class TestSCRAMSHA1(IntegrationTest):
 
 # https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#scram-sha-256-and-mechanism-negotiation
 class TestSCRAM(IntegrationTest):
+    pytestmark = pytest.mark.auth
+
     @client_context.require_auth
     @client_context.require_version_min(3, 7, 2)
     def setUp(self):
@@ -608,6 +617,8 @@ class TestSCRAM(IntegrationTest):
 
 
 class TestAuthURIOptions(IntegrationTest):
+    pytestmark = pytest.mark.auth
+
     @client_context.require_auth
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Also added a marker for auth so we're not running the full test suite.

Before: 12 tasks across 12 build variants
After: 7 tasks across 7 build variants

<img width="206" alt="image" src="https://github.com/user-attachments/assets/69ddb5c5-194b-4bee-8aed-5594440b8037">
