### PR TITLE
PYTHON-4888 Use shrub.py for versioned api tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2305,28 +2305,6 @@ axes:
         variables:
            COVERAGE: "coverage"
 
-  - id: versionedApi
-    display_name: "versionedApi"
-    values:
-      # Test against a cluster with requireApiVersion=1.
-      - id: "requireApiVersion1"
-        display_name: "requireApiVersion1"
-        tags: [ "versionedApi_tag" ]
-        variables:
-          # REQUIRE_API_VERSION is set to make drivers-evergreen-tools
-          # start a cluster with the requireApiVersion parameter.
-          REQUIRE_API_VERSION: "1"
-          # MONGODB_API_VERSION is the apiVersion to use in the test suite.
-          MONGODB_API_VERSION: "1"
-      # Test against a cluster with acceptApiVersion2 but without
-      # requireApiVersion, and don't automatically add apiVersion to
-      # clients created in the test suite.
-      - id: "acceptApiVersion2"
-        display_name: "acceptApiVersion2"
-        tags: [ "versionedApi_tag" ]
-        variables:
-          ORCHESTRATION_FILE: "versioned-api-testing.json"
-
   - id: serverless
     display_name: "Serverless"
     values:
@@ -3366,6 +3344,74 @@ buildvariants:
     SSL: ssl
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 
+# Versioned API tests.
+- name: versioned-api-requireapiversion1-rhel8-py3.9-auth
+  tasks:
+    - name: .standalone .5.0
+    - name: .standalone .6.0
+    - name: .standalone .7.0
+    - name: .standalone .8.0
+    - name: .standalone .rapid
+    - name: .standalone .latest
+  display_name: Versioned API requireApiVersion1 RHEL8 py3.9 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    REQUIRE_API_VERSION: "1"
+    MONGODB_API_VERSION: "1"
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+  tags: [versionedApi_tag]
+- name: versioned-api-acceptapiversion2-rhel8-py3.9-auth
+  tasks:
+    - name: .standalone .5.0
+    - name: .standalone .6.0
+    - name: .standalone .7.0
+    - name: .standalone .8.0
+    - name: .standalone .rapid
+    - name: .standalone .latest
+  display_name: Versioned API acceptApiVersion2 RHEL8 py3.9 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    ORCHESTRATION_FILE: versioned-api-testing.json
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+  tags: [versionedApi_tag]
+- name: versioned-api-requireapiversion1-rhel8-py3.13-auth
+  tasks:
+    - name: .standalone .5.0
+    - name: .standalone .6.0
+    - name: .standalone .7.0
+    - name: .standalone .8.0
+    - name: .standalone .rapid
+    - name: .standalone .latest
+  display_name: Versioned API requireApiVersion1 RHEL8 py3.13 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    REQUIRE_API_VERSION: "1"
+    MONGODB_API_VERSION: "1"
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+  tags: [versionedApi_tag]
+- name: versioned-api-acceptapiversion2-rhel8-py3.13-auth
+  tasks:
+    - name: .standalone .5.0
+    - name: .standalone .6.0
+    - name: .standalone .7.0
+    - name: .standalone .8.0
+    - name: .standalone .rapid
+    - name: .standalone .latest
+  display_name: Versioned API acceptApiVersion2 RHEL8 py3.13 Auth
+  run_on:
+    - rhel87-small
+  expansions:
+    AUTH: auth
+    ORCHESTRATION_FILE: versioned-api-testing.json
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+  tags: [versionedApi_tag]
+
 - matrix_name: "tests-fips"
   matrix_spec:
     platform:
@@ -3558,22 +3604,6 @@ buildvariants:
   display_name: "Atlas Data Lake ${python-version} ${c-extensions}"
   tasks:
     - name: atlas-data-lake-tests
-
-- matrix_name: "stable-api-tests"
-  matrix_spec:
-    platform: rhel8
-    python-version: ["3.9", "3.10"]
-    auth: "auth"
-    versionedApi: "*"
-  display_name: "Versioned API ${versionedApi} ${python-version}"
-  batchtime: 10080  # 7 days
-  tasks:
-    # Versioned API was introduced in MongoDB 4.7
-    - "test-latest-standalone"
-    - "test-8.0-standalone"
-    - "test-7.0-standalone"
-    - "test-6.0-standalone"
-    - "test-5.0-standalone"
 
 # OCSP test matrix.
 - name: ocsp-test-rhel8-v4.4-py3.9

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3345,7 +3345,7 @@ buildvariants:
     PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 
 # Versioned API tests.
-- name: versioned-api-requireapiversion1-rhel8-py3.9-auth
+- name: versioned-api-require-v1-rhel8-py3.9-auth
   tasks:
     - name: .standalone .5.0
     - name: .standalone .6.0
@@ -3353,7 +3353,7 @@ buildvariants:
     - name: .standalone .8.0
     - name: .standalone .rapid
     - name: .standalone .latest
-  display_name: Versioned API requireApiVersion1 RHEL8 py3.9 Auth
+  display_name: Versioned API require v1 RHEL8 py3.9 Auth
   run_on:
     - rhel87-small
   expansions:
@@ -3362,7 +3362,7 @@ buildvariants:
     MONGODB_API_VERSION: "1"
     PYTHON_BINARY: /opt/python/3.9/bin/python3
   tags: [versionedApi_tag]
-- name: versioned-api-acceptapiversion2-rhel8-py3.9-auth
+- name: versioned-api-accept-v2-rhel8-py3.9-auth
   tasks:
     - name: .standalone .5.0
     - name: .standalone .6.0
@@ -3370,7 +3370,7 @@ buildvariants:
     - name: .standalone .8.0
     - name: .standalone .rapid
     - name: .standalone .latest
-  display_name: Versioned API acceptApiVersion2 RHEL8 py3.9 Auth
+  display_name: Versioned API accept v2 RHEL8 py3.9 Auth
   run_on:
     - rhel87-small
   expansions:
@@ -3378,7 +3378,7 @@ buildvariants:
     ORCHESTRATION_FILE: versioned-api-testing.json
     PYTHON_BINARY: /opt/python/3.9/bin/python3
   tags: [versionedApi_tag]
-- name: versioned-api-requireapiversion1-rhel8-py3.13-auth
+- name: versioned-api-require-v1-rhel8-py3.13-auth
   tasks:
     - name: .standalone .5.0
     - name: .standalone .6.0
@@ -3386,7 +3386,7 @@ buildvariants:
     - name: .standalone .8.0
     - name: .standalone .rapid
     - name: .standalone .latest
-  display_name: Versioned API requireApiVersion1 RHEL8 py3.13 Auth
+  display_name: Versioned API require v1 RHEL8 py3.13 Auth
   run_on:
     - rhel87-small
   expansions:
@@ -3395,7 +3395,7 @@ buildvariants:
     MONGODB_API_VERSION: "1"
     PYTHON_BINARY: /opt/python/3.13/bin/python3
   tags: [versionedApi_tag]
-- name: versioned-api-acceptapiversion2-rhel8-py3.13-auth
+- name: versioned-api-accept-v2-rhel8-py3.13-auth
   tasks:
     - name: .standalone .5.0
     - name: .standalone .6.0
@@ -3403,7 +3403,7 @@ buildvariants:
     - name: .standalone .8.0
     - name: .standalone .rapid
     - name: .standalone .latest
-  display_name: Versioned API acceptApiVersion2 RHEL8 py3.13 Auth
+  display_name: Versioned API accept v2 RHEL8 py3.13 Auth
   run_on:
     - rhel87-small
   expansions:

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -454,7 +454,7 @@ def create_versioned_api_tests():
     tags = ["versionedApi_tag"]
     tasks = [f".standalone .{v}" for v in get_pythons_from("5.0")]
     variants = []
-    types = ["requireApiVersion1", "acceptApiVersion2"]
+    types = ["require v1", "accept v2"]
 
     # All python versions across platforms.
     for python, test_type in product(MIN_MAX_PYTHON, types):

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -23,7 +23,6 @@ from shrub.v3.shrub_service import ShrubService
 ##############
 
 ALL_VERSIONS = ["4.0", "4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"]
-VERSIONS_6_0_PLUS = ["6.0", "7.0", "8.0", "rapid", "latest"]
 CPYTHONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 PYPYS = ["pypy3.9", "pypy3.10"]
 ALL_PYTHONS = CPYTHONS + PYPYS
@@ -110,6 +109,14 @@ def get_python_binary(python: str, host: str) -> str:
         return f"/Library/Frameworks/Python.Framework/Versions/{python}/bin/python3"
 
     raise ValueError(f"no match found for python {python} on {host}")
+
+
+def get_pythons_from(min_version: str) -> list[str]:
+    """Get all pythons starting from a minimum version."""
+    min_version_float = float(min_version)
+    rapid_latest = ["rapid", "latest"]
+    versions = [v for v in ALL_VERSIONS if v not in rapid_latest]
+    return [v for v in versions if float(v) >= min_version_float] + rapid_latest
 
 
 def get_display_name(base: str, host: str, **kwargs) -> str:
@@ -243,7 +250,7 @@ def create_server_variants() -> list[BuildVariant]:
             tasks = [f".{topology}"]
             # MacOS arm64 only works on server versions 6.0+
             if host == "macos-arm64":
-                tasks = [f".{topology} .{version}" for version in VERSIONS_6_0_PLUS]
+                tasks = [f".{topology} .{version}" for version in get_pythons_from("6.0")]
             expansions = dict(AUTH=auth, SSL=ssl, TEST_SUITES=test_suite, SKIP_CSOT_TESTS="true")
             display_name = get_display_name("Test", host, python=python, **expansions)
             variant = create_variant(
@@ -330,7 +337,7 @@ def create_load_balancer_variants():
     task_names = ["load-balancer-test"]
     batchtime = BATCHTIME_WEEK
     expansions_base = dict(test_loadbalancer="true")
-    versions = ["6.0", "7.0", "8.0", "latest", "rapid"]
+    versions = get_pythons_from("6.0")
     variants = []
     pythons = CPYTHONS + PYPYS
     for ind, (version, (auth, ssl)) in enumerate(product(versions, AUTH_SSLS)):
@@ -442,10 +449,42 @@ def create_pyopenssl_variants():
     return variants
 
 
+def create_versioned_api_tests():
+    host = "rhel8"
+    tags = ["versionedApi_tag"]
+    tasks = [f".standalone .{v}" for v in get_pythons_from("5.0")]
+    variants = []
+    types = ["requireApiVersion1", "acceptApiVersion2"]
+
+    # All python versions across platforms.
+    for python, test_type in product(MIN_MAX_PYTHON, types):
+        expansions = dict(AUTH="auth")
+        # Test against a cluster with requireApiVersion=1.
+        if test_type == types[0]:
+            # REQUIRE_API_VERSION is set to make drivers-evergreen-tools
+            # start a cluster with the requireApiVersion parameter.
+            expansions["REQUIRE_API_VERSION"] = "1"
+            # MONGODB_API_VERSION is the apiVersion to use in the test suite.
+            expansions["MONGODB_API_VERSION"] = "1"
+        else:
+            # Test against a cluster with acceptApiVersion2 but without
+            # requireApiVersion, and don't automatically add apiVersion to
+            # clients created in the test suite.
+            expansions["ORCHESTRATION_FILE"] = "versioned-api-testing.json"
+        base_display_name = f"Versioned API {test_type}"
+        display_name = get_display_name(base_display_name, host, python=python, **expansions)
+        variant = create_variant(
+            tasks, display_name, host=host, python=python, tags=tags, expansions=expansions
+        )
+        variants.append(variant)
+
+    return variants
+
+
 ##################
 # Generate Config
 ##################
 
-variants = create_pyopenssl_variants()
+variants = create_versioned_api_tests()
 # print(len(variants))
 generate_yaml(variants=variants)


### PR DESCRIPTION
Before: 20 tasks across 4 build variants
After: 24 tasks across 4 build variants

<img width="203" alt="Versioned API accept v2 RHEL8 py" src="https://github.com/user-attachments/assets/0a14be99-2d2c-4f73-b9ef-3ab4542bc86e">

Passing [build](https://spruce.mongodb.com/version/67129edccfe943000796dac7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)