### PR TITLE
PYTHON-4956 Generated config cleanup

### DIFF
--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1,15 +1,12 @@
 buildvariants:
   # Alternative hosts tests
-  - name: openssl-1.0.2-rhel7-py3.9
+  - name: openssl-1.0.2-rhel7-python3.9
     tasks:
       - name: .5.0 .standalone !.sync_async
-    display_name: OpenSSL 1.0.2 RHEL7 py3.9
+    display_name: OpenSSL 1.0.2 RHEL7 Python3.9
     run_on:
       - rhel79-small
     batchtime: 10080
-    expansions:
-      SKIP_HATCH: "true"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: other-hosts-rhel9-fips
     tasks:
       - name: .6.0 .standalone !.sync_async
@@ -17,8 +14,6 @@ buildvariants:
     run_on:
       - rhel92-fips
     batchtime: 10080
-    expansions:
-      SKIP_HATCH: "true"
   - name: other-hosts-rhel8-zseries
     tasks:
       - name: .6.0 .standalone !.sync_async
@@ -26,8 +21,6 @@ buildvariants:
     run_on:
       - rhel8-zseries-small
     batchtime: 10080
-    expansions:
-      SKIP_HATCH: "true"
   - name: other-hosts-rhel8-power8
     tasks:
       - name: .6.0 .standalone !.sync_async
@@ -35,8 +28,6 @@ buildvariants:
     run_on:
       - rhel8-power-small
     batchtime: 10080
-    expansions:
-      SKIP_HATCH: "true"
   - name: other-hosts-rhel8-arm64
     tasks:
       - name: .6.0 .standalone !.sync_async
@@ -44,69 +35,49 @@ buildvariants:
     run_on:
       - rhel82-arm64-small
     batchtime: 10080
-    expansions:
-      SKIP_HATCH: "true"
 
   # Atlas connect tests
-  - name: atlas-connect-rhel8-py3.9
+  - name: atlas-connect-rhel8-python3.9
     tasks:
       - name: atlas-connect
-    display_name: Atlas connect RHEL8 py3.9
+    display_name: Atlas connect RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: atlas-connect-rhel8-py3.13
+  - name: atlas-connect-rhel8-python3.13
     tasks:
       - name: atlas-connect
-    display_name: Atlas connect RHEL8 py3.13
+    display_name: Atlas connect RHEL8 Python3.13
     run_on:
       - rhel87-small
-    expansions:
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Atlas data lake tests
-  - name: atlas-data-lake-ubuntu-22-py3.9-auth-no-c
+  - name: atlas-data-lake-ubuntu-22-python3.9-auth-no-c
     tasks:
       - name: atlas-data-lake-tests
-    display_name: Atlas Data Lake Ubuntu-22 py3.9 Auth No C
+    display_name: Atlas Data Lake Ubuntu-22 Python3.9 Auth No C
     run_on:
       - ubuntu2204-small
-    expansions:
-      AUTH: auth
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: atlas-data-lake-ubuntu-22-py3.9-auth
+  - name: atlas-data-lake-ubuntu-22-python3.9-auth
     tasks:
       - name: atlas-data-lake-tests
-    display_name: Atlas Data Lake Ubuntu-22 py3.9 Auth
+    display_name: Atlas Data Lake Ubuntu-22 Python3.9 Auth
     run_on:
       - ubuntu2204-small
-    expansions:
-      AUTH: auth
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: atlas-data-lake-ubuntu-22-py3.13-auth-no-c
+  - name: atlas-data-lake-ubuntu-22-python3.13-auth-no-c
     tasks:
       - name: atlas-data-lake-tests
-    display_name: Atlas Data Lake Ubuntu-22 py3.13 Auth No C
+    display_name: Atlas Data Lake Ubuntu-22 Python3.13 Auth No C
     run_on:
       - ubuntu2204-small
-    expansions:
-      AUTH: auth
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
-  - name: atlas-data-lake-ubuntu-22-py3.13-auth
+  - name: atlas-data-lake-ubuntu-22-python3.13-auth
     tasks:
       - name: atlas-data-lake-tests
-    display_name: Atlas Data Lake Ubuntu-22 py3.13 Auth
+    display_name: Atlas Data Lake Ubuntu-22 Python3.13 Auth
     run_on:
       - ubuntu2204-small
-    expansions:
-      AUTH: auth
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Aws auth tests
-  - name: auth-aws-ubuntu-20-py3.9
+  - name: auth-aws-ubuntu-20-python3.9
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -115,12 +86,10 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: Auth AWS Ubuntu-20 py3.9
+    display_name: Auth AWS Ubuntu-20 Python3.9
     run_on:
       - ubuntu2004-small
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: auth-aws-ubuntu-20-py3.13
+  - name: auth-aws-ubuntu-20-python3.13
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -129,12 +98,10 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: Auth AWS Ubuntu-20 py3.13
+    display_name: Auth AWS Ubuntu-20 Python3.13
     run_on:
       - ubuntu2004-small
-    expansions:
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
-  - name: auth-aws-win64-py3.9
+  - name: auth-aws-win64-python3.9
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -143,13 +110,10 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: Auth AWS Win64 py3.9
+    display_name: Auth AWS Win64 Python3.9
     run_on:
       - windows-64-vsMulti-small
-    expansions:
-      skip_ECS_auth_test: "true"
-      PYTHON_BINARY: C:/python/Python39/python.exe
-  - name: auth-aws-win64-py3.13
+  - name: auth-aws-win64-python3.13
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -158,13 +122,10 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: Auth AWS Win64 py3.13
+    display_name: Auth AWS Win64 Python3.13
     run_on:
       - windows-64-vsMulti-small
-    expansions:
-      skip_ECS_auth_test: "true"
-      PYTHON_BINARY: C:/python/Python313/python.exe
-  - name: auth-aws-macos-py3.9
+  - name: auth-aws-macos-python3.9
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -173,15 +134,10 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: Auth AWS macOS py3.9
+    display_name: Auth AWS macOS Python3.9
     run_on:
       - macos-14
-    expansions:
-      skip_ECS_auth_test: "true"
-      skip_EC2_auth_test: "true"
-      skip_web_identity_auth_test: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: auth-aws-macos-py3.13
+  - name: auth-aws-macos-python3.13
     tasks:
       - name: aws-auth-test-4.4
       - name: aws-auth-test-5.0
@@ -190,769 +146,507 @@ buildvariants:
       - name: aws-auth-test-8.0
       - name: aws-auth-test-rapid
       - name: aws-auth-test-latest
-    display_name: Auth AWS macOS py3.13
+    display_name: Auth AWS macOS Python3.13
     run_on:
       - macos-14
-    expansions:
-      skip_ECS_auth_test: "true"
-      skip_EC2_auth_test: "true"
-      skip_web_identity_auth_test: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
   # Compression tests
-  - name: compression-snappy-rhel8-py3.9-no-c
+  - name: compression-snappy-rhel8-python3.9-no-c
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Compression snappy RHEL8 py3.9 No C
+    display_name: Compression snappy RHEL8 Python3.9 No C
     run_on:
       - rhel87-small
-    expansions:
-      COMPRESSORS: snappy
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: compression-snappy-rhel8-py3.10
+  - name: compression-snappy-rhel8-python3.10
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Compression snappy RHEL8 py3.10
+    display_name: Compression snappy RHEL8 Python3.10
     run_on:
       - rhel87-small
-    expansions:
-      COMPRESSORS: snappy
-      PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: compression-zlib-rhel8-py3.11-no-c
+  - name: compression-zlib-rhel8-python3.11-no-c
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Compression zlib RHEL8 py3.11 No C
+    display_name: Compression zlib RHEL8 Python3.11 No C
     run_on:
       - rhel87-small
-    expansions:
-      COMPRESSORS: zlib
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: compression-zlib-rhel8-py3.12
+  - name: compression-zlib-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Compression zlib RHEL8 py3.12
+    display_name: Compression zlib RHEL8 Python3.12
     run_on:
       - rhel87-small
-    expansions:
-      COMPRESSORS: zlib
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: compression-zstd-rhel8-py3.13-no-c
+  - name: compression-zstd-rhel8-python3.13-no-c
     tasks:
       - name: .standalone .noauth .nossl .sync_async !.4.0
-    display_name: Compression zstd RHEL8 py3.13 No C
+    display_name: Compression zstd RHEL8 Python3.13 No C
     run_on:
       - rhel87-small
-    expansions:
-      COMPRESSORS: zstd
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
-  - name: compression-zstd-rhel8-py3.9
+  - name: compression-zstd-rhel8-python3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async !.4.0
-    display_name: Compression zstd RHEL8 py3.9
+    display_name: Compression zstd RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      COMPRESSORS: zstd
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: compression-snappy-rhel8-pypy3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Compression snappy RHEL8 pypy3.9
+    display_name: Compression snappy RHEL8 PyPy3.9
     run_on:
       - rhel87-small
-    expansions:
-      COMPRESSORS: snappy
-      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
   - name: compression-zlib-rhel8-pypy3.10
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Compression zlib RHEL8 pypy3.10
+    display_name: Compression zlib RHEL8 PyPy3.10
     run_on:
       - rhel87-small
-    expansions:
-      COMPRESSORS: zlib
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
   - name: compression-zstd-rhel8-pypy3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async !.4.0
-    display_name: Compression zstd RHEL8 pypy3.9
+    display_name: Compression zstd RHEL8 PyPy3.9
     run_on:
       - rhel87-small
-    expansions:
-      COMPRESSORS: zstd
-      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
 
   # Disable test commands tests
-  - name: disable-test-commands-rhel8-py3.9
+  - name: disable-test-commands-rhel8-python3.9
     tasks:
       - name: .latest .sync_async
-    display_name: Disable test commands RHEL8 py3.9
+    display_name: Disable test commands RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      SSL: ssl
-      DISABLE_TEST_COMMANDS: "1"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Doctests tests
-  - name: doctests-rhel8-py3.9
+  - name: doctests-rhel8-python3.9
     tasks:
       - name: doctests
-    display_name: Doctests RHEL8 py3.9
+    display_name: Doctests RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Encryption tests
-  - name: encryption-rhel8-py3.9
+  - name: encryption-rhel8-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption RHEL8 py3.9
+    display_name: Encryption RHEL8 Python3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [encryption_tag]
-  - name: encryption-rhel8-py3.13
+  - name: encryption-rhel8-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption RHEL8 py3.13
+    display_name: Encryption RHEL8 Python3.13
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [encryption_tag]
   - name: encryption-rhel8-pypy3.10
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption RHEL8 pypy3.10
+    display_name: Encryption RHEL8 PyPy3.10
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [encryption_tag]
-  - name: encryption-crypt_shared-rhel8-py3.9
+  - name: encryption-crypt_shared-rhel8-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption crypt_shared RHEL8 py3.9
+    display_name: Encryption crypt_shared RHEL8 Python3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_crypt_shared: "true"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [encryption_tag]
-  - name: encryption-crypt_shared-rhel8-py3.13
+  - name: encryption-crypt_shared-rhel8-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption crypt_shared RHEL8 py3.13
+    display_name: Encryption crypt_shared RHEL8 Python3.13
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_crypt_shared: "true"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [encryption_tag]
   - name: encryption-crypt_shared-rhel8-pypy3.10
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption crypt_shared RHEL8 pypy3.10
+    display_name: Encryption crypt_shared RHEL8 PyPy3.10
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_crypt_shared: "true"
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [encryption_tag]
-  - name: encryption-pyopenssl-rhel8-py3.9
+  - name: encryption-pyopenssl-rhel8-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption PyOpenSSL RHEL8 py3.9
+    display_name: Encryption PyOpenSSL RHEL8 Python3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_encryption_pyopenssl: "true"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [encryption_tag]
-  - name: encryption-pyopenssl-rhel8-py3.13
+  - name: encryption-pyopenssl-rhel8-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption PyOpenSSL RHEL8 py3.13
+    display_name: Encryption PyOpenSSL RHEL8 Python3.13
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_encryption_pyopenssl: "true"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [encryption_tag]
   - name: encryption-pyopenssl-rhel8-pypy3.10
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption PyOpenSSL RHEL8 pypy3.10
+    display_name: Encryption PyOpenSSL RHEL8 PyPy3.10
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_encryption_pyopenssl: "true"
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [encryption_tag]
-  - name: encryption-rhel8-py3.10
+  - name: encryption-rhel8-python3.10
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
-    display_name: Encryption RHEL8 py3.10
+    display_name: Encryption RHEL8 Python3.10
     run_on:
       - rhel87-small
-    expansions:
-      test_encryption: "true"
-      PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: encryption-crypt_shared-rhel8-py3.11
+  - name: encryption-crypt_shared-rhel8-python3.11
     tasks:
       - name: .replica_set .noauth .ssl .sync_async
-    display_name: Encryption crypt_shared RHEL8 py3.11
+    display_name: Encryption crypt_shared RHEL8 Python3.11
     run_on:
       - rhel87-small
-    expansions:
-      test_encryption: "true"
-      test_crypt_shared: "true"
-      PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: encryption-pyopenssl-rhel8-py3.12
+  - name: encryption-pyopenssl-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Encryption PyOpenSSL RHEL8 py3.12
+    display_name: Encryption PyOpenSSL RHEL8 Python3.12
     run_on:
       - rhel87-small
-    expansions:
-      test_encryption: "true"
-      test_encryption_pyopenssl: "true"
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: encryption-rhel8-pypy3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
-    display_name: Encryption RHEL8 pypy3.9
+    display_name: Encryption RHEL8 PyPy3.9
     run_on:
       - rhel87-small
-    expansions:
-      test_encryption: "true"
-      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-  - name: encryption-macos-py3.9
+  - name: encryption-macos-python3.9
     tasks:
       - name: .latest .replica_set .sync_async
-    display_name: Encryption macOS py3.9
+    display_name: Encryption macOS Python3.9
     run_on:
       - macos-14
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     tags: [encryption_tag]
-  - name: encryption-macos-py3.13
+  - name: encryption-macos-python3.13
     tasks:
       - name: .latest .replica_set .sync_async
-    display_name: Encryption macOS py3.13
+    display_name: Encryption macOS Python3.13
     run_on:
       - macos-14
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
     tags: [encryption_tag]
-  - name: encryption-crypt_shared-macos-py3.9
+  - name: encryption-crypt_shared-macos-python3.9
     tasks:
       - name: .latest .replica_set .sync_async
-    display_name: Encryption crypt_shared macOS py3.9
+    display_name: Encryption crypt_shared macOS Python3.9
     run_on:
       - macos-14
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_crypt_shared: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     tags: [encryption_tag]
-  - name: encryption-crypt_shared-macos-py3.13
+  - name: encryption-crypt_shared-macos-python3.13
     tasks:
       - name: .latest .replica_set .sync_async
-    display_name: Encryption crypt_shared macOS py3.13
+    display_name: Encryption crypt_shared macOS Python3.13
     run_on:
       - macos-14
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_crypt_shared: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
     tags: [encryption_tag]
-  - name: encryption-win64-py3.9
+  - name: encryption-win64-python3.9
     tasks:
       - name: .latest .replica_set .sync_async
-    display_name: Encryption Win64 py3.9
+    display_name: Encryption Win64 Python3.9
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      PYTHON_BINARY: C:/python/Python39/python.exe
     tags: [encryption_tag]
-  - name: encryption-win64-py3.13
+  - name: encryption-win64-python3.13
     tasks:
       - name: .latest .replica_set .sync_async
-    display_name: Encryption Win64 py3.13
+    display_name: Encryption Win64 Python3.13
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      PYTHON_BINARY: C:/python/Python313/python.exe
     tags: [encryption_tag]
-  - name: encryption-crypt_shared-win64-py3.9
+  - name: encryption-crypt_shared-win64-python3.9
     tasks:
       - name: .latest .replica_set .sync_async
-    display_name: Encryption crypt_shared Win64 py3.9
+    display_name: Encryption crypt_shared Win64 Python3.9
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_crypt_shared: "true"
-      PYTHON_BINARY: C:/python/Python39/python.exe
     tags: [encryption_tag]
-  - name: encryption-crypt_shared-win64-py3.13
+  - name: encryption-crypt_shared-win64-python3.13
     tasks:
       - name: .latest .replica_set .sync_async
-    display_name: Encryption crypt_shared Win64 py3.13
+    display_name: Encryption crypt_shared Win64 Python3.13
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
-    expansions:
-      test_encryption: "true"
-      test_crypt_shared: "true"
-      PYTHON_BINARY: C:/python/Python313/python.exe
     tags: [encryption_tag]
 
   # Enterprise auth tests
-  - name: auth-enterprise-macos-py3.9-auth
+  - name: auth-enterprise-macos-python3.9-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Auth Enterprise macOS py3.9 Auth
+    display_name: Auth Enterprise macOS Python3.9 Auth
     run_on:
       - macos-14
-    expansions:
-      AUTH: auth
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: auth-enterprise-rhel8-py3.10-auth
+  - name: auth-enterprise-rhel8-python3.10-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Auth Enterprise RHEL8 py3.10 Auth
+    display_name: Auth Enterprise RHEL8 Python3.10 Auth
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: auth-enterprise-rhel8-py3.11-auth
+  - name: auth-enterprise-rhel8-python3.11-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Auth Enterprise RHEL8 py3.11 Auth
+    display_name: Auth Enterprise RHEL8 Python3.11 Auth
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: auth-enterprise-rhel8-py3.12-auth
+  - name: auth-enterprise-rhel8-python3.12-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Auth Enterprise RHEL8 py3.12 Auth
+    display_name: Auth Enterprise RHEL8 Python3.12 Auth
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: auth-enterprise-win64-py3.13-auth
+  - name: auth-enterprise-win64-python3.13-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Auth Enterprise Win64 py3.13 Auth
+    display_name: Auth Enterprise Win64 Python3.13 Auth
     run_on:
       - windows-64-vsMulti-small
-    expansions:
-      AUTH: auth
-      PYTHON_BINARY: C:/python/Python313/python.exe
   - name: auth-enterprise-rhel8-pypy3.9-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Auth Enterprise RHEL8 pypy3.9 Auth
+    display_name: Auth Enterprise RHEL8 PyPy3.9 Auth
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
   - name: auth-enterprise-rhel8-pypy3.10-auth
     tasks:
       - name: test-enterprise-auth
-    display_name: Auth Enterprise RHEL8 pypy3.10 Auth
+    display_name: Auth Enterprise RHEL8 PyPy3.10 Auth
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 
   # Green framework tests
-  - name: green-eventlet-rhel8-py3.9
+  - name: green-eventlet-rhel8-python3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Green Eventlet RHEL8 py3.9
+    display_name: Green Eventlet RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      GREEN_FRAMEWORK: eventlet
-      AUTH: auth
-      SSL: ssl
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: green-gevent-rhel8-py3.9
+  - name: green-gevent-rhel8-python3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Green Gevent RHEL8 py3.9
+    display_name: Green Gevent RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      GREEN_FRAMEWORK: gevent
-      AUTH: auth
-      SSL: ssl
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: green-eventlet-rhel8-py3.12
+  - name: green-eventlet-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Green Eventlet RHEL8 py3.12
+    display_name: Green Eventlet RHEL8 Python3.12
     run_on:
       - rhel87-small
-    expansions:
-      GREEN_FRAMEWORK: eventlet
-      AUTH: auth
-      SSL: ssl
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: green-gevent-rhel8-py3.12
+  - name: green-gevent-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: Green Gevent RHEL8 py3.12
+    display_name: Green Gevent RHEL8 Python3.12
     run_on:
       - rhel87-small
-    expansions:
-      GREEN_FRAMEWORK: gevent
-      AUTH: auth
-      SSL: ssl
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
 
   # Load balancer tests
-  - name: load-balancer-rhel8-v6.0-py3.9
+  - name: load-balancer-rhel8-v6.0-python3.9
     tasks:
       - name: .load-balancer
-    display_name: Load Balancer RHEL8 v6.0 py3.9
+    display_name: Load Balancer RHEL8 v6.0 Python3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-      VERSION: "6.0"
-  - name: load-balancer-rhel8-v7.0-py3.9
+  - name: load-balancer-rhel8-v7.0-python3.9
     tasks:
       - name: .load-balancer
-    display_name: Load Balancer RHEL8 v7.0 py3.9
+    display_name: Load Balancer RHEL8 v7.0 Python3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-      VERSION: "7.0"
-  - name: load-balancer-rhel8-v8.0-py3.9
+  - name: load-balancer-rhel8-v8.0-python3.9
     tasks:
       - name: .load-balancer
-    display_name: Load Balancer RHEL8 v8.0 py3.9
+    display_name: Load Balancer RHEL8 v8.0 Python3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-      VERSION: "8.0"
-  - name: load-balancer-rhel8-rapid-py3.9
+  - name: load-balancer-rhel8-rapid-python3.9
     tasks:
       - name: .load-balancer
-    display_name: Load Balancer RHEL8 rapid py3.9
+    display_name: Load Balancer RHEL8 rapid Python3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-      VERSION: rapid
-  - name: load-balancer-rhel8-latest-py3.9
+  - name: load-balancer-rhel8-latest-python3.9
     tasks:
       - name: .load-balancer
-    display_name: Load Balancer RHEL8 latest py3.9
+    display_name: Load Balancer RHEL8 latest Python3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-      VERSION: latest
 
   # Mockupdb tests
-  - name: mockupdb-rhel8-py3.9
+  - name: mockupdb-rhel8-python3.9
     tasks:
       - name: mockupdb
-    display_name: MockupDB RHEL8 py3.9
+    display_name: MockupDB RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Mod wsgi tests
-  - name: mod_wsgi-ubuntu-22-py3.9
+  - name: mod_wsgi-ubuntu-22-python3.9
     tasks:
       - name: mod-wsgi-standalone
       - name: mod-wsgi-replica-set
       - name: mod-wsgi-embedded-mode-standalone
       - name: mod-wsgi-embedded-mode-replica-set
-    display_name: mod_wsgi Ubuntu-22 py3.9
+    display_name: mod_wsgi Ubuntu-22 Python3.9
     run_on:
       - ubuntu2204-small
-    expansions:
-      MOD_WSGI_VERSION: "4"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: mod_wsgi-ubuntu-22-py3.13
+  - name: mod_wsgi-ubuntu-22-python3.13
     tasks:
       - name: mod-wsgi-standalone
       - name: mod-wsgi-replica-set
       - name: mod-wsgi-embedded-mode-standalone
       - name: mod-wsgi-embedded-mode-replica-set
-    display_name: mod_wsgi Ubuntu-22 py3.13
+    display_name: mod_wsgi Ubuntu-22 Python3.13
     run_on:
       - ubuntu2204-small
-    expansions:
-      MOD_WSGI_VERSION: "4"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # No c ext tests
-  - name: no-c-ext-rhel8-py3.9
+  - name: no-c-ext-rhel8-python3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: No C Ext RHEL8 py3.9
+    display_name: No C Ext RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: no-c-ext-rhel8-py3.10
+  - name: no-c-ext-rhel8-python3.10
     tasks:
       - name: .replica_set .noauth .nossl .sync_async
-    display_name: No C Ext RHEL8 py3.10
+    display_name: No C Ext RHEL8 Python3.10
     run_on:
       - rhel87-small
-    expansions:
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: no-c-ext-rhel8-py3.11
+  - name: no-c-ext-rhel8-python3.11
     tasks:
       - name: .sharded_cluster .noauth .nossl .sync_async
-    display_name: No C Ext RHEL8 py3.11
+    display_name: No C Ext RHEL8 Python3.11
     run_on:
       - rhel87-small
-    expansions:
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: no-c-ext-rhel8-py3.12
+  - name: no-c-ext-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
-    display_name: No C Ext RHEL8 py3.12
+    display_name: No C Ext RHEL8 Python3.12
     run_on:
       - rhel87-small
-    expansions:
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: no-c-ext-rhel8-py3.13
+  - name: no-c-ext-rhel8-python3.13
     tasks:
       - name: .replica_set .noauth .nossl .sync_async
-    display_name: No C Ext RHEL8 py3.13
+    display_name: No C Ext RHEL8 Python3.13
     run_on:
       - rhel87-small
-    expansions:
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Ocsp tests
-  - name: ocsp-rhel8-v4.4-py3.9
+  - name: ocsp-rhel8-v4.4-python3.9
     tasks:
       - name: .ocsp
-    display_name: OCSP RHEL8 v4.4 py3.9
+    display_name: OCSP RHEL8 v4.4 Python3.9
     run_on:
       - rhel87-small
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-      VERSION: "4.4"
-  - name: ocsp-rhel8-v5.0-py3.10
+  - name: ocsp-rhel8-v5.0-python3.10
     tasks:
       - name: .ocsp
-    display_name: OCSP RHEL8 v5.0 py3.10
+    display_name: OCSP RHEL8 v5.0 Python3.10
     run_on:
       - rhel87-small
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: /opt/python/3.10/bin/python3
-      VERSION: "5.0"
-  - name: ocsp-rhel8-v6.0-py3.11
+  - name: ocsp-rhel8-v6.0-python3.11
     tasks:
       - name: .ocsp
-    display_name: OCSP RHEL8 v6.0 py3.11
+    display_name: OCSP RHEL8 v6.0 Python3.11
     run_on:
       - rhel87-small
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: /opt/python/3.11/bin/python3
-      VERSION: "6.0"
-  - name: ocsp-rhel8-v7.0-py3.12
+  - name: ocsp-rhel8-v7.0-python3.12
     tasks:
       - name: .ocsp
-    display_name: OCSP RHEL8 v7.0 py3.12
+    display_name: OCSP RHEL8 v7.0 Python3.12
     run_on:
       - rhel87-small
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
-      VERSION: "7.0"
-  - name: ocsp-rhel8-v8.0-py3.13
+  - name: ocsp-rhel8-v8.0-python3.13
     tasks:
       - name: .ocsp
-    display_name: OCSP RHEL8 v8.0 py3.13
+    display_name: OCSP RHEL8 v8.0 Python3.13
     run_on:
       - rhel87-small
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
-      VERSION: "8.0"
   - name: ocsp-rhel8-rapid-pypy3.9
     tasks:
       - name: .ocsp
-    display_name: OCSP RHEL8 rapid pypy3.9
+    display_name: OCSP RHEL8 rapid PyPy3.9
     run_on:
       - rhel87-small
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-      VERSION: rapid
   - name: ocsp-rhel8-latest-pypy3.10
     tasks:
       - name: .ocsp
-    display_name: OCSP RHEL8 latest pypy3.10
+    display_name: OCSP RHEL8 latest PyPy3.10
     run_on:
       - rhel87-small
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-      VERSION: latest
-  - name: ocsp-win64-v4.4-py3.9
+  - name: ocsp-win64-v4.4-python3.9
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
-    display_name: OCSP Win64 v4.4 py3.9
+    display_name: OCSP Win64 v4.4 Python3.9
     run_on:
       - windows-64-vsMulti-small
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: C:/python/Python39/python.exe
-      VERSION: "4.4"
-  - name: ocsp-win64-v8.0-py3.13
+  - name: ocsp-win64-v8.0-python3.13
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
-    display_name: OCSP Win64 v8.0 py3.13
+    display_name: OCSP Win64 v8.0 Python3.13
     run_on:
       - windows-64-vsMulti-small
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: C:/python/Python313/python.exe
-      VERSION: "8.0"
-  - name: ocsp-macos-v4.4-py3.9
+  - name: ocsp-macos-v4.4-python3.9
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
-    display_name: OCSP macOS v4.4 py3.9
+    display_name: OCSP macOS v4.4 Python3.9
     run_on:
       - macos-14
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-      VERSION: "4.4"
-  - name: ocsp-macos-v8.0-py3.13
+  - name: ocsp-macos-v8.0-python3.13
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
-    display_name: OCSP macOS v8.0 py3.13
+    display_name: OCSP macOS v8.0 Python3.13
     run_on:
       - macos-14
     batchtime: 20160
-    expansions:
-      AUTH: noauth
-      SSL: ssl
-      TOPOLOGY: server
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-      VERSION: "8.0"
 
   # Oidc auth tests
   - name: auth-oidc-ubuntu-22
@@ -981,198 +675,148 @@ buildvariants:
     batchtime: 20160
 
   # Pyopenssl tests
-  - name: pyopenssl-macos-py3.9
+  - name: pyopenssl-macos-python3.9
     tasks:
       - name: .replica_set .noauth .nossl .sync_async
       - name: .7.0 .noauth .nossl .sync_async
-    display_name: PyOpenSSL macOS py3.9
+    display_name: PyOpenSSL macOS Python3.9
     run_on:
       - macos-14
     batchtime: 10080
-    expansions:
-      test_pyopenssl: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: pyopenssl-rhel8-py3.10
+  - name: pyopenssl-rhel8-python3.10
     tasks:
       - name: .replica_set .auth .ssl .sync_async
       - name: .7.0 .auth .ssl .sync_async
-    display_name: PyOpenSSL RHEL8 py3.10
+    display_name: PyOpenSSL RHEL8 Python3.10
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_pyopenssl: "true"
-      PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: pyopenssl-rhel8-py3.11
+  - name: pyopenssl-rhel8-python3.11
     tasks:
       - name: .replica_set .auth .ssl .sync_async
       - name: .7.0 .auth .ssl .sync_async
-    display_name: PyOpenSSL RHEL8 py3.11
+    display_name: PyOpenSSL RHEL8 Python3.11
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_pyopenssl: "true"
-      PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: pyopenssl-rhel8-py3.12
+  - name: pyopenssl-rhel8-python3.12
     tasks:
       - name: .replica_set .auth .ssl .sync_async
       - name: .7.0 .auth .ssl .sync_async
-    display_name: PyOpenSSL RHEL8 py3.12
+    display_name: PyOpenSSL RHEL8 Python3.12
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_pyopenssl: "true"
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
-  - name: pyopenssl-win64-py3.13
+  - name: pyopenssl-win64-python3.13
     tasks:
       - name: .replica_set .auth .ssl .sync_async
       - name: .7.0 .auth .ssl .sync_async
-    display_name: PyOpenSSL Win64 py3.13
+    display_name: PyOpenSSL Win64 Python3.13
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
-    expansions:
-      test_pyopenssl: "true"
-      PYTHON_BINARY: C:/python/Python313/python.exe
   - name: pyopenssl-rhel8-pypy3.9
     tasks:
       - name: .replica_set .auth .ssl .sync_async
       - name: .7.0 .auth .ssl .sync_async
-    display_name: PyOpenSSL RHEL8 pypy3.9
+    display_name: PyOpenSSL RHEL8 PyPy3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_pyopenssl: "true"
-      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
   - name: pyopenssl-rhel8-pypy3.10
     tasks:
       - name: .replica_set .auth .ssl .sync_async
       - name: .7.0 .auth .ssl .sync_async
-    display_name: PyOpenSSL RHEL8 pypy3.10
+    display_name: PyOpenSSL RHEL8 PyPy3.10
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_pyopenssl: "true"
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 
   # Search index tests
-  - name: search-index-helpers-rhel8-py3.9
+  - name: search-index-helpers-rhel8-python3.9
     tasks:
       - name: test_atlas_task_group_search_indexes
-    display_name: Search Index Helpers RHEL8 py3.9
+    display_name: Search Index Helpers RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Server tests
-  - name: test-rhel8-py3.9-cov
+  - name: test-rhel8-python3.9-cov
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
       - name: .sharded_cluster .sync_async
-    display_name: "* Test RHEL8 py3.9 cov"
+    display_name: "* Test RHEL8 Python3.9 cov"
     run_on:
       - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [coverage_tag]
-  - name: test-rhel8-py3.13-cov
+  - name: test-rhel8-python3.13-cov
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
       - name: .sharded_cluster .sync_async
-    display_name: "* Test RHEL8 py3.13 cov"
+    display_name: "* Test RHEL8 Python3.13 cov"
     run_on:
       - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [coverage_tag]
   - name: test-rhel8-pypy3.10-cov
     tasks:
       - name: .standalone .sync_async
       - name: .replica_set .sync_async
       - name: .sharded_cluster .sync_async
-    display_name: "* Test RHEL8 pypy3.10 cov"
+    display_name: "* Test RHEL8 PyPy3.10 cov"
     run_on:
       - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [coverage_tag]
-  - name: test-rhel8-py3.10
+  - name: test-rhel8-python3.10
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: "* Test RHEL8 py3.10"
+    display_name: "* Test RHEL8 Python3.10"
     run_on:
       - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: test-rhel8-py3.11
+  - name: test-rhel8-python3.11
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: "* Test RHEL8 py3.11"
+    display_name: "* Test RHEL8 Python3.11"
     run_on:
       - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: test-rhel8-py3.12
+  - name: test-rhel8-python3.12
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: "* Test RHEL8 py3.12"
+    display_name: "* Test RHEL8 Python3.12"
     run_on:
       - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: test-rhel8-pypy3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
       - name: .replica_set .noauth .ssl .sync_async
       - name: .standalone .noauth .nossl .sync_async
-    display_name: "* Test RHEL8 pypy3.9"
+    display_name: "* Test RHEL8 PyPy3.9"
     run_on:
       - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
-  - name: test-macos-py3.9
+  - name: test-macos-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: "* Test macOS py3.9"
+    display_name: "* Test macOS Python3.9"
     run_on:
       - macos-14
-    expansions:
-      SKIP_CSOT_TESTS: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: test-macos-py3.13
+  - name: test-macos-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: "* Test macOS py3.13"
+    display_name: "* Test macOS Python3.13"
     run_on:
       - macos-14
-    expansions:
-      SKIP_CSOT_TESTS: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-  - name: test-macos-arm64-py3.9
+  - name: test-macos-arm64-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
       - name: .replica_set .noauth .ssl .6.0 !.sync_async
@@ -1189,13 +833,10 @@ buildvariants:
       - name: .sharded_cluster .auth .ssl .latest !.sync_async
       - name: .replica_set .noauth .ssl .latest !.sync_async
       - name: .standalone .noauth .nossl .latest !.sync_async
-    display_name: "* Test macOS Arm64 py3.9"
+    display_name: "* Test macOS Arm64 Python3.9"
     run_on:
       - macos-14-arm64
-    expansions:
-      SKIP_CSOT_TESTS: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
-  - name: test-macos-arm64-py3.13
+  - name: test-macos-arm64-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
       - name: .replica_set .noauth .ssl .6.0 !.sync_async
@@ -1212,85 +853,60 @@ buildvariants:
       - name: .sharded_cluster .auth .ssl .latest !.sync_async
       - name: .replica_set .noauth .ssl .latest !.sync_async
       - name: .standalone .noauth .nossl .latest !.sync_async
-    display_name: "* Test macOS Arm64 py3.13"
+    display_name: "* Test macOS Arm64 Python3.13"
     run_on:
       - macos-14-arm64
-    expansions:
-      SKIP_CSOT_TESTS: "true"
-      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
-  - name: test-win64-py3.9
+  - name: test-win64-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: "* Test Win64 py3.9"
+    display_name: "* Test Win64 Python3.9"
     run_on:
       - windows-64-vsMulti-small
-    expansions:
-      SKIP_CSOT_TESTS: "true"
-      PYTHON_BINARY: C:/python/Python39/python.exe
-  - name: test-win64-py3.13
+  - name: test-win64-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: "* Test Win64 py3.13"
+    display_name: "* Test Win64 Python3.13"
     run_on:
       - windows-64-vsMulti-small
-    expansions:
-      SKIP_CSOT_TESTS: "true"
-      PYTHON_BINARY: C:/python/Python313/python.exe
-  - name: test-win32-py3.9
+  - name: test-win32-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: "* Test Win32 py3.9"
+    display_name: "* Test Win32 Python3.9"
     run_on:
       - windows-64-vsMulti-small
-    expansions:
-      SKIP_CSOT_TESTS: "true"
-      PYTHON_BINARY: C:/python/32/Python39/python.exe
-  - name: test-win32-py3.13
+  - name: test-win32-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
       - name: .replica_set .noauth .ssl !.sync_async
       - name: .standalone .noauth .nossl !.sync_async
-    display_name: "* Test Win32 py3.13"
+    display_name: "* Test Win32 Python3.13"
     run_on:
       - windows-64-vsMulti-small
-    expansions:
-      SKIP_CSOT_TESTS: "true"
-      PYTHON_BINARY: C:/python/32/Python313/python.exe
 
   # Serverless tests
-  - name: serverless-rhel8-py3.9
+  - name: serverless-rhel8-python3.9
     tasks:
       - name: serverless_task_group
-    display_name: Serverless RHEL8 py3.9
+    display_name: Serverless RHEL8 Python3.9
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_serverless: "true"
-      AUTH: auth
-      SSL: ssl
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: serverless-rhel8-py3.13
+  - name: serverless-rhel8-python3.13
     tasks:
       - name: serverless_task_group
-    display_name: Serverless RHEL8 py3.13
+    display_name: Serverless RHEL8 Python3.13
     run_on:
       - rhel87-small
     batchtime: 10080
-    expansions:
-      test_serverless: "true"
-      AUTH: auth
-      SSL: ssl
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Stable api tests
-  - name: stable-api-require-v1-rhel8-py3.9-auth
+  - name: stable-api-require-v1-rhel8-python3.9-auth
     tasks:
       - name: .standalone .5.0 .noauth .nossl .sync_async
       - name: .standalone .6.0 .noauth .nossl .sync_async
@@ -1298,16 +914,11 @@ buildvariants:
       - name: .standalone .8.0 .noauth .nossl .sync_async
       - name: .standalone .rapid .noauth .nossl .sync_async
       - name: .standalone .latest .noauth .nossl .sync_async
-    display_name: Stable API require v1 RHEL8 py3.9 Auth
+    display_name: Stable API require v1 RHEL8 Python3.9 Auth
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      REQUIRE_API_VERSION: "1"
-      MONGODB_API_VERSION: "1"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [versionedApi_tag]
-  - name: stable-api-accept-v2-rhel8-py3.9-auth
+  - name: stable-api-accept-v2-rhel8-python3.9-auth
     tasks:
       - name: .standalone .5.0 .noauth .nossl .sync_async
       - name: .standalone .6.0 .noauth .nossl .sync_async
@@ -1315,15 +926,11 @@ buildvariants:
       - name: .standalone .8.0 .noauth .nossl .sync_async
       - name: .standalone .rapid .noauth .nossl .sync_async
       - name: .standalone .latest .noauth .nossl .sync_async
-    display_name: Stable API accept v2 RHEL8 py3.9 Auth
+    display_name: Stable API accept v2 RHEL8 Python3.9 Auth
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      ORCHESTRATION_FILE: versioned-api-testing.json
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [versionedApi_tag]
-  - name: stable-api-require-v1-rhel8-py3.13-auth
+  - name: stable-api-require-v1-rhel8-python3.13-auth
     tasks:
       - name: .standalone .5.0 .noauth .nossl .sync_async
       - name: .standalone .6.0 .noauth .nossl .sync_async
@@ -1331,16 +938,11 @@ buildvariants:
       - name: .standalone .8.0 .noauth .nossl .sync_async
       - name: .standalone .rapid .noauth .nossl .sync_async
       - name: .standalone .latest .noauth .nossl .sync_async
-    display_name: Stable API require v1 RHEL8 py3.13 Auth
+    display_name: Stable API require v1 RHEL8 Python3.13 Auth
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      REQUIRE_API_VERSION: "1"
-      MONGODB_API_VERSION: "1"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [versionedApi_tag]
-  - name: stable-api-accept-v2-rhel8-py3.13-auth
+  - name: stable-api-accept-v2-rhel8-python3.13-auth
     tasks:
       - name: .standalone .5.0 .noauth .nossl .sync_async
       - name: .standalone .6.0 .noauth .nossl .sync_async
@@ -1348,17 +950,13 @@ buildvariants:
       - name: .standalone .8.0 .noauth .nossl .sync_async
       - name: .standalone .rapid .noauth .nossl .sync_async
       - name: .standalone .latest .noauth .nossl .sync_async
-    display_name: Stable API accept v2 RHEL8 py3.13 Auth
+    display_name: Stable API accept v2 RHEL8 Python3.13 Auth
     run_on:
       - rhel87-small
-    expansions:
-      AUTH: auth
-      ORCHESTRATION_FILE: versioned-api-testing.json
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [versionedApi_tag]
 
   # Storage engine tests
-  - name: storage-inmemory-rhel8-py3.9
+  - name: storage-inmemory-rhel8-python3.9
     tasks:
       - name: .standalone .noauth .nossl .4.0 .sync_async
       - name: .standalone .noauth .nossl .4.4 .sync_async
@@ -1368,19 +966,13 @@ buildvariants:
       - name: .standalone .noauth .nossl .8.0 .sync_async
       - name: .standalone .noauth .nossl .rapid .sync_async
       - name: .standalone .noauth .nossl .latest .sync_async
-    display_name: Storage InMemory RHEL8 py3.9
+    display_name: Storage InMemory RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      STORAGE_ENGINE: inmemory
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: storage-mmapv1-rhel8-py3.9
+  - name: storage-mmapv1-rhel8-python3.9
     tasks:
       - name: .standalone .4.0 .noauth .nossl .sync_async
       - name: .replica_set .4.0 .noauth .nossl .sync_async
-    display_name: Storage MMAPv1 RHEL8 py3.9
+    display_name: Storage MMAPv1 RHEL8 Python3.9
     run_on:
       - rhel87-small
-    expansions:
-      STORAGE_ENGINE: mmapv1
-      PYTHON_BINARY: /opt/python/3.9/bin/python3

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -7,6 +7,9 @@ buildvariants:
     run_on:
       - rhel79-small
     batchtime: 10080
+    expansions:
+      SKIP_HATCH: "true"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: other-hosts-rhel9-fips
     tasks:
       - name: .6.0 .standalone !.sync_async
@@ -14,6 +17,8 @@ buildvariants:
     run_on:
       - rhel92-fips
     batchtime: 10080
+    expansions:
+      SKIP_HATCH: "true"
   - name: other-hosts-rhel8-zseries
     tasks:
       - name: .6.0 .standalone !.sync_async
@@ -21,6 +26,8 @@ buildvariants:
     run_on:
       - rhel8-zseries-small
     batchtime: 10080
+    expansions:
+      SKIP_HATCH: "true"
   - name: other-hosts-rhel8-power8
     tasks:
       - name: .6.0 .standalone !.sync_async
@@ -28,6 +35,8 @@ buildvariants:
     run_on:
       - rhel8-power-small
     batchtime: 10080
+    expansions:
+      SKIP_HATCH: "true"
   - name: other-hosts-rhel8-arm64
     tasks:
       - name: .6.0 .standalone !.sync_async
@@ -35,6 +44,8 @@ buildvariants:
     run_on:
       - rhel82-arm64-small
     batchtime: 10080
+    expansions:
+      SKIP_HATCH: "true"
 
   # Atlas connect tests
   - name: atlas-connect-rhel8-python3.9
@@ -43,12 +54,16 @@ buildvariants:
     display_name: Atlas connect RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: atlas-connect-rhel8-python3.13
     tasks:
       - name: atlas-connect
     display_name: Atlas connect RHEL8 Python3.13
     run_on:
       - rhel87-small
+    expansions:
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Atlas data lake tests
   - name: atlas-data-lake-ubuntu-22-python3.9-auth-no-c
@@ -57,24 +72,38 @@ buildvariants:
     display_name: Atlas Data Lake Ubuntu-22 Python3.9 Auth No C
     run_on:
       - ubuntu2204-small
+    expansions:
+      AUTH: auth
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: atlas-data-lake-ubuntu-22-python3.9-auth
     tasks:
       - name: atlas-data-lake-tests
     display_name: Atlas Data Lake Ubuntu-22 Python3.9 Auth
     run_on:
       - ubuntu2204-small
+    expansions:
+      AUTH: auth
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: atlas-data-lake-ubuntu-22-python3.13-auth-no-c
     tasks:
       - name: atlas-data-lake-tests
     display_name: Atlas Data Lake Ubuntu-22 Python3.13 Auth No C
     run_on:
       - ubuntu2204-small
+    expansions:
+      AUTH: auth
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
   - name: atlas-data-lake-ubuntu-22-python3.13-auth
     tasks:
       - name: atlas-data-lake-tests
     display_name: Atlas Data Lake Ubuntu-22 Python3.13 Auth
     run_on:
       - ubuntu2204-small
+    expansions:
+      AUTH: auth
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Aws auth tests
   - name: auth-aws-ubuntu-20-python3.9
@@ -89,6 +118,8 @@ buildvariants:
     display_name: Auth AWS Ubuntu-20 Python3.9
     run_on:
       - ubuntu2004-small
+    expansions:
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: auth-aws-ubuntu-20-python3.13
     tasks:
       - name: aws-auth-test-4.4
@@ -101,6 +132,8 @@ buildvariants:
     display_name: Auth AWS Ubuntu-20 Python3.13
     run_on:
       - ubuntu2004-small
+    expansions:
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
   - name: auth-aws-win64-python3.9
     tasks:
       - name: aws-auth-test-4.4
@@ -113,6 +146,9 @@ buildvariants:
     display_name: Auth AWS Win64 Python3.9
     run_on:
       - windows-64-vsMulti-small
+    expansions:
+      skip_ECS_auth_test: "true"
+      PYTHON_BINARY: C:/python/Python39/python.exe
   - name: auth-aws-win64-python3.13
     tasks:
       - name: aws-auth-test-4.4
@@ -125,6 +161,9 @@ buildvariants:
     display_name: Auth AWS Win64 Python3.13
     run_on:
       - windows-64-vsMulti-small
+    expansions:
+      skip_ECS_auth_test: "true"
+      PYTHON_BINARY: C:/python/Python313/python.exe
   - name: auth-aws-macos-python3.9
     tasks:
       - name: aws-auth-test-4.4
@@ -137,6 +176,11 @@ buildvariants:
     display_name: Auth AWS macOS Python3.9
     run_on:
       - macos-14
+    expansions:
+      skip_ECS_auth_test: "true"
+      skip_EC2_auth_test: "true"
+      skip_web_identity_auth_test: "true"
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
   - name: auth-aws-macos-python3.13
     tasks:
       - name: aws-auth-test-4.4
@@ -149,6 +193,11 @@ buildvariants:
     display_name: Auth AWS macOS Python3.13
     run_on:
       - macos-14
+    expansions:
+      skip_ECS_auth_test: "true"
+      skip_EC2_auth_test: "true"
+      skip_web_identity_auth_test: "true"
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
   # Compression tests
   - name: compression-snappy-rhel8-python3.9-no-c
@@ -157,54 +206,84 @@ buildvariants:
     display_name: Compression snappy RHEL8 Python3.9 No C
     run_on:
       - rhel87-small
+    expansions:
+      COMPRESSORS: snappy
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: compression-snappy-rhel8-python3.10
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: Compression snappy RHEL8 Python3.10
     run_on:
       - rhel87-small
+    expansions:
+      COMPRESSORS: snappy
+      PYTHON_BINARY: /opt/python/3.10/bin/python3
   - name: compression-zlib-rhel8-python3.11-no-c
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: Compression zlib RHEL8 Python3.11 No C
     run_on:
       - rhel87-small
+    expansions:
+      COMPRESSORS: zlib
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.11/bin/python3
   - name: compression-zlib-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: Compression zlib RHEL8 Python3.12
     run_on:
       - rhel87-small
+    expansions:
+      COMPRESSORS: zlib
+      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: compression-zstd-rhel8-python3.13-no-c
     tasks:
       - name: .standalone .noauth .nossl .sync_async !.4.0
     display_name: Compression zstd RHEL8 Python3.13 No C
     run_on:
       - rhel87-small
+    expansions:
+      COMPRESSORS: zstd
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
   - name: compression-zstd-rhel8-python3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async !.4.0
     display_name: Compression zstd RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      COMPRESSORS: zstd
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: compression-snappy-rhel8-pypy3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: Compression snappy RHEL8 PyPy3.9
     run_on:
       - rhel87-small
+    expansions:
+      COMPRESSORS: snappy
+      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
   - name: compression-zlib-rhel8-pypy3.10
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: Compression zlib RHEL8 PyPy3.10
     run_on:
       - rhel87-small
+    expansions:
+      COMPRESSORS: zlib
+      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
   - name: compression-zstd-rhel8-pypy3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async !.4.0
     display_name: Compression zstd RHEL8 PyPy3.9
     run_on:
       - rhel87-small
+    expansions:
+      COMPRESSORS: zstd
+      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
 
   # Disable test commands tests
   - name: disable-test-commands-rhel8-python3.9
@@ -213,6 +292,11 @@ buildvariants:
     display_name: Disable test commands RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      SSL: ssl
+      DISABLE_TEST_COMMANDS: "1"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Doctests tests
   - name: doctests-rhel8-python3.9
@@ -221,6 +305,8 @@ buildvariants:
     display_name: Doctests RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Encryption tests
   - name: encryption-rhel8-python3.9
@@ -232,6 +318,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [encryption_tag]
   - name: encryption-rhel8-python3.13
     tasks:
@@ -242,6 +331,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [encryption_tag]
   - name: encryption-rhel8-pypy3.10
     tasks:
@@ -252,6 +344,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [encryption_tag]
   - name: encryption-crypt_shared-rhel8-python3.9
     tasks:
@@ -262,6 +357,10 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_crypt_shared: "true"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [encryption_tag]
   - name: encryption-crypt_shared-rhel8-python3.13
     tasks:
@@ -272,6 +371,10 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_crypt_shared: "true"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [encryption_tag]
   - name: encryption-crypt_shared-rhel8-pypy3.10
     tasks:
@@ -282,6 +385,10 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_crypt_shared: "true"
+      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [encryption_tag]
   - name: encryption-pyopenssl-rhel8-python3.9
     tasks:
@@ -292,6 +399,10 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_encryption_pyopenssl: "true"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [encryption_tag]
   - name: encryption-pyopenssl-rhel8-python3.13
     tasks:
@@ -302,6 +413,10 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_encryption_pyopenssl: "true"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [encryption_tag]
   - name: encryption-pyopenssl-rhel8-pypy3.10
     tasks:
@@ -312,6 +427,10 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_encryption_pyopenssl: "true"
+      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [encryption_tag]
   - name: encryption-rhel8-python3.10
     tasks:
@@ -319,24 +438,38 @@ buildvariants:
     display_name: Encryption RHEL8 Python3.10
     run_on:
       - rhel87-small
+    expansions:
+      test_encryption: "true"
+      PYTHON_BINARY: /opt/python/3.10/bin/python3
   - name: encryption-crypt_shared-rhel8-python3.11
     tasks:
       - name: .replica_set .noauth .ssl .sync_async
     display_name: Encryption crypt_shared RHEL8 Python3.11
     run_on:
       - rhel87-small
+    expansions:
+      test_encryption: "true"
+      test_crypt_shared: "true"
+      PYTHON_BINARY: /opt/python/3.11/bin/python3
   - name: encryption-pyopenssl-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: Encryption PyOpenSSL RHEL8 Python3.12
     run_on:
       - rhel87-small
+    expansions:
+      test_encryption: "true"
+      test_encryption_pyopenssl: "true"
+      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: encryption-rhel8-pypy3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
     display_name: Encryption RHEL8 PyPy3.9
     run_on:
       - rhel87-small
+    expansions:
+      test_encryption: "true"
+      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
   - name: encryption-macos-python3.9
     tasks:
       - name: .latest .replica_set .sync_async
@@ -344,6 +477,9 @@ buildvariants:
     run_on:
       - macos-14
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     tags: [encryption_tag]
   - name: encryption-macos-python3.13
     tasks:
@@ -352,6 +488,9 @@ buildvariants:
     run_on:
       - macos-14
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
     tags: [encryption_tag]
   - name: encryption-crypt_shared-macos-python3.9
     tasks:
@@ -360,6 +499,10 @@ buildvariants:
     run_on:
       - macos-14
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_crypt_shared: "true"
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
     tags: [encryption_tag]
   - name: encryption-crypt_shared-macos-python3.13
     tasks:
@@ -368,6 +511,10 @@ buildvariants:
     run_on:
       - macos-14
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_crypt_shared: "true"
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
     tags: [encryption_tag]
   - name: encryption-win64-python3.9
     tasks:
@@ -376,6 +523,9 @@ buildvariants:
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      PYTHON_BINARY: C:/python/Python39/python.exe
     tags: [encryption_tag]
   - name: encryption-win64-python3.13
     tasks:
@@ -384,6 +534,9 @@ buildvariants:
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      PYTHON_BINARY: C:/python/Python313/python.exe
     tags: [encryption_tag]
   - name: encryption-crypt_shared-win64-python3.9
     tasks:
@@ -392,6 +545,10 @@ buildvariants:
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_crypt_shared: "true"
+      PYTHON_BINARY: C:/python/Python39/python.exe
     tags: [encryption_tag]
   - name: encryption-crypt_shared-win64-python3.13
     tasks:
@@ -400,6 +557,10 @@ buildvariants:
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
+    expansions:
+      test_encryption: "true"
+      test_crypt_shared: "true"
+      PYTHON_BINARY: C:/python/Python313/python.exe
     tags: [encryption_tag]
 
   # Enterprise auth tests
@@ -409,42 +570,63 @@ buildvariants:
     display_name: Auth Enterprise macOS Python3.9 Auth
     run_on:
       - macos-14
+    expansions:
+      AUTH: auth
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
   - name: auth-enterprise-rhel8-python3.10-auth
     tasks:
       - name: test-enterprise-auth
     display_name: Auth Enterprise RHEL8 Python3.10 Auth
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      PYTHON_BINARY: /opt/python/3.10/bin/python3
   - name: auth-enterprise-rhel8-python3.11-auth
     tasks:
       - name: test-enterprise-auth
     display_name: Auth Enterprise RHEL8 Python3.11 Auth
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      PYTHON_BINARY: /opt/python/3.11/bin/python3
   - name: auth-enterprise-rhel8-python3.12-auth
     tasks:
       - name: test-enterprise-auth
     display_name: Auth Enterprise RHEL8 Python3.12 Auth
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: auth-enterprise-win64-python3.13-auth
     tasks:
       - name: test-enterprise-auth
     display_name: Auth Enterprise Win64 Python3.13 Auth
     run_on:
       - windows-64-vsMulti-small
+    expansions:
+      AUTH: auth
+      PYTHON_BINARY: C:/python/Python313/python.exe
   - name: auth-enterprise-rhel8-pypy3.9-auth
     tasks:
       - name: test-enterprise-auth
     display_name: Auth Enterprise RHEL8 PyPy3.9 Auth
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
   - name: auth-enterprise-rhel8-pypy3.10-auth
     tasks:
       - name: test-enterprise-auth
     display_name: Auth Enterprise RHEL8 PyPy3.10 Auth
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 
   # Green framework tests
   - name: green-eventlet-rhel8-python3.9
@@ -453,24 +635,44 @@ buildvariants:
     display_name: Green Eventlet RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      GREEN_FRAMEWORK: eventlet
+      AUTH: auth
+      SSL: ssl
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: green-gevent-rhel8-python3.9
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: Green Gevent RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      GREEN_FRAMEWORK: gevent
+      AUTH: auth
+      SSL: ssl
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: green-eventlet-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: Green Eventlet RHEL8 Python3.12
     run_on:
       - rhel87-small
+    expansions:
+      GREEN_FRAMEWORK: eventlet
+      AUTH: auth
+      SSL: ssl
+      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: green-gevent-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: Green Gevent RHEL8 Python3.12
     run_on:
       - rhel87-small
+    expansions:
+      GREEN_FRAMEWORK: gevent
+      AUTH: auth
+      SSL: ssl
+      PYTHON_BINARY: /opt/python/3.12/bin/python3
 
   # Load balancer tests
   - name: load-balancer-rhel8-v6.0-python3.9
@@ -480,6 +682,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      VERSION: "6.0"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: load-balancer-rhel8-v7.0-python3.9
     tasks:
       - name: .load-balancer
@@ -487,6 +692,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      VERSION: "7.0"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: load-balancer-rhel8-v8.0-python3.9
     tasks:
       - name: .load-balancer
@@ -494,6 +702,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      VERSION: "8.0"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: load-balancer-rhel8-rapid-python3.9
     tasks:
       - name: .load-balancer
@@ -501,6 +712,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      VERSION: rapid
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: load-balancer-rhel8-latest-python3.9
     tasks:
       - name: .load-balancer
@@ -508,6 +722,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      VERSION: latest
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Mockupdb tests
   - name: mockupdb-rhel8-python3.9
@@ -516,6 +733,8 @@ buildvariants:
     display_name: MockupDB RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Mod wsgi tests
   - name: mod_wsgi-ubuntu-22-python3.9
@@ -527,6 +746,9 @@ buildvariants:
     display_name: mod_wsgi Ubuntu-22 Python3.9
     run_on:
       - ubuntu2204-small
+    expansions:
+      MOD_WSGI_VERSION: "4"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: mod_wsgi-ubuntu-22-python3.13
     tasks:
       - name: mod-wsgi-standalone
@@ -536,6 +758,9 @@ buildvariants:
     display_name: mod_wsgi Ubuntu-22 Python3.13
     run_on:
       - ubuntu2204-small
+    expansions:
+      MOD_WSGI_VERSION: "4"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # No c ext tests
   - name: no-c-ext-rhel8-python3.9
@@ -544,30 +769,45 @@ buildvariants:
     display_name: No C Ext RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: no-c-ext-rhel8-python3.10
     tasks:
       - name: .replica_set .noauth .nossl .sync_async
     display_name: No C Ext RHEL8 Python3.10
     run_on:
       - rhel87-small
+    expansions:
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.10/bin/python3
   - name: no-c-ext-rhel8-python3.11
     tasks:
       - name: .sharded_cluster .noauth .nossl .sync_async
     display_name: No C Ext RHEL8 Python3.11
     run_on:
       - rhel87-small
+    expansions:
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.11/bin/python3
   - name: no-c-ext-rhel8-python3.12
     tasks:
       - name: .standalone .noauth .nossl .sync_async
     display_name: No C Ext RHEL8 Python3.12
     run_on:
       - rhel87-small
+    expansions:
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: no-c-ext-rhel8-python3.13
     tasks:
       - name: .replica_set .noauth .nossl .sync_async
     display_name: No C Ext RHEL8 Python3.13
     run_on:
       - rhel87-small
+    expansions:
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Ocsp tests
   - name: ocsp-rhel8-v4.4-python3.9
@@ -577,6 +817,12 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: "4.4"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: ocsp-rhel8-v5.0-python3.10
     tasks:
       - name: .ocsp
@@ -584,6 +830,12 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: "5.0"
+      PYTHON_BINARY: /opt/python/3.10/bin/python3
   - name: ocsp-rhel8-v6.0-python3.11
     tasks:
       - name: .ocsp
@@ -591,6 +843,12 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: "6.0"
+      PYTHON_BINARY: /opt/python/3.11/bin/python3
   - name: ocsp-rhel8-v7.0-python3.12
     tasks:
       - name: .ocsp
@@ -598,6 +856,12 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: "7.0"
+      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: ocsp-rhel8-v8.0-python3.13
     tasks:
       - name: .ocsp
@@ -605,6 +869,12 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: "8.0"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
   - name: ocsp-rhel8-rapid-pypy3.9
     tasks:
       - name: .ocsp
@@ -612,6 +882,12 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: rapid
+      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
   - name: ocsp-rhel8-latest-pypy3.10
     tasks:
       - name: .ocsp
@@ -619,6 +895,12 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: latest
+      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
   - name: ocsp-win64-v4.4-python3.9
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
@@ -626,6 +908,12 @@ buildvariants:
     run_on:
       - windows-64-vsMulti-small
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: "4.4"
+      PYTHON_BINARY: C:/python/Python39/python.exe
   - name: ocsp-win64-v8.0-python3.13
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
@@ -633,6 +921,12 @@ buildvariants:
     run_on:
       - windows-64-vsMulti-small
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: "8.0"
+      PYTHON_BINARY: C:/python/Python313/python.exe
   - name: ocsp-macos-v4.4-python3.9
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
@@ -640,6 +934,12 @@ buildvariants:
     run_on:
       - macos-14
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: "4.4"
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
   - name: ocsp-macos-v8.0-python3.13
     tasks:
       - name: .ocsp-rsa !.ocsp-staple
@@ -647,6 +947,12 @@ buildvariants:
     run_on:
       - macos-14
     batchtime: 20160
+    expansions:
+      AUTH: noauth
+      SSL: ssl
+      TOPOLOGY: server
+      VERSION: "8.0"
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
 
   # Oidc auth tests
   - name: auth-oidc-ubuntu-22
@@ -683,6 +989,9 @@ buildvariants:
     run_on:
       - macos-14
     batchtime: 10080
+    expansions:
+      test_pyopenssl: "true"
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
   - name: pyopenssl-rhel8-python3.10
     tasks:
       - name: .replica_set .auth .ssl .sync_async
@@ -691,6 +1000,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_pyopenssl: "true"
+      PYTHON_BINARY: /opt/python/3.10/bin/python3
   - name: pyopenssl-rhel8-python3.11
     tasks:
       - name: .replica_set .auth .ssl .sync_async
@@ -699,6 +1011,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_pyopenssl: "true"
+      PYTHON_BINARY: /opt/python/3.11/bin/python3
   - name: pyopenssl-rhel8-python3.12
     tasks:
       - name: .replica_set .auth .ssl .sync_async
@@ -707,6 +1022,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_pyopenssl: "true"
+      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: pyopenssl-win64-python3.13
     tasks:
       - name: .replica_set .auth .ssl .sync_async
@@ -715,6 +1033,9 @@ buildvariants:
     run_on:
       - windows-64-vsMulti-small
     batchtime: 10080
+    expansions:
+      test_pyopenssl: "true"
+      PYTHON_BINARY: C:/python/Python313/python.exe
   - name: pyopenssl-rhel8-pypy3.9
     tasks:
       - name: .replica_set .auth .ssl .sync_async
@@ -723,6 +1044,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_pyopenssl: "true"
+      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
   - name: pyopenssl-rhel8-pypy3.10
     tasks:
       - name: .replica_set .auth .ssl .sync_async
@@ -731,6 +1055,9 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_pyopenssl: "true"
+      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 
   # Search index tests
   - name: search-index-helpers-rhel8-python3.9
@@ -739,6 +1066,8 @@ buildvariants:
     display_name: Search Index Helpers RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Server tests
   - name: test-rhel8-python3.9-cov
@@ -749,6 +1078,9 @@ buildvariants:
     display_name: "* Test RHEL8 Python3.9 cov"
     run_on:
       - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [coverage_tag]
   - name: test-rhel8-python3.13-cov
     tasks:
@@ -758,6 +1090,9 @@ buildvariants:
     display_name: "* Test RHEL8 Python3.13 cov"
     run_on:
       - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [coverage_tag]
   - name: test-rhel8-pypy3.10-cov
     tasks:
@@ -767,6 +1102,9 @@ buildvariants:
     display_name: "* Test RHEL8 PyPy3.10 cov"
     run_on:
       - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [coverage_tag]
   - name: test-rhel8-python3.10
     tasks:
@@ -776,6 +1114,9 @@ buildvariants:
     display_name: "* Test RHEL8 Python3.10"
     run_on:
       - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      PYTHON_BINARY: /opt/python/3.10/bin/python3
   - name: test-rhel8-python3.11
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
@@ -784,6 +1125,9 @@ buildvariants:
     display_name: "* Test RHEL8 Python3.11"
     run_on:
       - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      PYTHON_BINARY: /opt/python/3.11/bin/python3
   - name: test-rhel8-python3.12
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
@@ -792,6 +1136,9 @@ buildvariants:
     display_name: "* Test RHEL8 Python3.12"
     run_on:
       - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: test-rhel8-pypy3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .sync_async
@@ -800,6 +1147,9 @@ buildvariants:
     display_name: "* Test RHEL8 PyPy3.9"
     run_on:
       - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      PYTHON_BINARY: /opt/python/pypy3.9/bin/python3
   - name: test-macos-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
@@ -808,6 +1158,8 @@ buildvariants:
     display_name: "* Test macOS Python3.9"
     run_on:
       - macos-14
+    expansions:
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
   - name: test-macos-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
@@ -816,6 +1168,8 @@ buildvariants:
     display_name: "* Test macOS Python3.13"
     run_on:
       - macos-14
+    expansions:
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
   - name: test-macos-arm64-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
@@ -836,6 +1190,8 @@ buildvariants:
     display_name: "* Test macOS Arm64 Python3.9"
     run_on:
       - macos-14-arm64
+    expansions:
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
   - name: test-macos-arm64-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl .6.0 !.sync_async
@@ -856,6 +1212,8 @@ buildvariants:
     display_name: "* Test macOS Arm64 Python3.13"
     run_on:
       - macos-14-arm64
+    expansions:
+      PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.13/bin/python3
   - name: test-win64-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
@@ -864,6 +1222,8 @@ buildvariants:
     display_name: "* Test Win64 Python3.9"
     run_on:
       - windows-64-vsMulti-small
+    expansions:
+      PYTHON_BINARY: C:/python/Python39/python.exe
   - name: test-win64-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
@@ -872,6 +1232,8 @@ buildvariants:
     display_name: "* Test Win64 Python3.13"
     run_on:
       - windows-64-vsMulti-small
+    expansions:
+      PYTHON_BINARY: C:/python/Python313/python.exe
   - name: test-win32-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
@@ -880,6 +1242,8 @@ buildvariants:
     display_name: "* Test Win32 Python3.9"
     run_on:
       - windows-64-vsMulti-small
+    expansions:
+      PYTHON_BINARY: C:/python/32/Python39/python.exe
   - name: test-win32-python3.13
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
@@ -888,6 +1252,8 @@ buildvariants:
     display_name: "* Test Win32 Python3.13"
     run_on:
       - windows-64-vsMulti-small
+    expansions:
+      PYTHON_BINARY: C:/python/32/Python313/python.exe
 
   # Serverless tests
   - name: serverless-rhel8-python3.9
@@ -897,6 +1263,11 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_serverless: "true"
+      AUTH: auth
+      SSL: ssl
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: serverless-rhel8-python3.13
     tasks:
       - name: serverless_task_group
@@ -904,6 +1275,11 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      test_serverless: "true"
+      AUTH: auth
+      SSL: ssl
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
 
   # Stable api tests
   - name: stable-api-require-v1-rhel8-python3.9-auth
@@ -917,6 +1293,11 @@ buildvariants:
     display_name: Stable API require v1 RHEL8 Python3.9 Auth
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      REQUIRE_API_VERSION: "1"
+      MONGODB_API_VERSION: "1"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [versionedApi_tag]
   - name: stable-api-accept-v2-rhel8-python3.9-auth
     tasks:
@@ -929,6 +1310,10 @@ buildvariants:
     display_name: Stable API accept v2 RHEL8 Python3.9 Auth
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      ORCHESTRATION_FILE: versioned-api-testing.json
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [versionedApi_tag]
   - name: stable-api-require-v1-rhel8-python3.13-auth
     tasks:
@@ -941,6 +1326,11 @@ buildvariants:
     display_name: Stable API require v1 RHEL8 Python3.13 Auth
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      REQUIRE_API_VERSION: "1"
+      MONGODB_API_VERSION: "1"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [versionedApi_tag]
   - name: stable-api-accept-v2-rhel8-python3.13-auth
     tasks:
@@ -953,6 +1343,10 @@ buildvariants:
     display_name: Stable API accept v2 RHEL8 Python3.13 Auth
     run_on:
       - rhel87-small
+    expansions:
+      AUTH: auth
+      ORCHESTRATION_FILE: versioned-api-testing.json
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
     tags: [versionedApi_tag]
 
   # Storage engine tests
@@ -969,6 +1363,9 @@ buildvariants:
     display_name: Storage InMemory RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      STORAGE_ENGINE: inmemory
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: storage-mmapv1-rhel8-python3.9
     tasks:
       - name: .standalone .4.0 .noauth .nossl .sync_async
@@ -976,3 +1373,6 @@ buildvariants:
     display_name: Storage MMAPv1 RHEL8 Python3.9
     run_on:
       - rhel87-small
+    expansions:
+      STORAGE_ENGINE: mmapv1
+      PYTHON_BINARY: /opt/python/3.9/bin/python3

--- a/.evergreen/scripts/configure-env.sh
+++ b/.evergreen/scripts/configure-env.sh
@@ -46,6 +46,11 @@ export PROJECT="$project"
 export PIP_QUIET=1
 EOT
 
+# Skip CSOT tests on non-linux platforms.
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "export SKIP_CSOT_TESTS=1" >> $SCRIPT_DIR/env.sh
+fi
+
 # Add these expansions to make it easier to call out tests scripts from the EVG yaml
 cat <<EOT > expansion.yml
 DRIVERS_TOOLS: "$DRIVERS_TOOLS"

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -132,7 +132,9 @@ def create_variant(
         expansions["VERSION"] = version
     if python:
         expansions["PYTHON_BINARY"] = get_python_binary(python, host)
-    return create_variant_generic(task_names, display_name, version=version, host=host, **kwargs)
+    return create_variant_generic(
+        task_names, display_name, version=version, host=host, expansions=expansions, **kwargs
+    )
 
 
 def get_python_binary(python: str, host: Host) -> str:


### PR DESCRIPTION
- Rename py3.x ->  Python3.x
- Centralize SKIP_CSOT_TEST usage
- Refactor handling of Host in generator and prep for moving the parts of the generator to drivers-evergreen-tools.