### PR TITLE
PYTHON-4894 Fix handling of auth test marker

### DIFF
--- a/test/pytest_conf.py
+++ b/test/pytest_conf.py
@@ -10,6 +10,6 @@ def pytest_collection_modifyitems(items, config):
             default_marker = "default_async"
         else:
             default_marker = "default"
-        markers = [m for m in item.iter_markes() if m not in overlap_markers]
+        markers = [m for m in item.iter_markers() if m not in overlap_markers]
         if not markers:
             item.add_marker(default_marker)

--- a/test/pytest_conf.py
+++ b/test/pytest_conf.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 
 def pytest_collection_modifyitems(items, config):
-    sync_items = []
-    async_items = [
-        item
-        for item in items
-        if "asynchronous" in item.fspath.dirname or sync_items.append(item)  # type: ignore[func-returns-value]
-    ]
-    for item in async_items:
-        if not any(item.iter_markers()):
-            item.add_marker("default_async")
-    for item in sync_items:
-        if not any(item.iter_markers()):
-            item.add_marker("default")
+    # Markers that should overlap with the default markers.
+    overlap_markers = ["async"]
+
+    for item in items:
+        if "asynchronous" in item.fspath.dirname:
+            default_marker = "default_async"
+        else:
+            default_marker = "default"
+        markers = [m for m in item.iter_markes() if m not in overlap_markers]
+        if not markers:
+            item.add_marker(default_marker)


### PR DESCRIPTION
Verified with `pytest  --collect-only -q | grep test_auth`.