### PR TITLE
PYTHON-2926 Updated signature of Binary.from_vector to take a BinaryVector

### DIFF
--- a/bson/binary.py
+++ b/bson/binary.py
@@ -426,7 +426,7 @@ class Binary(bytes):
                 )
             dtype = vector.dtype
             padding = vector.padding
-            vector = vector.data
+            vector = vector.data  # type: ignore
 
         padding = 0 if padding is None else padding
         if dtype == BinaryVectorDtype.INT8:  # pack ints in [-128, 127] as signed int8
@@ -443,7 +443,7 @@ class Binary(bytes):
             raise NotImplementedError("%s not yet supported" % dtype)
 
         metadata = struct.pack("<sB", dtype.value, padding)
-        data = struct.pack(f"<{len(vector)}{format_str}", *vector)
+        data = struct.pack(f"<{len(vector)}{format_str}", *vector)  # type: ignore
         return cls(metadata + data, subtype=VECTOR_SUBTYPE)
 
     def as_vector(self) -> BinaryVector:

--- a/bson/binary.py
+++ b/bson/binary.py
@@ -404,14 +404,14 @@ class Binary(bytes):
         dtype: Optional[BinaryVectorDtype] = None,
         padding: Optional[int] = None,
     ) -> Binary:
-        """**(BETA)** Create a BSON :class:`~bson.binary.Binary` of Vector subtype from a list of Numbers.
+        """**(BETA)** Create a BSON :class:`~bson.binary.Binary` of Vector subtype.
 
         To interpret the representation of the numbers, a data type must be included.
         See :class:`~bson.binary.BinaryVectorDtype` for available types and descriptions.
 
         The dtype and padding are prepended to the binary data's value.
 
-        :param vector: List of values
+        :param vector: Either a List of values, or a :class:`~bson.binary.BinaryVector` dataclass.
         :param dtype: Data type of the values
         :param padding: For fractional bytes, number of bits to ignore at end of vector.
         :return: Binary packed data identified by dtype and padding.

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -51,7 +51,13 @@ from bson import (
     is_valid,
     json_util,
 )
-from bson.binary import USER_DEFINED_SUBTYPE, Binary, BinaryVectorDtype, UuidRepresentation
+from bson.binary import (
+    USER_DEFINED_SUBTYPE,
+    Binary,
+    BinaryVector,
+    BinaryVectorDtype,
+    UuidRepresentation,
+)
 from bson.code import Code
 from bson.codec_options import CodecOptions, DatetimeConversion
 from bson.datetime_ms import _DATETIME_ERROR_SUGGESTION
@@ -784,6 +790,18 @@ class TestBSON(unittest.TestCase):
                 self.assertTrue(isinstance(exc, struct.error))
             else:
                 self.fail("Failed to raise an exception.")
+
+        # Test form of Binary.from_vector(BinaryVector)
+
+        assert padded_vec == Binary.from_vector(
+            BinaryVector(list_vector, BinaryVectorDtype.PACKED_BIT, padding)
+        )
+        assert binary_vector == Binary.from_vector(
+            BinaryVector(list_vector, BinaryVectorDtype.INT8)
+        )
+        assert float_binary == Binary.from_vector(
+            BinaryVector(list_vector, BinaryVectorDtype.FLOAT32)
+        )
 
     def test_unicode_regex(self):
         """Tests we do not get a segfault for C extension on unicode RegExs.


### PR DESCRIPTION
Backward-compatible change of `Binary.from_vector` to take the BinaryVector dataclass as an alternative to separate list, dtype, and padding.