### PR TITLE
PYTHON-4907 Avoid noisy TypeError at interpreter exit

### DIFF
--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -1195,7 +1195,8 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
                     ResourceWarning,
                     stacklevel=2,
                 )
-        except AttributeError:
+        except (AttributeError, TypeError):
+            # Ignore errors at interpreter exit.
             pass
 
     def _close_cursor_soon(

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -1193,7 +1193,8 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
                     ResourceWarning,
                     stacklevel=2,
                 )
-        except AttributeError:
+        except (AttributeError, TypeError):
+            # Ignore errors at interpreter exit.
             pass
 
     def _close_cursor_soon(


### PR DESCRIPTION
PYTHON-4907 Avoid noisy TypeError at interpreter exit