### PR TITLE
PYTHON-4898 Ensure consistent versions of tests across hosts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2172,7 +2172,7 @@ axes:
           PYTHON_BINARY: "C:/python/Python313/python.exe"
 
 buildvariants:
-# Server Tests for RHEL8.
+# Server Tests.
 - name: test-rhel8-py3.9-auth-ssl-cov
   tasks:
     - name: .standalone
@@ -2339,8 +2339,6 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-
-# Server tests for MacOS.
 - name: test-macos-py3.9-auth-ssl-sync
   tasks:
     - name: .standalone
@@ -2351,8 +2349,32 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-py3.9-noauth-ssl-sync
+  tasks:
+    - name: .standalone
+  display_name: Test macOS py3.9 NoAuth SSL Sync
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-py3.9-noauth-nossl-sync
+  tasks:
+    - name: .standalone
+  display_name: Test macOS py3.9 NoAuth NoSSL Sync
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 - name: test-macos-py3.9-auth-ssl-async
   tasks:
     - name: .standalone
@@ -2363,47 +2385,23 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-    SKIP_CSOT_TESTS: "true"
-- name: test-macos-py3.13-noauth-ssl-sync
+- name: test-macos-py3.9-noauth-ssl-async
   tasks:
-    - name: .replica_set
-  display_name: Test macOS py3.13 NoAuth SSL Sync
-  run_on:
-    - macos-14
-  expansions:
-    AUTH: noauth
-    SSL: ssl
-    TEST_SUITES: default
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-    SKIP_CSOT_TESTS: "true"
-- name: test-macos-py3.13-noauth-ssl-async
-  tasks:
-    - name: .replica_set
-  display_name: Test macOS py3.13 NoAuth SSL Async
+    - name: .standalone
+  display_name: Test macOS py3.9 NoAuth SSL Async
   run_on:
     - macos-14
   expansions:
     AUTH: noauth
     SSL: ssl
     TEST_SUITES: default_async
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
     SKIP_CSOT_TESTS: "true"
-- name: test-macos-py3.9-noauth-nossl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test macOS py3.9 NoAuth NoSSL Sync
-  run_on:
-    - macos-14
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-    SKIP_CSOT_TESTS: "true"
 - name: test-macos-py3.9-noauth-nossl-async
   tasks:
-    - name: .sharded_cluster
+    - name: .standalone
   display_name: Test macOS py3.9 NoAuth NoSSL Async
   run_on:
     - macos-14
@@ -2411,10 +2409,80 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     TEST_SUITES: default_async
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     SKIP_CSOT_TESTS: "true"
-
-# Server tests for macOS Arm64.
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-py3.13-auth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 Auth SSL Sync
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-py3.13-noauth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 NoAuth SSL Sync
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-py3.13-noauth-nossl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 NoAuth NoSSL Sync
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-py3.13-auth-ssl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 Auth SSL Async
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-py3.13-noauth-ssl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 NoAuth SSL Async
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-py3.13-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test macOS py3.13 NoAuth NoSSL Async
+  run_on:
+    - macos-14
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 - name: test-macos-arm64-py3.9-auth-ssl-sync
   tasks:
     - name: .standalone .6.0
@@ -2428,6 +2496,38 @@ buildvariants:
   expansions:
     AUTH: auth
     SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-arm64-py3.9-noauth-ssl-sync
+  tasks:
+    - name: .standalone .6.0
+    - name: .standalone .7.0
+    - name: .standalone .8.0
+    - name: .standalone .rapid
+    - name: .standalone .latest
+  display_name: Test macOS Arm64 py3.9 NoAuth SSL Sync
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
+- name: test-macos-arm64-py3.9-noauth-nossl-sync
+  tasks:
+    - name: .standalone .6.0
+    - name: .standalone .7.0
+    - name: .standalone .8.0
+    - name: .standalone .rapid
+    - name: .standalone .latest
+  display_name: Test macOS Arm64 py3.9 NoAuth NoSSL Sync
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: nossl
     TEST_SUITES: default
     SKIP_CSOT_TESTS: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
@@ -2447,30 +2547,14 @@ buildvariants:
     TEST_SUITES: default_async
     SKIP_CSOT_TESTS: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-- name: test-macos-arm64-py3.13-noauth-ssl-sync
+- name: test-macos-arm64-py3.9-noauth-ssl-async
   tasks:
-    - name: .replica_set .6.0
-    - name: .replica_set .7.0
-    - name: .replica_set .8.0
-    - name: .replica_set .rapid
-    - name: .replica_set .latest
-  display_name: Test macOS Arm64 py3.13 NoAuth SSL Sync
-  run_on:
-    - macos-14-arm64
-  expansions:
-    AUTH: noauth
-    SSL: ssl
-    TEST_SUITES: default
-    SKIP_CSOT_TESTS: "true"
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-- name: test-macos-arm64-py3.13-noauth-ssl-async
-  tasks:
-    - name: .replica_set .6.0
-    - name: .replica_set .7.0
-    - name: .replica_set .8.0
-    - name: .replica_set .rapid
-    - name: .replica_set .latest
-  display_name: Test macOS Arm64 py3.13 NoAuth SSL Async
+    - name: .standalone .6.0
+    - name: .standalone .7.0
+    - name: .standalone .8.0
+    - name: .standalone .rapid
+    - name: .standalone .latest
+  display_name: Test macOS Arm64 py3.9 NoAuth SSL Async
   run_on:
     - macos-14-arm64
   expansions:
@@ -2478,30 +2562,14 @@ buildvariants:
     SSL: ssl
     TEST_SUITES: default_async
     SKIP_CSOT_TESTS: "true"
-    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-- name: test-macos-arm64-py3.9-noauth-nossl-sync
-  tasks:
-    - name: .sharded_cluster .6.0
-    - name: .sharded_cluster .7.0
-    - name: .sharded_cluster .8.0
-    - name: .sharded_cluster .rapid
-    - name: .sharded_cluster .latest
-  display_name: Test macOS Arm64 py3.9 NoAuth NoSSL Sync
-  run_on:
-    - macos-14-arm64
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default
-    SKIP_CSOT_TESTS: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
 - name: test-macos-arm64-py3.9-noauth-nossl-async
   tasks:
-    - name: .sharded_cluster .6.0
-    - name: .sharded_cluster .7.0
-    - name: .sharded_cluster .8.0
-    - name: .sharded_cluster .rapid
-    - name: .sharded_cluster .latest
+    - name: .standalone .6.0
+    - name: .standalone .7.0
+    - name: .standalone .8.0
+    - name: .standalone .rapid
+    - name: .standalone .latest
   display_name: Test macOS Arm64 py3.9 NoAuth NoSSL Async
   run_on:
     - macos-14-arm64
@@ -2511,8 +2579,102 @@ buildvariants:
     TEST_SUITES: default_async
     SKIP_CSOT_TESTS: "true"
     PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-
-# Server tests for Windows.
+- name: test-macos-arm64-py3.13-auth-ssl-sync
+  tasks:
+    - name: .sharded_cluster .6.0
+    - name: .sharded_cluster .7.0
+    - name: .sharded_cluster .8.0
+    - name: .sharded_cluster .rapid
+    - name: .sharded_cluster .latest
+  display_name: Test macOS Arm64 py3.13 Auth SSL Sync
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-arm64-py3.13-noauth-ssl-sync
+  tasks:
+    - name: .sharded_cluster .6.0
+    - name: .sharded_cluster .7.0
+    - name: .sharded_cluster .8.0
+    - name: .sharded_cluster .rapid
+    - name: .sharded_cluster .latest
+  display_name: Test macOS Arm64 py3.13 NoAuth SSL Sync
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-arm64-py3.13-noauth-nossl-sync
+  tasks:
+    - name: .sharded_cluster .6.0
+    - name: .sharded_cluster .7.0
+    - name: .sharded_cluster .8.0
+    - name: .sharded_cluster .rapid
+    - name: .sharded_cluster .latest
+  display_name: Test macOS Arm64 py3.13 NoAuth NoSSL Sync
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-arm64-py3.13-auth-ssl-async
+  tasks:
+    - name: .sharded_cluster .6.0
+    - name: .sharded_cluster .7.0
+    - name: .sharded_cluster .8.0
+    - name: .sharded_cluster .rapid
+    - name: .sharded_cluster .latest
+  display_name: Test macOS Arm64 py3.13 Auth SSL Async
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-arm64-py3.13-noauth-ssl-async
+  tasks:
+    - name: .sharded_cluster .6.0
+    - name: .sharded_cluster .7.0
+    - name: .sharded_cluster .8.0
+    - name: .sharded_cluster .rapid
+    - name: .sharded_cluster .latest
+  display_name: Test macOS Arm64 py3.13 NoAuth SSL Async
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
+- name: test-macos-arm64-py3.13-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster .6.0
+    - name: .sharded_cluster .7.0
+    - name: .sharded_cluster .8.0
+    - name: .sharded_cluster .rapid
+    - name: .sharded_cluster .latest
+  display_name: Test macOS Arm64 py3.13 NoAuth NoSSL Async
+  run_on:
+    - macos-14-arm64
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 - name: test-win64-py3.9-auth-ssl-sync
   tasks:
     - name: .standalone
@@ -2523,8 +2685,32 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default
-    PYTHON_BINARY: C:/python/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python39/python.exe
+- name: test-win64-py3.9-noauth-ssl-sync
+  tasks:
+    - name: .standalone
+  display_name: Test Win64 py3.9 NoAuth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python39/python.exe
+- name: test-win64-py3.9-noauth-nossl-sync
+  tasks:
+    - name: .standalone
+  display_name: Test Win64 py3.9 NoAuth NoSSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python39/python.exe
 - name: test-win64-py3.9-auth-ssl-async
   tasks:
     - name: .standalone
@@ -2535,47 +2721,23 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
     PYTHON_BINARY: C:/python/Python39/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-py3.13-noauth-ssl-sync
+- name: test-win64-py3.9-noauth-ssl-async
   tasks:
-    - name: .replica_set
-  display_name: Test Win64 py3.13 NoAuth SSL Sync
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: noauth
-    SSL: ssl
-    TEST_SUITES: default
-    PYTHON_BINARY: C:/python/Python313/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win64-py3.13-noauth-ssl-async
-  tasks:
-    - name: .replica_set
-  display_name: Test Win64 py3.13 NoAuth SSL Async
+    - name: .standalone
+  display_name: Test Win64 py3.9 NoAuth SSL Async
   run_on:
     - windows-64-vsMulti-small
   expansions:
     AUTH: noauth
     SSL: ssl
     TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/Python313/python.exe
     SKIP_CSOT_TESTS: "true"
-- name: test-win64-py3.9-noauth-nossl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win64 py3.9 NoAuth NoSSL Sync
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default
     PYTHON_BINARY: C:/python/Python39/python.exe
-    SKIP_CSOT_TESTS: "true"
 - name: test-win64-py3.9-noauth-nossl-async
   tasks:
-    - name: .sharded_cluster
+    - name: .standalone
   display_name: Test Win64 py3.9 NoAuth NoSSL Async
   run_on:
     - windows-64-vsMulti-small
@@ -2583,8 +2745,80 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python39/python.exe
+- name: test-win64-py3.13-auth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py3.13 Auth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python313/python.exe
+- name: test-win64-py3.13-noauth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py3.13 NoAuth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python313/python.exe
+- name: test-win64-py3.13-noauth-nossl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py3.13 NoAuth NoSSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python313/python.exe
+- name: test-win64-py3.13-auth-ssl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py3.13 Auth SSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python313/python.exe
+- name: test-win64-py3.13-noauth-ssl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py3.13 NoAuth SSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python313/python.exe
+- name: test-win64-py3.13-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win64 py3.13 NoAuth NoSSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/Python313/python.exe
 - name: test-win32-py3.9-auth-ssl-sync
   tasks:
     - name: .standalone
@@ -2595,10 +2829,32 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default
-    PYTHON_BINARY: C:/python/32/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
-
-# Server tests for Win32.
+    PYTHON_BINARY: C:/python/32/Python39/python.exe
+- name: test-win32-py3.9-noauth-ssl-sync
+  tasks:
+    - name: .standalone
+  display_name: Test Win32 py3.9 NoAuth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/32/Python39/python.exe
+- name: test-win32-py3.9-noauth-nossl-sync
+  tasks:
+    - name: .standalone
+  display_name: Test Win32 py3.9 NoAuth NoSSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/32/Python39/python.exe
 - name: test-win32-py3.9-auth-ssl-async
   tasks:
     - name: .standalone
@@ -2609,47 +2865,23 @@ buildvariants:
     AUTH: auth
     SSL: ssl
     TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
     PYTHON_BINARY: C:/python/32/Python39/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win32-py3.13-noauth-ssl-sync
+- name: test-win32-py3.9-noauth-ssl-async
   tasks:
-    - name: .replica_set
-  display_name: Test Win32 py3.13 NoAuth SSL Sync
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: noauth
-    SSL: ssl
-    TEST_SUITES: default
-    PYTHON_BINARY: C:/python/32/Python313/python.exe
-    SKIP_CSOT_TESTS: "true"
-- name: test-win32-py3.13-noauth-ssl-async
-  tasks:
-    - name: .replica_set
-  display_name: Test Win32 py3.13 NoAuth SSL Async
+    - name: .standalone
+  display_name: Test Win32 py3.9 NoAuth SSL Async
   run_on:
     - windows-64-vsMulti-small
   expansions:
     AUTH: noauth
     SSL: ssl
     TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/32/Python313/python.exe
     SKIP_CSOT_TESTS: "true"
-- name: test-win32-py3.9-noauth-nossl-sync
-  tasks:
-    - name: .sharded_cluster
-  display_name: Test Win32 py3.9 NoAuth NoSSL Sync
-  run_on:
-    - windows-64-vsMulti-small
-  expansions:
-    AUTH: noauth
-    SSL: nossl
-    TEST_SUITES: default
     PYTHON_BINARY: C:/python/32/Python39/python.exe
-    SKIP_CSOT_TESTS: "true"
 - name: test-win32-py3.9-noauth-nossl-async
   tasks:
-    - name: .sharded_cluster
+    - name: .standalone
   display_name: Test Win32 py3.9 NoAuth NoSSL Async
   run_on:
     - windows-64-vsMulti-small
@@ -2657,8 +2889,80 @@ buildvariants:
     AUTH: noauth
     SSL: nossl
     TEST_SUITES: default_async
-    PYTHON_BINARY: C:/python/32/Python39/python.exe
     SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/32/Python39/python.exe
+- name: test-win32-py3.13-auth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win32 py3.13 Auth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+- name: test-win32-py3.13-noauth-ssl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win32 py3.13 NoAuth SSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+- name: test-win32-py3.13-noauth-nossl-sync
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win32 py3.13 NoAuth NoSSL Sync
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+- name: test-win32-py3.13-auth-ssl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win32 py3.13 Auth SSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: auth
+    SSL: ssl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+- name: test-win32-py3.13-noauth-ssl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win32 py3.13 NoAuth SSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: ssl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
+- name: test-win32-py3.13-noauth-nossl-async
+  tasks:
+    - name: .sharded_cluster
+  display_name: Test Win32 py3.13 NoAuth NoSSL Async
+  run_on:
+    - windows-64-vsMulti-small
+  expansions:
+    AUTH: noauth
+    SSL: nossl
+    TEST_SUITES: default_async
+    SKIP_CSOT_TESTS: "true"
+    PYTHON_BINARY: C:/python/32/Python313/python.exe
 
 # Encryption tests.
 - name: encryption-rhel8-py3.9-auth-ssl

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -254,10 +254,13 @@ def create_server_variants() -> list[BuildVariant]:
 
     # Test a subset on each of the other platforms.
     for host in ("macos", "macos-arm64", "win64", "win32"):
-        for (python, (auth, ssl), topology), sync in product(
-            zip_cycle(MIN_MAX_PYTHON, AUTH_SSLS, TOPOLOGIES), SYNCS
-        ):
+        for (
+            python,
+            sync,
+            (auth, ssl),
+        ) in product(MIN_MAX_PYTHON, SYNCS, AUTH_SSLS):
             test_suite = "default" if sync == "sync" else "default_async"
+            topology = TOPOLOGIES[0] if python == CPYTHONS[0] else TOPOLOGIES[-1]
             tasks = [f".{topology}"]
             # MacOS arm64 only works on server versions 6.0+
             if host == "macos-arm64":
@@ -610,6 +613,6 @@ def generate_serverless_variants():
 # Generate Config
 ##################
 
-variants = generate_serverless_variants()
+variants = create_server_variants()
 # print(len(variants))
 generate_yaml(variants=variants)


### PR DESCRIPTION
We'll be able to reduce the number of variants again once we start automating tasks, which will allow us to put auth and ssl in the task definitions.