### PR TITLE
PYTHON-4893 Use shrub.py for aws auth tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3533,6 +3533,7 @@ buildvariants:
   run_on:
     - windows-64-vsMulti-small
   expansions:
+    skip_ECS_auth_test: "true"
     PYTHON_BINARY: C:/python/Python39/python.exe
 - name: aws-auth-win64-py3.13
   tasks:
@@ -3547,6 +3548,7 @@ buildvariants:
   run_on:
     - windows-64-vsMulti-small
   expansions:
+    skip_ECS_auth_test: "true"
     PYTHON_BINARY: C:/python/Python313/python.exe
 - name: aws-auth-macos-py3.9
   tasks:
@@ -3561,6 +3563,7 @@ buildvariants:
   run_on:
     - macos-14
   expansions:
+    skip_ECS_auth_test: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 - name: aws-auth-macos-py3.13
   tasks:
@@ -3575,6 +3578,7 @@ buildvariants:
   run_on:
     - macos-14
   expansions:
+    skip_ECS_auth_test: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
 - matrix_name: "tests-fips"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3492,7 +3492,7 @@ buildvariants:
     PYTHON_BINARY: /opt/python/3.13/bin/python3
 
 # AWS Auth tests.
-- name: aws-auth-rhel8-py3.9
+- name: aws-auth-ubuntu-20-py3.9
   tasks:
     - name: aws-auth-test-4.4
     - name: aws-auth-test-5.0
@@ -3501,12 +3501,12 @@ buildvariants:
     - name: aws-auth-test-8.0
     - name: aws-auth-test-rapid
     - name: aws-auth-test-latest
-  display_name: AWS Auth RHEL8 py3.9
+  display_name: AWS Auth Ubuntu-20 py3.9
   run_on:
-    - rhel87-small
+    - ubuntu2004-small
   expansions:
     PYTHON_BINARY: /opt/python/3.9/bin/python3
-- name: aws-auth-rhel8-py3.13
+- name: aws-auth-ubuntu-20-py3.13
   tasks:
     - name: aws-auth-test-4.4
     - name: aws-auth-test-5.0
@@ -3515,9 +3515,9 @@ buildvariants:
     - name: aws-auth-test-8.0
     - name: aws-auth-test-rapid
     - name: aws-auth-test-latest
-  display_name: AWS Auth RHEL8 py3.13
+  display_name: AWS Auth Ubuntu-20 py3.13
   run_on:
-    - rhel87-small
+    - ubuntu2004-small
   expansions:
     PYTHON_BINARY: /opt/python/3.13/bin/python3
 - name: aws-auth-win64-py3.9

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3564,6 +3564,7 @@ buildvariants:
     - macos-14
   expansions:
     skip_ECS_auth_test: "true"
+    skip_web_identity_auth_test: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 - name: aws-auth-macos-py3.13
   tasks:
@@ -3579,6 +3580,7 @@ buildvariants:
     - macos-14
   expansions:
     skip_ECS_auth_test: "true"
+    skip_web_identity_auth_test: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
 - matrix_name: "tests-fips"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3491,6 +3491,92 @@ buildvariants:
     SSL: ssl
     PYTHON_BINARY: /opt/python/3.13/bin/python3
 
+# AWS Auth tests.
+- name: aws-auth-rhel8-py3.9
+  tasks:
+    - name: aws-auth-test-4.4
+    - name: aws-auth-test-5.0
+    - name: aws-auth-test-6.0
+    - name: aws-auth-test-7.0
+    - name: aws-auth-test-8.0
+    - name: aws-auth-test-rapid
+    - name: aws-auth-test-latest
+  display_name: AWS Auth RHEL8 py3.9
+  run_on:
+    - rhel87-small
+  expansions:
+    PYTHON_BINARY: /opt/python/3.9/bin/python3
+- name: aws-auth-rhel8-py3.13
+  tasks:
+    - name: aws-auth-test-4.4
+    - name: aws-auth-test-5.0
+    - name: aws-auth-test-6.0
+    - name: aws-auth-test-7.0
+    - name: aws-auth-test-8.0
+    - name: aws-auth-test-rapid
+    - name: aws-auth-test-latest
+  display_name: AWS Auth RHEL8 py3.13
+  run_on:
+    - rhel87-small
+  expansions:
+    PYTHON_BINARY: /opt/python/3.13/bin/python3
+- name: aws-auth-win64-py3.9
+  tasks:
+    - name: aws-auth-test-4.4
+    - name: aws-auth-test-5.0
+    - name: aws-auth-test-6.0
+    - name: aws-auth-test-7.0
+    - name: aws-auth-test-8.0
+    - name: aws-auth-test-rapid
+    - name: aws-auth-test-latest
+  display_name: AWS Auth Win64 py3.9
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    PYTHON_BINARY: C:/python/Python39/python.exe
+- name: aws-auth-win64-py3.13
+  tasks:
+    - name: aws-auth-test-4.4
+    - name: aws-auth-test-5.0
+    - name: aws-auth-test-6.0
+    - name: aws-auth-test-7.0
+    - name: aws-auth-test-8.0
+    - name: aws-auth-test-rapid
+    - name: aws-auth-test-latest
+  display_name: AWS Auth Win64 py3.13
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    PYTHON_BINARY: C:/python/Python313/python.exe
+- name: aws-auth-macos-py3.9
+  tasks:
+    - name: aws-auth-test-4.4
+    - name: aws-auth-test-5.0
+    - name: aws-auth-test-6.0
+    - name: aws-auth-test-7.0
+    - name: aws-auth-test-8.0
+    - name: aws-auth-test-rapid
+    - name: aws-auth-test-latest
+  display_name: AWS Auth macOS py3.9
+  run_on:
+    - macos-14
+  expansions:
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: aws-auth-macos-py3.13
+  tasks:
+    - name: aws-auth-test-4.4
+    - name: aws-auth-test-5.0
+    - name: aws-auth-test-6.0
+    - name: aws-auth-test-7.0
+    - name: aws-auth-test-8.0
+    - name: aws-auth-test-rapid
+    - name: aws-auth-test-latest
+  display_name: AWS Auth macOS py3.13
+  run_on:
+    - macos-14
+  expansions:
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+
 - matrix_name: "tests-fips"
   matrix_spec:
     platform:
@@ -3932,47 +4018,6 @@ buildvariants:
   tasks:
     - name: testgcpoidc_task_group
       batchtime: 20160 # Use a batchtime of 14 days as suggested by the CSFLE test README
-
-- matrix_name: "aws-auth-test"
-  matrix_spec:
-    platform: [ubuntu-20.04]
-    python-version: ["3.9"]
-  display_name: "MONGODB-AWS Auth ${platform} ${python-version}"
-  tasks:
-    - name: "aws-auth-test-4.4"
-    - name: "aws-auth-test-5.0"
-    - name: "aws-auth-test-6.0"
-    - name: "aws-auth-test-7.0"
-    - name: "aws-auth-test-8.0"
-    - name: "aws-auth-test-rapid"
-    - name: "aws-auth-test-latest"
-
-- matrix_name: "aws-auth-test-mac"
-  matrix_spec:
-    platform: [macos]
-  display_name: "MONGODB-AWS Auth ${platform} ${python-version-mac}"
-  tasks:
-    - name: "aws-auth-test-4.4"
-    - name: "aws-auth-test-5.0"
-    - name: "aws-auth-test-6.0"
-    - name: "aws-auth-test-7.0"
-    - name: "aws-auth-test-8.0"
-    - name: "aws-auth-test-rapid"
-    - name: "aws-auth-test-latest"
-
-- matrix_name: "aws-auth-test-windows"
-  matrix_spec:
-    platform: [windows]
-    python-version-windows: "*"
-  display_name: "MONGODB-AWS Auth ${platform} ${python-version-windows}"
-  tasks:
-    - name: "aws-auth-test-4.4"
-    - name: "aws-auth-test-5.0"
-    - name: "aws-auth-test-6.0"
-    - name: "aws-auth-test-7.0"
-    - name: "aws-auth-test-8.0"
-    - name: "aws-auth-test-rapid"
-    - name: "aws-auth-test-latest"
 
 - name: testgcpkms-variant
   display_name: "GCP KMS"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3564,6 +3564,7 @@ buildvariants:
     - macos-14
   expansions:
     skip_ECS_auth_test: "true"
+    skip_EC2_auth_test: "true"
     skip_web_identity_auth_test: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 - name: aws-auth-macos-py3.13
@@ -3580,6 +3581,7 @@ buildvariants:
     - macos-14
   expansions:
     skip_ECS_auth_test: "true"
+    skip_EC2_auth_test: "true"
     skip_web_identity_auth_test: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -620,8 +620,15 @@ def generate_aws_auth_variants():
     ]
 
     for host, python in product(["ubuntu20", "win64", "macos"], MIN_MAX_PYTHON):
+        expansions = dict()
+        if host != "ubuntu20":
+            expansions["skip_ECS_auth_test"] = "true"
         variant = create_variant(
-            tasks, get_display_name("AWS Auth", host, python=python), host=host, python=python
+            tasks,
+            get_display_name("AWS Auth", host, python=python),
+            host=host,
+            python=python,
+            expansions=expansions,
         )
         variants.append(variant)
     return variants

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -623,6 +623,9 @@ def generate_aws_auth_variants():
         expansions = dict()
         if host != "ubuntu20":
             expansions["skip_ECS_auth_test"] = "true"
+        if host == "macos":
+            expansions["skip_ECS_auth_test"] = "true"
+            expansions["skip_web_identity_auth_test"] = "true"
         variant = create_variant(
             tasks,
             get_display_name("AWS Auth", host, python=python),

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -54,6 +54,7 @@ HOSTS["win64"] = Host("win64", "windows-64-vsMulti-small", "Win64")
 HOSTS["win32"] = Host("win32", "windows-64-vsMulti-small", "Win32")
 HOSTS["macos"] = Host("macos", "macos-14", "macOS")
 HOSTS["macos-arm64"] = Host("macos-arm64", "macos-14-arm64", "macOS Arm64")
+HOSTS["ubuntu20"] = Host("ubuntu20", "ubuntu2004-small", "Ubuntu-20")
 HOSTS["ubuntu22"] = Host("ubuntu22", "ubuntu2204-small", "Ubuntu-22")
 
 
@@ -103,7 +104,7 @@ def get_python_binary(python: str, host: str) -> str:
         python = python.replace(".", "")
         return f"{base}/Python{python}/python.exe"
 
-    if host in ["rhel8", "ubuntu22"]:
+    if host in ["rhel8", "ubuntu22", "ubuntu20"]:
         return f"/opt/python/{python}/bin/python3"
 
     if host in ["macos", "macos-arm64"]:
@@ -618,7 +619,7 @@ def generate_aws_auth_variants():
         "aws-auth-test-latest",
     ]
 
-    for host, python in product(["rhel8", "win64", "macos"], MIN_MAX_PYTHON):
+    for host, python in product(["ubuntu20", "win64", "macos"], MIN_MAX_PYTHON):
         variant = create_variant(
             tasks, get_display_name("AWS Auth", host, python=python), host=host, python=python
         )

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -624,7 +624,7 @@ def generate_aws_auth_variants():
         if host != "ubuntu20":
             expansions["skip_ECS_auth_test"] = "true"
         if host == "macos":
-            expansions["skip_ECS_auth_test"] = "true"
+            expansions["skip_EC2_auth_test"] = "true"
             expansions["skip_web_identity_auth_test"] = "true"
         variant = create_variant(
             tasks,

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -606,10 +606,30 @@ def generate_serverless_variants():
     ]
 
 
+def generate_aws_auth_variants():
+    variants = []
+    tasks = [
+        "aws-auth-test-4.4",
+        "aws-auth-test-5.0",
+        "aws-auth-test-6.0",
+        "aws-auth-test-7.0",
+        "aws-auth-test-8.0",
+        "aws-auth-test-rapid",
+        "aws-auth-test-latest",
+    ]
+
+    for host, python in product(["rhel8", "win64", "macos"], MIN_MAX_PYTHON):
+        variant = create_variant(
+            tasks, get_display_name("AWS Auth", host, python=python), host=host, python=python
+        )
+        variants.append(variant)
+    return variants
+
+
 ##################
 # Generate Config
 ##################
 
-variants = generate_serverless_variants()
+variants = generate_aws_auth_variants()
 # print(len(variants))
 generate_yaml(variants=variants)


### PR DESCRIPTION
Before: 49 tasks across 7 build variants
Covered all cpython versions across the three hosts.

After: 42 tasks across 6 build variants, min and max cpython versions.

<img width="163" alt="Pasted Graphic 17" src="https://github.com/user-attachments/assets/ad74e27a-2cf7-4411-a8fd-4257f40f7f32">

Patch [build](https://spruce.mongodb.com/version/6716a697ddc5920007831646/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
