### PR TITLE
PYTHON-4885 Fix legacy extended JSON encoding of DatetimeMS

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -617,25 +617,28 @@ def _parse_canonical_datetime(
         raise TypeError(f"Bad $date, extra field(s): {doc}")
     # mongoexport 2.6 and newer
     if isinstance(dtm, str):
-        # Parse offset
-        if dtm[-1] == "Z":
-            dt = dtm[:-1]
-            offset = "Z"
-        elif dtm[-6] in ("+", "-") and dtm[-3] == ":":
-            # (+|-)HH:MM
-            dt = dtm[:-6]
-            offset = dtm[-6:]
-        elif dtm[-5] in ("+", "-"):
-            # (+|-)HHMM
-            dt = dtm[:-5]
-            offset = dtm[-5:]
-        elif dtm[-3] in ("+", "-"):
-            # (+|-)HH
-            dt = dtm[:-3]
-            offset = dtm[-3:]
-        else:
-            dt = dtm
-            offset = ""
+        try:
+            # Parse offset
+            if dtm[-1] == "Z":
+                dt = dtm[:-1]
+                offset = "Z"
+            elif dtm[-6] in ("+", "-") and dtm[-3] == ":":
+                # (+|-)HH:MM
+                dt = dtm[:-6]
+                offset = dtm[-6:]
+            elif dtm[-5] in ("+", "-"):
+                # (+|-)HHMM
+                dt = dtm[:-5]
+                offset = dtm[-5:]
+            elif dtm[-3] in ("+", "-"):
+                # (+|-)HH
+                dt = dtm[:-3]
+                offset = dtm[-3:]
+            else:
+                dt = dtm
+                offset = ""
+        except IndexError as exc:
+            raise ValueError(f"time data {dtm!r} does not match ISO-8601 datetime format") from exc
 
         # Parse the optional factional seconds portion.
         dot_index = dt.rfind(".")
@@ -848,7 +851,7 @@ def _encode_datetimems(obj: Any, json_options: JSONOptions) -> dict:
     ):
         return _encode_datetime(obj.as_datetime(), json_options)
     elif json_options.datetime_representation == DatetimeRepresentation.LEGACY:
-        return {"$date": str(int(obj))}
+        return {"$date": int(obj)}
     return {"$date": {"$numberLong": str(int(obj))}}
 
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -28,6 +28,11 @@ PyMongo 4.11 brings a number of changes including:
   :meth:`~pymongo.asynchronous.mongo_client.AsyncMongoClient.bulk_write` now throw an error
   when ``ordered=True`` or ``verboseResults=True`` are used with unacknowledged writes.
   These are unavoidable breaking changes.
+- Fixed a bug in :const:`bson.json_util.dumps` where a :class:`bson.datetime_ms.DatetimeMS` would
+  be incorrectly encoded as ``'{"$date": "X"}'`` instead of ``'{"$date": X}'`` when using the
+  legacy MongoDB Extended JSON datetime representation.
+- Fixed a bug where :const:`bson.json_util.loads` would raise an IndexError when parsing an invalid
+  ``"$date"`` instead of a ValueError.
 
 Issues Resolved
 ...............

--- a/test/test_json_util.py
+++ b/test/test_json_util.py
@@ -137,7 +137,7 @@ class TestJsonUtil(unittest.TestCase):
             '{"dt": { "$date" : "1970-01-01T00:00:00.000Z"}}',
             '{"dt": { "$date" : "1970-01-01T00:00:00.000000Z"}}',
             '{"dt": { "$date" : "1970-01-01T00:00:00Z"}}',
-            '{"dt": {"$date": "1970-01-01T00:00:00.000"}}',
+            '{"dt": { "$date" : "1970-01-01T00:00:00.000"}}',
             '{"dt": { "$date" : "1970-01-01T00:00:00"}}',
             '{"dt": { "$date" : "1970-01-01T00:00:00.000000"}}',
             '{"dt": { "$date" : "1969-12-31T16:00:00.000-0800"}}',
@@ -282,9 +282,9 @@ class TestJsonUtil(unittest.TestCase):
         opts = JSONOptions(
             datetime_representation=DatetimeRepresentation.LEGACY, json_mode=JSONMode.LEGACY
         )
-        self.assertEqual('{"x": {"$date": "-1"}}', json_util.dumps(dat_min, json_options=opts))
+        self.assertEqual('{"x": {"$date": -1}}', json_util.dumps(dat_min, json_options=opts))
         self.assertEqual(
-            '{"x": {"$date": "' + str(int(dat_max["x"])) + '"}}',
+            '{"x": {"$date": ' + str(int(dat_max["x"])) + "}}",
             json_util.dumps(dat_max, json_options=opts),
         )
 
@@ -316,6 +316,25 @@ class TestJsonUtil(unittest.TestCase):
             DatetimeMS(dat_max["x"]),
             json_util.loads(json_util.dumps(dat_max), json_options=opts)["x"],
         )
+
+    def test_parse_invalid_date(self):
+        # These cases should raise ValueError, not IndexError.
+        for invalid in [
+            '{"dt": { "$date" : "1970-01-01T00:00:"}}',
+            '{"dt": { "$date" : "1970-01-01T01:00"}}',
+            '{"dt": { "$date" : "1970-01-01T01:"}}',
+            '{"dt": { "$date" : "1970-01-01T01"}}',
+            '{"dt": { "$date" : "1970-01-01T"}}',
+            '{"dt": { "$date" : "1970-01-01"}}',
+            '{"dt": { "$date" : "1970-01-"}}',
+            '{"dt": { "$date" : "1970-01"}}',
+            '{"dt": { "$date" : "1970-"}}',
+            '{"dt": { "$date" : "1970"}}',
+            '{"dt": { "$date" : "1"}}',
+            '{"dt": { "$date" : ""}}',
+        ]:
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                json_util.loads(invalid)
 
     def test_regex_object_hook(self):
         # Extended JSON format regular expression.


### PR DESCRIPTION
PYTHON-4885 Fix legacy extended JSON encoding of DatetimeMS

Note I opted _not_ to introduce logic to parse previously encoded invalid "$date" data for a few reasons:

1. It's not clear if that behavior would be useful. No one has reported this as an issue.
1. We can always introduce it later if we get new info that it's required.
1. Adding it is problematic since it's invalid. We don't know if the data is genuinly invalid or a result of the encoding bug. For example, does the user intend this `'{"dt": { "$date" : "1970"}}'` to be the year 1970 or is it 1970 milliseconds after the epoch?   

Old behavior:
```python
>>> dumps({'d': DatetimeMS(1)}, json_options=LEGACY_JSON_OPTIONS)
'{"d": {"$date": "1"}}'
```
New behavior:
```python
>>> dumps({'d': DatetimeMS(1)}, json_options=LEGACY_JSON_OPTIONS)
'{"d": {"$date": 1}}'
```

This PR also fixes a bug in the parsing logic where we would incorrectly raise an IndexError on invalid $date:

Old behavior:
```python
>>> loads('{"dt": { "$date" : "1"}}')
Traceback (most recent call last):
...
  File "/Users/shane/git/mongo-python-driver/bson/json_util.py", line 624, in _parse_canonical_datetime
    elif dtm[-6] in ("+", "-") and dtm[-3] == ":":
         ~~~^^^^
IndexError: string index out of range
```
New behavior:
```python
>>> loads('{"dt": { "$date" : "1"}}')
Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/bson/json_util.py", line 625, in _parse_canonical_datetime
    elif dtm[-6] in ("+", "-") and dtm[-3] == ":":
         ~~~^^^^
IndexError: string index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
...
  File "/Users/shane/git/mongo-python-driver/bson/json_util.py", line 641, in _parse_canonical_datetime
    raise ValueError(f"time data {dtm!r} does not match ISO-8601 datetime format") from exc
ValueError: time data '1' does not match ISO-8601 datetime format
```