### PR TITLE
PYTHON-4766 - Fix logic for determining whether to populate BulkWriteException.partialResult

### DIFF
--- a/test/crud/unified/client-bulkWrite-partialResults.json
+++ b/test/crud/unified/client-bulkWrite-partialResults.json
@@ -486,7 +486,7 @@
       ]
     },
     {
-      "description": "partialResult is set when first operation fails during an unordered bulk write (summary)",
+      "description": "partialResult is set when second operation fails during an unordered bulk write (summary)",
       "operations": [
         {
           "object": "client0",


### PR DESCRIPTION
Our implementation already used the correct logic, so this is purely adding the new spec tests (thanks Shruti!)