### PR TITLE
PYTHON-4943 Clean up EVG Variant Display Names

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1779,19 +1779,14 @@ buildvariants:
   tasks:
      - name: "coverage-report"
 
-- name: testgcpkms-variant
-  display_name: "GCP KMS"
+- name: testkms-variant
+  display_name: "KMS"
   run_on:
     - debian11-small
   tasks:
     - name: testgcpkms_task_group
       batchtime: 20160 # Use a batchtime of 14 days as suggested by the CSFLE test README
     - testgcpkms-fail-task
-
-- name: testazurekms-variant
-  display_name: "Azure KMS"
-  run_on: debian11-small
-  tasks:
     - name: testazurekms_task_group
       batchtime: 20160 # Use a batchtime of 14 days as suggested by the CSFLE test README
     - testazurekms-fail-task

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1727,7 +1727,7 @@ tasks:
 
 buildvariants:
 - name: "no-server"
-  display_name: "No server test"
+  display_name: "No server"
   run_on:
     - rhel84-small
   tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1792,13 +1792,13 @@ buildvariants:
     - testazurekms-fail-task
 
 - name: rhel8-test-lambda
-  display_name: AWS Lambda handler tests
+  display_name: FaaS Lambda
   run_on: rhel87-small
   tasks:
     - name: test_aws_lambda_task_group
 
 - name: rhel8-import-time
-  display_name: Import Time Check
+  display_name: Import Time
   run_on: rhel87-small
   tasks:
     - name: "check-import-time"
@@ -1811,7 +1811,7 @@ buildvariants:
     - name: "backport-pr"
 
 - name: "perf-tests"
-  display_name: "Performance Benchmark Tests"
+  display_name: "Performance Benchmarks"
   batchtime: 10080  # 7 days
   run_on: rhel90-dbx-perf-large
   tasks:

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1070,7 +1070,7 @@ buildvariants:
       PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Server tests
-  - name: "*-test-rhel8-py3.9-cov"
+  - name: test-rhel8-py3.9-cov
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
@@ -1082,7 +1082,7 @@ buildvariants:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [coverage_tag]
-  - name: "*-test-rhel8-py3.13-cov"
+  - name: test-rhel8-py3.13-cov
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
@@ -1094,7 +1094,7 @@ buildvariants:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [coverage_tag]
-  - name: "*-test-rhel8-pypy3.10-cov"
+  - name: test-rhel8-pypy3.10-cov
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
@@ -1106,7 +1106,7 @@ buildvariants:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [coverage_tag]
-  - name: "*-test-rhel8-py3.10"
+  - name: test-rhel8-py3.10
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
@@ -1117,7 +1117,7 @@ buildvariants:
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: "*-test-rhel8-py3.11"
+  - name: test-rhel8-py3.11
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
@@ -1128,7 +1128,7 @@ buildvariants:
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: "*-test-rhel8-py3.12"
+  - name: test-rhel8-py3.12
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
@@ -1139,7 +1139,7 @@ buildvariants:
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: "*-test-rhel8-pypy3.9"
+  - name: test-rhel8-pypy3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
@@ -1150,7 +1150,7 @@ buildvariants:
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-  - name: "*-test-macos-py3.9"
+  - name: test-macos-py3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
@@ -1161,7 +1161,7 @@ buildvariants:
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: "*-test-macos-py3.13"
+  - name: test-macos-py3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
@@ -1172,7 +1172,7 @@ buildvariants:
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-  - name: "*-test-macos-arm64-py3.9"
+  - name: test-macos-arm64-py3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
       - name: .replica_set .noauth .ssl .6.0 !.sync_async
@@ -1195,7 +1195,7 @@ buildvariants:
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: "*-test-macos-arm64-py3.13"
+  - name: test-macos-arm64-py3.13
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
       - name: .replica_set .noauth .ssl .6.0 !.sync_async
@@ -1218,7 +1218,7 @@ buildvariants:
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-  - name: "*-test-win64-py3.9"
+  - name: test-win64-py3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
@@ -1229,7 +1229,7 @@ buildvariants:
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: C:/python/Python39/python.exe
-  - name: "*-test-win64-py3.13"
+  - name: test-win64-py3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
@@ -1240,7 +1240,7 @@ buildvariants:
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: C:/python/Python313/python.exe
-  - name: "*-test-win32-py3.9"
+  - name: test-win32-py3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
@@ -1251,7 +1251,7 @@ buildvariants:
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: C:/python/32/Python39/python.exe
-  - name: "*-test-win32-py3.13"
+  - name: test-win32-py3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -106,7 +106,7 @@ buildvariants:
       PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Aws auth tests
-  - name: aws-auth-ubuntu-20-py3.9
+  - name: auth-aws-ubuntu-20-py3.9
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -115,12 +115,12 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: AWS Auth Ubuntu-20 py3.9
+    display_name: Auth AWS Ubuntu-20 py3.9
     run_on:
       - ubuntu2004-small
     expansions:
       PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: aws-auth-ubuntu-20-py3.13
+  - name: auth-aws-ubuntu-20-py3.13
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -129,12 +129,12 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: AWS Auth Ubuntu-20 py3.13
+    display_name: Auth AWS Ubuntu-20 py3.13
     run_on:
       - ubuntu2004-small
     expansions:
       PYTHON_BINARY: /opt/python/3.13/bin/python3
-  - name: aws-auth-win64-py3.9
+  - name: auth-aws-win64-py3.9
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -143,13 +143,13 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: AWS Auth Win64 py3.9
+    display_name: Auth AWS Win64 py3.9
     run_on:
       - windows-64-vsMulti-small
     expansions:
       skip_ECS_auth_test: "true"
       PYTHON_BINARY: C:/python/Python39/python.exe
-  - name: aws-auth-win64-py3.13
+  - name: auth-aws-win64-py3.13
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -158,13 +158,13 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: AWS Auth Win64 py3.13
+    display_name: Auth AWS Win64 py3.13
     run_on:
       - windows-64-vsMulti-small
     expansions:
       skip_ECS_auth_test: "true"
       PYTHON_BINARY: C:/python/Python313/python.exe
-  - name: aws-auth-macos-py3.9
+  - name: auth-aws-macos-py3.9
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -173,7 +173,7 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: AWS Auth macOS py3.9
+    display_name: Auth AWS macOS py3.9
     run_on:
       - macos-14
     expansions:
@@ -181,7 +181,7 @@ buildvariants:
       skip_EC2_auth_test: "true"
       skip_web_identity_auth_test: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: aws-auth-macos-py3.13
+  - name: auth-aws-macos-py3.13
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -190,7 +190,7 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: AWS Auth macOS py3.13
+    display_name: Auth AWS macOS py3.13
     run_on:
       - macos-14
     expansions:
@@ -200,85 +200,85 @@ buildvariants:
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
   # Compression tests
-  - name: snappy-compression-rhel8-py3.9-no-c
+  - name: compression-snappy-rhel8-py3.9-no-c
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: snappy compression RHEL8 py3.9 No C
+    display_name: Compression snappy RHEL8 py3.9 No C
     run_on:
       - rhel87-small
     expansions:
       COMPRESSORS: snappy
       NO_EXT: "1"
       PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: snappy-compression-rhel8-py3.10
+  - name: compression-snappy-rhel8-py3.10
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: snappy compression RHEL8 py3.10
+    display_name: Compression snappy RHEL8 py3.10
     run_on:
       - rhel87-small
     expansions:
       COMPRESSORS: snappy
       PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: zlib-compression-rhel8-py3.11-no-c
+  - name: compression-zlib-rhel8-py3.11-no-c
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: zlib compression RHEL8 py3.11 No C
+    display_name: Compression zlib RHEL8 py3.11 No C
     run_on:
       - rhel87-small
     expansions:
       COMPRESSORS: zlib
       NO_EXT: "1"
       PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: zlib-compression-rhel8-py3.12
+  - name: compression-zlib-rhel8-py3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: zlib compression RHEL8 py3.12
+    display_name: Compression zlib RHEL8 py3.12
     run_on:
       - rhel87-small
     expansions:
       COMPRESSORS: zlib
       PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: zstd-compression-rhel8-py3.13-no-c
+  - name: compression-zstd-rhel8-py3.13-no-c
     tasks:
       - name: .standalone .noauth .nossl .sync_async !.4.0
-    display_name: zstd compression RHEL8 py3.13 No C
+    display_name: Compression zstd RHEL8 py3.13 No C
     run_on:
       - rhel87-small
     expansions:
       COMPRESSORS: zstd
       NO_EXT: "1"
       PYTHON_BINARY: /opt/python/3.13/bin/python3
-  - name: zstd-compression-rhel8-py3.9
+  - name: compression-zstd-rhel8-py3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async !.4.0
-    display_name: zstd compression RHEL8 py3.9
+    display_name: Compression zstd RHEL8 py3.9
     run_on:
       - rhel87-small
     expansions:
       COMPRESSORS: zstd
       PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: snappy-compression-rhel8-pypy3.9
+  - name: compression-snappy-rhel8-pypy3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: snappy compression RHEL8 pypy3.9
+    display_name: Compression snappy RHEL8 pypy3.9
     run_on:
       - rhel87-small
     expansions:
       COMPRESSORS: snappy
       PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-  - name: zlib-compression-rhel8-pypy3.10
+  - name: compression-zlib-rhel8-pypy3.10
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: zlib compression RHEL8 pypy3.10
+    display_name: Compression zlib RHEL8 pypy3.10
     run_on:
       - rhel87-small
     expansions:
       COMPRESSORS: zlib
       PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-  - name: zstd-compression-rhel8-pypy3.9
+  - name: compression-zstd-rhel8-pypy3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async !.4.0
-    display_name: zstd compression RHEL8 pypy3.9
+    display_name: Compression zstd RHEL8 pypy3.9
     run_on:
       - rhel87-small
     expansions:
@@ -564,64 +564,64 @@ buildvariants:
     tags: [encryption_tag]
 
   # Enterprise auth tests
-  - name: enterprise-auth-macos-py3.9-auth
+  - name: auth-enterprise-macos-py3.9-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Enterprise Auth macOS py3.9 Auth
+    display_name: Auth Enterprise macOS py3.9 Auth
     run_on:
       - macos-14
     expansions:
       AUTH: auth
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: enterprise-auth-rhel8-py3.10-auth
+  - name: auth-enterprise-rhel8-py3.10-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Enterprise Auth RHEL8 py3.10 Auth
+    display_name: Auth Enterprise RHEL8 py3.10 Auth
     run_on:
       - rhel87-small
     expansions:
       AUTH: auth
       PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: enterprise-auth-rhel8-py3.11-auth
+  - name: auth-enterprise-rhel8-py3.11-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Enterprise Auth RHEL8 py3.11 Auth
+    display_name: Auth Enterprise RHEL8 py3.11 Auth
     run_on:
       - rhel87-small
     expansions:
       AUTH: auth
       PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: enterprise-auth-rhel8-py3.12-auth
+  - name: auth-enterprise-rhel8-py3.12-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Enterprise Auth RHEL8 py3.12 Auth
+    display_name: Auth Enterprise RHEL8 py3.12 Auth
     run_on:
       - rhel87-small
     expansions:
       AUTH: auth
       PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: enterprise-auth-win64-py3.13-auth
+  - name: auth-enterprise-win64-py3.13-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Enterprise Auth Win64 py3.13 Auth
+    display_name: Auth Enterprise Win64 py3.13 Auth
     run_on:
       - windows-64-vsMulti-small
     expansions:
       AUTH: auth
       PYTHON_BINARY: C:/python/Python313/python.exe
-  - name: enterprise-auth-rhel8-pypy3.9-auth
+  - name: auth-enterprise-rhel8-pypy3.9-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Enterprise Auth RHEL8 pypy3.9 Auth
+    display_name: Auth Enterprise RHEL8 pypy3.9 Auth
     run_on:
       - rhel87-small
     expansions:
       AUTH: auth
       PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-  - name: enterprise-auth-rhel8-pypy3.10-auth
+  - name: auth-enterprise-rhel8-pypy3.10-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Enterprise Auth RHEL8 pypy3.10 Auth
+    display_name: Auth Enterprise RHEL8 pypy3.10 Auth
     run_on:
       - rhel87-small
     expansions:
@@ -629,10 +629,10 @@ buildvariants:
       PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 
   # Green framework tests
-  - name: eventlet-rhel8-py3.9
+  - name: green-eventlet-rhel8-py3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Eventlet RHEL8 py3.9
+    display_name: Green Eventlet RHEL8 py3.9
     run_on:
       - rhel87-small
     expansions:
@@ -640,10 +640,10 @@ buildvariants:
       AUTH: auth
       SSL: ssl
       PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: gevent-rhel8-py3.9
+  - name: green-gevent-rhel8-py3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Gevent RHEL8 py3.9
+    display_name: Green Gevent RHEL8 py3.9
     run_on:
       - rhel87-small
     expansions:
@@ -651,10 +651,10 @@ buildvariants:
       AUTH: auth
       SSL: ssl
       PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: eventlet-rhel8-py3.12
+  - name: green-eventlet-rhel8-py3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Eventlet RHEL8 py3.12
+    display_name: Green Eventlet RHEL8 py3.12
     run_on:
       - rhel87-small
     expansions:
@@ -662,10 +662,10 @@ buildvariants:
       AUTH: auth
       SSL: ssl
       PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: gevent-rhel8-py3.12
+  - name: green-gevent-rhel8-py3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Gevent RHEL8 py3.12
+    display_name: Green Gevent RHEL8 py3.12
     run_on:
       - rhel87-small
     expansions:
@@ -727,10 +727,10 @@ buildvariants:
       VERSION: latest
 
   # Mockupdb tests
-  - name: mockupdb-tests-rhel8-py3.9
+  - name: mockupdb-rhel8-py3.9
     tasks:
       - name: mockupdb
-    display_name: MockupDB Tests RHEL8 py3.9
+    display_name: MockupDB RHEL8 py3.9
     run_on:
       - rhel87-small
     expansions:
@@ -810,10 +810,10 @@ buildvariants:
       PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Ocsp tests
-  - name: ocsp-test-rhel8-v4.4-py3.9
+  - name: ocsp-rhel8-v4.4-py3.9
     tasks:
       - name: .ocsp
-    display_name: OCSP test RHEL8 v4.4 py3.9
+    display_name: OCSP RHEL8 v4.4 py3.9
     run_on:
       - rhel87-small
     batchtime: 20160
@@ -823,10 +823,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: /opt/python/3.9/bin/python3
       VERSION: "4.4"
-  - name: ocsp-test-rhel8-v5.0-py3.10
+  - name: ocsp-rhel8-v5.0-py3.10
     tasks:
       - name: .ocsp
-    display_name: OCSP test RHEL8 v5.0 py3.10
+    display_name: OCSP RHEL8 v5.0 py3.10
     run_on:
       - rhel87-small
     batchtime: 20160
@@ -836,10 +836,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: /opt/python/3.10/bin/python3
       VERSION: "5.0"
-  - name: ocsp-test-rhel8-v6.0-py3.11
+  - name: ocsp-rhel8-v6.0-py3.11
     tasks:
       - name: .ocsp
-    display_name: OCSP test RHEL8 v6.0 py3.11
+    display_name: OCSP RHEL8 v6.0 py3.11
     run_on:
       - rhel87-small
     batchtime: 20160
@@ -849,10 +849,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: /opt/python/3.11/bin/python3
       VERSION: "6.0"
-  - name: ocsp-test-rhel8-v7.0-py3.12
+  - name: ocsp-rhel8-v7.0-py3.12
     tasks:
       - name: .ocsp
-    display_name: OCSP test RHEL8 v7.0 py3.12
+    display_name: OCSP RHEL8 v7.0 py3.12
     run_on:
       - rhel87-small
     batchtime: 20160
@@ -862,10 +862,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: /opt/python/3.12/bin/python3
       VERSION: "7.0"
-  - name: ocsp-test-rhel8-v8.0-py3.13
+  - name: ocsp-rhel8-v8.0-py3.13
     tasks:
       - name: .ocsp
-    display_name: OCSP test RHEL8 v8.0 py3.13
+    display_name: OCSP RHEL8 v8.0 py3.13
     run_on:
       - rhel87-small
     batchtime: 20160
@@ -875,10 +875,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: /opt/python/3.13/bin/python3
       VERSION: "8.0"
-  - name: ocsp-test-rhel8-rapid-pypy3.9
+  - name: ocsp-rhel8-rapid-pypy3.9
     tasks:
       - name: .ocsp
-    display_name: OCSP test RHEL8 rapid pypy3.9
+    display_name: OCSP RHEL8 rapid pypy3.9
     run_on:
       - rhel87-small
     batchtime: 20160
@@ -888,10 +888,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
       VERSION: rapid
-  - name: ocsp-test-rhel8-latest-pypy3.10
+  - name: ocsp-rhel8-latest-pypy3.10
     tasks:
       - name: .ocsp
-    display_name: OCSP test RHEL8 latest pypy3.10
+    display_name: OCSP RHEL8 latest pypy3.10
     run_on:
       - rhel87-small
     batchtime: 20160
@@ -901,10 +901,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
       VERSION: latest
-  - name: ocsp-test-win64-v4.4-py3.9
+  - name: ocsp-win64-v4.4-py3.9
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
-    display_name: OCSP test Win64 v4.4 py3.9
+    display_name: OCSP Win64 v4.4 py3.9
     run_on:
       - windows-64-vsMulti-small
     batchtime: 20160
@@ -914,10 +914,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: C:/python/Python39/python.exe
       VERSION: "4.4"
-  - name: ocsp-test-win64-v8.0-py3.13
+  - name: ocsp-win64-v8.0-py3.13
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
-    display_name: OCSP test Win64 v8.0 py3.13
+    display_name: OCSP Win64 v8.0 py3.13
     run_on:
       - windows-64-vsMulti-small
     batchtime: 20160
@@ -927,10 +927,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: C:/python/Python313/python.exe
       VERSION: "8.0"
-  - name: ocsp-test-macos-v4.4-py3.9
+  - name: ocsp-macos-v4.4-py3.9
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
-    display_name: OCSP test macOS v4.4 py3.9
+    display_name: OCSP macOS v4.4 py3.9
     run_on:
       - macos-14
     batchtime: 20160
@@ -940,10 +940,10 @@ buildvariants:
       TOPOLOGY: server
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
       VERSION: "4.4"
-  - name: ocsp-test-macos-v8.0-py3.13
+  - name: ocsp-macos-v8.0-py3.13
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
-    display_name: OCSP test macOS v8.0 py3.13
+    display_name: OCSP macOS v8.0 py3.13
     run_on:
       - macos-14
     batchtime: 20160
@@ -955,24 +955,24 @@ buildvariants:
       VERSION: "8.0"
 
   # Oidc auth tests
-  - name: oidc-auth-rhel8
+  - name: auth-oidc-rhel8
     tasks:
       - name: testoidc_task_group
-    display_name: OIDC Auth RHEL8
+    display_name: Auth OIDC RHEL8
     run_on:
       - rhel87-small
     batchtime: 20160
-  - name: oidc-auth-macos
+  - name: auth-oidc-macos
     tasks:
       - name: testoidc_task_group
-    display_name: OIDC Auth macOS
+    display_name: Auth OIDC macOS
     run_on:
       - macos-14
     batchtime: 20160
-  - name: oidc-auth-win64
+  - name: auth-oidc-win64
     tasks:
       - name: testoidc_task_group
-    display_name: OIDC Auth Win64
+    display_name: Auth OIDC Win64
     run_on:
       - windows-64-vsMulti-small
     batchtime: 20160
@@ -1285,3 +1285,99 @@ buildvariants:
       AUTH: auth
       SSL: ssl
       PYTHON_BINARY: /opt/python/3.13/bin/python3
+
+  # Storage engine tests
+  - name: storage-inmemory-rhel8-py3.9
+    tasks:
+      - name: .standalone .noauth .nossl .4.0 .sync_async
+      - name: .standalone .noauth .nossl .4.4 .sync_async
+      - name: .standalone .noauth .nossl .5.0 .sync_async
+      - name: .standalone .noauth .nossl .6.0 .sync_async
+      - name: .standalone .noauth .nossl .7.0 .sync_async
+      - name: .standalone .noauth .nossl .8.0 .sync_async
+      - name: .standalone .noauth .nossl .rapid .sync_async
+      - name: .standalone .noauth .nossl .latest .sync_async
+    display_name: Storage InMemory RHEL8 py3.9
+    run_on:
+      - rhel87-small
+    expansions:
+      STORAGE_ENGINE: inmemory
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
+  - name: storage-mmapv1-rhel8-py3.9
+    tasks:
+      - name: .standalone .4.0 .noauth .nossl .sync_async
+      - name: .replica_set .4.0 .noauth .nossl .sync_async
+    display_name: Storage MMAPv1 RHEL8 py3.9
+    run_on:
+      - rhel87-small
+    expansions:
+      STORAGE_ENGINE: mmapv1
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
+
+  # Versioned api tests
+  - name: versioned-api-require-v1-rhel8-py3.9-auth
+    tasks:
+      - name: .standalone .5.0 .noauth .nossl .sync_async
+      - name: .standalone .6.0 .noauth .nossl .sync_async
+      - name: .standalone .7.0 .noauth .nossl .sync_async
+      - name: .standalone .8.0 .noauth .nossl .sync_async
+      - name: .standalone .rapid .noauth .nossl .sync_async
+      - name: .standalone .latest .noauth .nossl .sync_async
+    display_name: Versioned API require v1 RHEL8 py3.9 Auth
+    run_on:
+      - rhel87-small
+    expansions:
+      AUTH: auth
+      REQUIRE_API_VERSION: "1"
+      MONGODB_API_VERSION: "1"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
+    tags: [versionedApi_tag]
+  - name: versioned-api-accept-v2-rhel8-py3.9-auth
+    tasks:
+      - name: .standalone .5.0 .noauth .nossl .sync_async
+      - name: .standalone .6.0 .noauth .nossl .sync_async
+      - name: .standalone .7.0 .noauth .nossl .sync_async
+      - name: .standalone .8.0 .noauth .nossl .sync_async
+      - name: .standalone .rapid .noauth .nossl .sync_async
+      - name: .standalone .latest .noauth .nossl .sync_async
+    display_name: Versioned API accept v2 RHEL8 py3.9 Auth
+    run_on:
+      - rhel87-small
+    expansions:
+      AUTH: auth
+      ORCHESTRATION_FILE: versioned-api-testing.json
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
+    tags: [versionedApi_tag]
+  - name: versioned-api-require-v1-rhel8-py3.13-auth
+    tasks:
+      - name: .standalone .5.0 .noauth .nossl .sync_async
+      - name: .standalone .6.0 .noauth .nossl .sync_async
+      - name: .standalone .7.0 .noauth .nossl .sync_async
+      - name: .standalone .8.0 .noauth .nossl .sync_async
+      - name: .standalone .rapid .noauth .nossl .sync_async
+      - name: .standalone .latest .noauth .nossl .sync_async
+    display_name: Versioned API require v1 RHEL8 py3.13 Auth
+    run_on:
+      - rhel87-small
+    expansions:
+      AUTH: auth
+      REQUIRE_API_VERSION: "1"
+      MONGODB_API_VERSION: "1"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
+    tags: [versionedApi_tag]
+  - name: versioned-api-accept-v2-rhel8-py3.13-auth
+    tasks:
+      - name: .standalone .5.0 .noauth .nossl .sync_async
+      - name: .standalone .6.0 .noauth .nossl .sync_async
+      - name: .standalone .7.0 .noauth .nossl .sync_async
+      - name: .standalone .8.0 .noauth .nossl .sync_async
+      - name: .standalone .rapid .noauth .nossl .sync_async
+      - name: .standalone .latest .noauth .nossl .sync_async
+    display_name: Versioned API accept v2 RHEL8 py3.13 Auth
+    run_on:
+      - rhel87-small
+    expansions:
+      AUTH: auth
+      ORCHESTRATION_FILE: versioned-api-testing.json
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
+    tags: [versionedApi_tag]

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1070,109 +1070,109 @@ buildvariants:
       PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Server tests
-  - name: _test-rhel8-py3.9-cov
+  - name: "*-test-rhel8-py3.9-cov"
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
       - name: .sharded_cluster .sync_async
-    display_name: _Test RHEL8 py3.9 cov
+    display_name: "* Test RHEL8 py3.9 cov"
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [coverage_tag]
-  - name: _test-rhel8-py3.13-cov
+  - name: "*-test-rhel8-py3.13-cov"
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
       - name: .sharded_cluster .sync_async
-    display_name: _Test RHEL8 py3.13 cov
+    display_name: "* Test RHEL8 py3.13 cov"
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [coverage_tag]
-  - name: _test-rhel8-pypy3.10-cov
+  - name: "*-test-rhel8-pypy3.10-cov"
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
       - name: .sharded_cluster .sync_async
-    display_name: _Test RHEL8 pypy3.10 cov
+    display_name: "* Test RHEL8 pypy3.10 cov"
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [coverage_tag]
-  - name: _test-rhel8-py3.10
+  - name: "*-test-rhel8-py3.10"
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: _Test RHEL8 py3.10
+    display_name: "* Test RHEL8 py3.10"
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: _test-rhel8-py3.11
+  - name: "*-test-rhel8-py3.11"
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: _Test RHEL8 py3.11
+    display_name: "* Test RHEL8 py3.11"
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: _test-rhel8-py3.12
+  - name: "*-test-rhel8-py3.12"
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: _Test RHEL8 py3.12
+    display_name: "* Test RHEL8 py3.12"
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: _test-rhel8-pypy3.9
+  - name: "*-test-rhel8-pypy3.9"
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: _Test RHEL8 pypy3.9
+    display_name: "* Test RHEL8 pypy3.9"
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-  - name: _test-macos-py3.9
+  - name: "*-test-macos-py3.9"
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: _Test macOS py3.9
+    display_name: "* Test macOS py3.9"
     run_on:
       - macos-14
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: _test-macos-py3.13
+  - name: "*-test-macos-py3.13"
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: _Test macOS py3.13
+    display_name: "* Test macOS py3.13"
     run_on:
       - macos-14
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-  - name: _test-macos-arm64-py3.9
+  - name: "*-test-macos-arm64-py3.9"
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
       - name: .replica_set .noauth .ssl .6.0 !.sync_async
@@ -1189,13 +1189,13 @@ buildvariants:
       - name: .sharded_cluster .auth .ssl .latest !.sync_async
       - name: .replica_set .noauth .ssl .latest !.sync_async
       - name: .standalone .noauth .nossl .latest !.sync_async
-    display_name: _Test macOS Arm64 py3.9
+    display_name: "* Test macOS Arm64 py3.9"
     run_on:
       - macos-14-arm64
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: _test-macos-arm64-py3.13
+  - name: "*-test-macos-arm64-py3.13"
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
       - name: .replica_set .noauth .ssl .6.0 !.sync_async
@@ -1212,51 +1212,51 @@ buildvariants:
       - name: .sharded_cluster .auth .ssl .latest !.sync_async
       - name: .replica_set .noauth .ssl .latest !.sync_async
       - name: .standalone .noauth .nossl .latest !.sync_async
-    display_name: _Test macOS Arm64 py3.13
+    display_name: "* Test macOS Arm64 py3.13"
     run_on:
       - macos-14-arm64
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-  - name: _test-win64-py3.9
+  - name: "*-test-win64-py3.9"
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: _Test Win64 py3.9
+    display_name: "* Test Win64 py3.9"
     run_on:
       - windows-64-vsMulti-small
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: C:/python/Python39/python.exe
-  - name: _test-win64-py3.13
+  - name: "*-test-win64-py3.13"
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: _Test Win64 py3.13
+    display_name: "* Test Win64 py3.13"
     run_on:
       - windows-64-vsMulti-small
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: C:/python/Python313/python.exe
-  - name: _test-win32-py3.9
+  - name: "*-test-win32-py3.9"
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: _Test Win32 py3.9
+    display_name: "* Test Win32 py3.9"
     run_on:
       - windows-64-vsMulti-small
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: C:/python/32/Python39/python.exe
-  - name: _test-win32-py3.13
+  - name: "*-test-win32-py3.13"
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: _Test Win32 py3.13
+    display_name: "* Test Win32 py3.13"
     run_on:
       - windows-64-vsMulti-small
     expansions:

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1289,6 +1289,74 @@ buildvariants:
       SSL: ssl
       PYTHON_BINARY: /opt/python/3.13/bin/python3
 
+  # Stable api tests
+  - name: stable-api-require-v1-rhel8-py3.9-auth
+    tasks:
+      - name: .standalone .5.0 .noauth .nossl .sync_async
+      - name: .standalone .6.0 .noauth .nossl .sync_async
+      - name: .standalone .7.0 .noauth .nossl .sync_async
+      - name: .standalone .8.0 .noauth .nossl .sync_async
+      - name: .standalone .rapid .noauth .nossl .sync_async
+      - name: .standalone .latest .noauth .nossl .sync_async
+    display_name: Stable API require v1 RHEL8 py3.9 Auth
+    run_on:
+      - rhel87-small
+    expansions:
+      AUTH: auth
+      REQUIRE_API_VERSION: "1"
+      MONGODB_API_VERSION: "1"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
+    tags: [versionedApi_tag]
+  - name: stable-api-accept-v2-rhel8-py3.9-auth
+    tasks:
+      - name: .standalone .5.0 .noauth .nossl .sync_async
+      - name: .standalone .6.0 .noauth .nossl .sync_async
+      - name: .standalone .7.0 .noauth .nossl .sync_async
+      - name: .standalone .8.0 .noauth .nossl .sync_async
+      - name: .standalone .rapid .noauth .nossl .sync_async
+      - name: .standalone .latest .noauth .nossl .sync_async
+    display_name: Stable API accept v2 RHEL8 py3.9 Auth
+    run_on:
+      - rhel87-small
+    expansions:
+      AUTH: auth
+      ORCHESTRATION_FILE: versioned-api-testing.json
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
+    tags: [versionedApi_tag]
+  - name: stable-api-require-v1-rhel8-py3.13-auth
+    tasks:
+      - name: .standalone .5.0 .noauth .nossl .sync_async
+      - name: .standalone .6.0 .noauth .nossl .sync_async
+      - name: .standalone .7.0 .noauth .nossl .sync_async
+      - name: .standalone .8.0 .noauth .nossl .sync_async
+      - name: .standalone .rapid .noauth .nossl .sync_async
+      - name: .standalone .latest .noauth .nossl .sync_async
+    display_name: Stable API require v1 RHEL8 py3.13 Auth
+    run_on:
+      - rhel87-small
+    expansions:
+      AUTH: auth
+      REQUIRE_API_VERSION: "1"
+      MONGODB_API_VERSION: "1"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
+    tags: [versionedApi_tag]
+  - name: stable-api-accept-v2-rhel8-py3.13-auth
+    tasks:
+      - name: .standalone .5.0 .noauth .nossl .sync_async
+      - name: .standalone .6.0 .noauth .nossl .sync_async
+      - name: .standalone .7.0 .noauth .nossl .sync_async
+      - name: .standalone .8.0 .noauth .nossl .sync_async
+      - name: .standalone .rapid .noauth .nossl .sync_async
+      - name: .standalone .latest .noauth .nossl .sync_async
+    display_name: Stable API accept v2 RHEL8 py3.13 Auth
+    run_on:
+      - rhel87-small
+    expansions:
+      AUTH: auth
+      ORCHESTRATION_FILE: versioned-api-testing.json
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
+    tags: [versionedApi_tag]
+
   # Storage engine tests
   - name: storage-inmemory-rhel8-py3.9
     tasks:
@@ -1316,71 +1384,3 @@ buildvariants:
     expansions:
       STORAGE_ENGINE: mmapv1
       PYTHON_BINARY: /opt/python/3.9/bin/python3
-
-  # Versioned api tests
-  - name: versioned-api-require-v1-rhel8-py3.9-auth
-    tasks:
-      - name: .standalone .5.0 .noauth .nossl .sync_async
-      - name: .standalone .6.0 .noauth .nossl .sync_async
-      - name: .standalone .7.0 .noauth .nossl .sync_async
-      - name: .standalone .8.0 .noauth .nossl .sync_async
-      - name: .standalone .rapid .noauth .nossl .sync_async
-      - name: .standalone .latest .noauth .nossl .sync_async
-    display_name: Versioned API require v1 RHEL8 py3.9 Auth
-    run_on:
-      - rhel87-small
-    expansions:
-      AUTH: auth
-      REQUIRE_API_VERSION: "1"
-      MONGODB_API_VERSION: "1"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-    tags: [versionedApi_tag]
-  - name: versioned-api-accept-v2-rhel8-py3.9-auth
-    tasks:
-      - name: .standalone .5.0 .noauth .nossl .sync_async
-      - name: .standalone .6.0 .noauth .nossl .sync_async
-      - name: .standalone .7.0 .noauth .nossl .sync_async
-      - name: .standalone .8.0 .noauth .nossl .sync_async
-      - name: .standalone .rapid .noauth .nossl .sync_async
-      - name: .standalone .latest .noauth .nossl .sync_async
-    display_name: Versioned API accept v2 RHEL8 py3.9 Auth
-    run_on:
-      - rhel87-small
-    expansions:
-      AUTH: auth
-      ORCHESTRATION_FILE: versioned-api-testing.json
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-    tags: [versionedApi_tag]
-  - name: versioned-api-require-v1-rhel8-py3.13-auth
-    tasks:
-      - name: .standalone .5.0 .noauth .nossl .sync_async
-      - name: .standalone .6.0 .noauth .nossl .sync_async
-      - name: .standalone .7.0 .noauth .nossl .sync_async
-      - name: .standalone .8.0 .noauth .nossl .sync_async
-      - name: .standalone .rapid .noauth .nossl .sync_async
-      - name: .standalone .latest .noauth .nossl .sync_async
-    display_name: Versioned API require v1 RHEL8 py3.13 Auth
-    run_on:
-      - rhel87-small
-    expansions:
-      AUTH: auth
-      REQUIRE_API_VERSION: "1"
-      MONGODB_API_VERSION: "1"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
-    tags: [versionedApi_tag]
-  - name: versioned-api-accept-v2-rhel8-py3.13-auth
-    tasks:
-      - name: .standalone .5.0 .noauth .nossl .sync_async
-      - name: .standalone .6.0 .noauth .nossl .sync_async
-      - name: .standalone .7.0 .noauth .nossl .sync_async
-      - name: .standalone .8.0 .noauth .nossl .sync_async
-      - name: .standalone .rapid .noauth .nossl .sync_async
-      - name: .standalone .latest .noauth .nossl .sync_async
-    display_name: Versioned API accept v2 RHEL8 py3.13 Auth
-    run_on:
-      - rhel87-small
-    expansions:
-      AUTH: auth
-      ORCHESTRATION_FILE: versioned-api-testing.json
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
-    tags: [versionedApi_tag]

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1070,109 +1070,109 @@ buildvariants:
       PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Server tests
-  - name: test-rhel8-py3.9-cov
+  - name: _test-rhel8-py3.9-cov
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
       - name: .sharded_cluster .sync_async
-    display_name: Test RHEL8 py3.9 cov
+    display_name: _Test RHEL8 py3.9 cov
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [coverage_tag]
-  - name: test-rhel8-py3.13-cov
+  - name: _test-rhel8-py3.13-cov
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
       - name: .sharded_cluster .sync_async
-    display_name: Test RHEL8 py3.13 cov
+    display_name: _Test RHEL8 py3.13 cov
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [coverage_tag]
-  - name: test-rhel8-pypy3.10-cov
+  - name: _test-rhel8-pypy3.10-cov
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
       - name: .sharded_cluster .sync_async
-    display_name: Test RHEL8 pypy3.10 cov
+    display_name: _Test RHEL8 pypy3.10 cov
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [coverage_tag]
-  - name: test-rhel8-py3.10
+  - name: _test-rhel8-py3.10
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Test RHEL8 py3.10
+    display_name: _Test RHEL8 py3.10
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: test-rhel8-py3.11
+  - name: _test-rhel8-py3.11
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Test RHEL8 py3.11
+    display_name: _Test RHEL8 py3.11
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: test-rhel8-py3.12
+  - name: _test-rhel8-py3.12
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Test RHEL8 py3.12
+    display_name: _Test RHEL8 py3.12
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: test-rhel8-pypy3.9
+  - name: _test-rhel8-pypy3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Test RHEL8 pypy3.9
+    display_name: _Test RHEL8 pypy3.9
     run_on:
       - rhel87-small
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-  - name: test-macos-py3.9
+  - name: _test-macos-py3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: Test macOS py3.9
+    display_name: _Test macOS py3.9
     run_on:
       - macos-14
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: test-macos-py3.13
+  - name: _test-macos-py3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: Test macOS py3.13
+    display_name: _Test macOS py3.13
     run_on:
       - macos-14
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-  - name: test-macos-arm64-py3.9
+  - name: _test-macos-arm64-py3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
       - name: .replica_set .noauth .ssl .6.0 !.sync_async
@@ -1189,13 +1189,13 @@ buildvariants:
       - name: .sharded_cluster .auth .ssl .latest !.sync_async
       - name: .replica_set .noauth .ssl .latest !.sync_async
       - name: .standalone .noauth .nossl .latest !.sync_async
-    display_name: Test macOS Arm64 py3.9
+    display_name: _Test macOS Arm64 py3.9
     run_on:
       - macos-14-arm64
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: test-macos-arm64-py3.13
+  - name: _test-macos-arm64-py3.13
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
       - name: .replica_set .noauth .ssl .6.0 !.sync_async
@@ -1212,51 +1212,51 @@ buildvariants:
       - name: .sharded_cluster .auth .ssl .latest !.sync_async
       - name: .replica_set .noauth .ssl .latest !.sync_async
       - name: .standalone .noauth .nossl .latest !.sync_async
-    display_name: Test macOS Arm64 py3.13
+    display_name: _Test macOS Arm64 py3.13
     run_on:
       - macos-14-arm64
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-  - name: test-win64-py3.9
+  - name: _test-win64-py3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: Test Win64 py3.9
+    display_name: _Test Win64 py3.9
     run_on:
       - windows-64-vsMulti-small
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: C:/python/Python39/python.exe
-  - name: test-win64-py3.13
+  - name: _test-win64-py3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: Test Win64 py3.13
+    display_name: _Test Win64 py3.13
     run_on:
       - windows-64-vsMulti-small
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: C:/python/Python313/python.exe
-  - name: test-win32-py3.9
+  - name: _test-win32-py3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: Test Win32 py3.9
+    display_name: _Test Win32 py3.9
     run_on:
       - windows-64-vsMulti-small
     expansions:
       SKIP_CSOT_TESTS: "true"
       PYTHON_BINARY: C:/python/32/Python39/python.exe
-  - name: test-win32-py3.13
+  - name: _test-win32-py3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: Test Win32 py3.13
+    display_name: _Test Win32 py3.13
     run_on:
       - windows-64-vsMulti-small
     expansions:

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -491,7 +491,7 @@ def create_storage_engine_variants():
     return variants
 
 
-def create_versioned_api_variants():
+def create_stable_api_variants():
     host = "rhel8"
     tags = ["versionedApi_tag"]
     tasks = [f".standalone .{v} .noauth .nossl .sync_async" for v in get_versions_from("5.0")]
@@ -513,7 +513,7 @@ def create_versioned_api_variants():
             # requireApiVersion, and don't automatically add apiVersion to
             # clients created in the test suite.
             expansions["ORCHESTRATION_FILE"] = "versioned-api-testing.json"
-        base_display_name = f"Versioned API {test_type}"
+        base_display_name = f"Stable API {test_type}"
         display_name = get_display_name(base_display_name, host, python=python, **expansions)
         variant = create_variant(
             tasks, display_name, host=host, python=python, tags=tags, expansions=expansions

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -241,10 +241,11 @@ def create_server_variants() -> list[BuildVariant]:
 
     # Run the full matrix on linux with min and max CPython, and latest pypy.
     host = "rhel8"
+    # Prefix the display name with an underscore so it is sorted first.
+    base_display_name = "_Test"
     for python in [*MIN_MAX_PYTHON, PYPYS[-1]]:
-        display_name = f"Test {host}"
         expansions = dict(COVERAGE="coverage")
-        display_name = get_display_name("Test", host, python=python, **expansions)
+        display_name = get_display_name(base_display_name, host, python=python, **expansions)
         variant = create_variant(
             [f".{t} .sync_async" for t in TOPOLOGIES],
             display_name,
@@ -258,7 +259,7 @@ def create_server_variants() -> list[BuildVariant]:
     # Test the rest of the pythons.
     for python in CPYTHONS[1:-1] + PYPYS[:-1]:
         display_name = f"Test {host}"
-        display_name = get_display_name("Test", host, python=python)
+        display_name = get_display_name(base_display_name, host, python=python)
         variant = create_variant(
             [f"{t} .sync_async" for t in SUB_TASKS],
             display_name,
@@ -278,7 +279,7 @@ def create_server_variants() -> list[BuildVariant]:
                 for version in get_versions_from("6.0"):
                     tasks.extend(f"{t} .{version} !.sync_async" for t in SUB_TASKS)
             expansions = dict(SKIP_CSOT_TESTS="true")
-            display_name = get_display_name("Test", host, python=python, **expansions)
+            display_name = get_display_name(base_display_name, host, python=python, **expansions)
             variant = create_variant(
                 tasks,
                 display_name,

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -241,8 +241,8 @@ def create_server_variants() -> list[BuildVariant]:
 
     # Run the full matrix on linux with min and max CPython, and latest pypy.
     host = "rhel8"
-    # Prefix the display name with an underscore so it is sorted first.
-    base_display_name = "_Test"
+    # Prefix the display name with an asterisk so it is sorted first.
+    base_display_name = "* Test"
     for python in [*MIN_MAX_PYTHON, PYPYS[-1]]:
         expansions = dict(COVERAGE="coverage")
         display_name = get_display_name(base_display_name, host, python=python, **expansions)

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -93,7 +93,7 @@ def create_variant(
     else:
         host = host or "rhel8"
         run_on = [HOSTS[host].run_on]
-    name = display_name.replace(" ", "-").lower()
+    name = display_name.replace(" ", "-").replace("*-", "").lower()
     if python:
         expansions["PYTHON_BINARY"] = get_python_binary(python, host)
     if version:

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -201,7 +201,7 @@ def create_ocsp_variants() -> list[BuildVariant]:
     variants = []
     batchtime = BATCHTIME_WEEK * 2
     expansions = dict(AUTH="noauth", SSL="ssl", TOPOLOGY="server")
-    base_display = "OCSP test"
+    base_display = "OCSP"
 
     # OCSP tests on rhel8 with all servers v4.4+ and all python versions.
     versions = [v for v in ALL_VERSIONS if v != "4.0"]
@@ -385,7 +385,7 @@ def create_compression_variants():
     for ind, (compressor, c_ext) in enumerate(product(["snappy", "zlib", "zstd"], C_EXTS)):
         expansions = dict(COMPRESSORS=compressor)
         handle_c_ext(c_ext, expansions)
-        base_name = f"{compressor} compression"
+        base_name = f"Compression {compressor}"
         python = CPYTHONS[ind % len(CPYTHONS)]
         display_name = get_display_name(base_name, host, python=python, **expansions)
         variant = create_variant(
@@ -401,7 +401,7 @@ def create_compression_variants():
     for compressor, python in zip_cycle(["snappy", "zlib", "zstd"], other_pythons):
         expansions = dict(COMPRESSORS=compressor)
         handle_c_ext(c_ext, expansions)
-        base_name = f"{compressor} compression"
+        base_name = f"Compression {compressor}"
         display_name = get_display_name(base_name, host, python=python, **expansions)
         variant = create_variant(
             task_names[compressor],
@@ -427,7 +427,7 @@ def create_enterprise_auth_variants():
             host = "win64"
         else:
             host = "rhel8"
-        display_name = get_display_name("Enterprise Auth", host, python=python, **expansions)
+        display_name = get_display_name("Auth Enterprise", host, python=python, **expansions)
         variant = create_variant(
             ["test-enterprise-auth"], display_name, host=host, python=python, expansions=expansions
         )
@@ -467,7 +467,7 @@ def create_pyopenssl_variants():
     return variants
 
 
-def create_storage_engine_tests():
+def create_storage_engine_variants():
     host = "rhel8"
     engines = ["InMemory", "MMAPv1"]
     variants = []
@@ -490,7 +490,7 @@ def create_storage_engine_tests():
     return variants
 
 
-def create_versioned_api_tests():
+def create_versioned_api_variants():
     host = "rhel8"
     tags = ["versionedApi_tag"]
     tasks = [f".standalone .{v} .noauth .nossl .sync_async" for v in get_versions_from("5.0")]
@@ -528,7 +528,7 @@ def create_green_framework_variants():
     host = "rhel8"
     for python, framework in product([CPYTHONS[0], CPYTHONS[-2]], ["eventlet", "gevent"]):
         expansions = dict(GREEN_FRAMEWORK=framework, AUTH="auth", SSL="ssl")
-        display_name = get_display_name(f"{framework.capitalize()}", host, python=python)
+        display_name = get_display_name(f"Green {framework.capitalize()}", host, python=python)
         variant = create_variant(
             tasks, display_name, host=host, python=python, expansions=expansions
         )
@@ -619,7 +619,7 @@ def create_oidc_auth_variants():
         variants.append(
             create_variant(
                 ["testoidc_task_group"],
-                get_display_name("OIDC Auth", host),
+                get_display_name("Auth OIDC", host),
                 host=host,
                 batchtime=BATCHTIME_WEEK * 2,
             )
@@ -646,7 +646,7 @@ def create_mockupdb_variants():
     return [
         create_variant(
             ["mockupdb"],
-            get_display_name("MockupDB Tests", host, python=python),
+            get_display_name("MockupDB", host, python=python),
             python=python,
             host=host,
         )
@@ -700,7 +700,7 @@ def create_aws_auth_variants():
             expansions["skip_web_identity_auth_test"] = "true"
         variant = create_variant(
             tasks,
-            get_display_name("AWS Auth", host, python=python),
+            get_display_name("Auth AWS", host, python=python),
             host=host,
             python=python,
             expansions=expansions,


### PR DESCRIPTION
Updated variant list:

```
* Test RHEL8 py3.10
* Test RHEL8 py3.11
* Test RHEL8 py3.12
* Test RHEL8 py3.13 cov
* Test RHEL8 py3.9 cov
* Test RHEL8 pypy3.10 cov
* Test RHEL8 pypy3.9
* Test Win32 py3.13
* Test Win32 py3.9
* Test Win64 py3.13
* Test Win64 py3.9
* Test macOS Arm64 py3.13
* Test macOS Arm64 py3.9
* Test macOS py3.13
* Test macOS py3.9
Atlas Data Lake Ubuntu-22 py3.13 Auth
Atlas Data Lake Ubuntu-22 py3.13 Auth No C
Atlas Data Lake Ubuntu-22 py3.9 Auth
Atlas Data Lake Ubuntu-22 py3.9 Auth No C
Atlas connect RHEL8 py3.13
Atlas connect RHEL8 py3.9
Auth AWS Ubuntu-20 py3.13
Auth AWS Ubuntu-20 py3.9
Auth AWS Win64 py3.13
Auth AWS Win64 py3.9
Auth AWS macOS py3.13
Auth AWS macOS py3.9
Auth Enterprise RHEL8 py3.10 Auth
Auth Enterprise RHEL8 py3.11 Auth
Auth Enterprise RHEL8 py3.12 Auth
Auth Enterprise RHEL8 pypy3.10 Auth
Auth Enterprise RHEL8 pypy3.9 Auth
Auth Enterprise Win64 py3.13 Auth
Auth Enterprise macOS py3.9 Auth
Auth OIDC Ubuntu-22
Auth OIDC Win64
Auth OIDC macOS
Compression snappy RHEL8 py3.10
Compression snappy RHEL8 py3.9 No C
Compression snappy RHEL8 pypy3.9
Compression zlib RHEL8 py3.11 No C
Compression zlib RHEL8 py3.12
Compression zlib RHEL8 pypy3.10
Compression zstd RHEL8 py3.13 No C
Compression zstd RHEL8 py3.9
Compression zstd RHEL8 pypy3.9
Coverage Report
Disable test commands RHEL8 py3.9
Doctests RHEL8 py3.9
Encryption PyOpenSSL RHEL8 py3.12
Encryption PyOpenSSL RHEL8 py3.13
Encryption PyOpenSSL RHEL8 py3.9
Encryption PyOpenSSL RHEL8 pypy3.10
Encryption RHEL8 py3.10
Encryption RHEL8 py3.13
Encryption RHEL8 py3.9
Encryption RHEL8 pypy3.10
Encryption RHEL8 pypy3.9
Encryption Win64 py3.13
Encryption Win64 py3.9
Encryption crypt_shared RHEL8 py3.11
Encryption crypt_shared RHEL8 py3.13
Encryption crypt_shared RHEL8 py3.9
Encryption crypt_shared RHEL8 pypy3.10
Encryption crypt_shared Win64 py3.13
Encryption crypt_shared Win64 py3.9
Encryption crypt_shared macOS py3.13
Encryption crypt_shared macOS py3.9
Encryption macOS py3.13
Encryption macOS py3.9
Faas Lambda
Green Eventlet RHEL8 py3.12
Green Eventlet RHEL8 py3.9
Green Gevent RHEL8 py3.12
Green Gevent RHEL8 py3.9
Import Time
KMS
Load Balancer RHEL8 latest py3.9
Load Balancer RHEL8 rapid py3.9
Load Balancer RHEL8 v6.0 py3.9
Load Balancer RHEL8 v.0 py3.9
Load Balancer RHEL8 v8.0 py3.9
MockupDB RHEL8 py3.9
No C Ext RHEL8 py3.10
No C Ext RHEL8 py3.11
No C Ext RHEL8 py3.12
No C Ext RHEL8 py3.13
No C Ext RHEL8 py3.9
No server
OCSP RHEL8 latest pypy3.10
OCSP RHEL8 rapid pypy3.9
OCSP RHEL8 v4.4 py3.9
OCSP RHEL8 v5.0 py3.10
OCSP RHEL8 v6.0 py3.11
OCSP RHEL8 v7.0 py3.12
OCSP RHEL8 v8.0 py3.13
OCSP Win64 v4.4 py3.9
OCSP Win64 v8.0 py3.13
OCSP macOS v4.4 py3.9
OCSP macOS v8.0 py3.13
OpenSSL 1.0.2 RHEL7 py3.9
Other hosts RHEL8-POWER8
Other hosts RHEL8-arm64
Other hosts RHEL8-zseries
Other hosts RHEL9-FIPS
Performance Benchmarks
PyOpenSSL RHEL8 py3.10
PyOpenSSL RHEL8 py3.11
PyOpenSSL RHEL8 py3.12
PyOpenSSL RHEL8 pypy3.10
PyOpenSSL RHEL8 pypy3.9
PyOpenSSL Win64 py3.13
PyOpenSSL macOS py3.9
Search Index Helpers RHEL8 py3.9
Serverless RHEL8 py3.13
Serverless RHEL8 py3.9
Stable API accept v2 RHEL8 py3.13 Auth
Stable API accept v2 RHEL8 py3.9 Auth
Stable API require v1 RHEL8 py3.13 Auth
Stable API require v1 RHEL8 py3.9 Auth
Storage InMemory RHEL8 py3.9
Storage MMAPv1 RHEL8 py3.9
mod_wsgi Ubuntu-22 py3.13
mod_wsgi Ubuntu-22 py3.9
```