### PR TITLE
PYTHON-4356 Unskip spec tests for agg $out

### DIFF
--- a/test/asynchronous/unified_format.py
+++ b/test/asynchronous/unified_format.py
@@ -545,15 +545,6 @@ class UnifiedSpecTestMixinV1(AsyncIntegrationTest):
                 or "Cancel server check" in spec["description"]
             ):
                 self.skipTest("MMAPv1 does not support retryWrites=True")
-        if (
-            "AsyncDatabase-level aggregate with $out includes read preference for 5.0+ server"
-            in spec["description"]
-        ):
-            if async_client_context.version[0] == 8:
-                self.skipTest("waiting on PYTHON-4356")
-        if "Aggregate with $out includes read preference for 5.0+ server" in spec["description"]:
-            if async_client_context.version[0] == 8:
-                self.skipTest("waiting on PYTHON-4356")
         if "Client side error in command starting transaction" in spec["description"]:
             self.skipTest("Implement PYTHON-1894")
         if "timeoutMS applied to entire download" in spec["description"]:

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -543,15 +543,6 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
                 or "Cancel server check" in spec["description"]
             ):
                 self.skipTest("MMAPv1 does not support retryWrites=True")
-        if (
-            "Database-level aggregate with $out includes read preference for 5.0+ server"
-            in spec["description"]
-        ):
-            if client_context.version[0] == 8:
-                self.skipTest("waiting on PYTHON-4356")
-        if "Aggregate with $out includes read preference for 5.0+ server" in spec["description"]:
-            if client_context.version[0] == 8:
-                self.skipTest("waiting on PYTHON-4356")
         if "Client side error in command starting transaction" in spec["description"]:
             self.skipTest("Implement PYTHON-1894")
         if "timeoutMS applied to entire download" in spec["description"]:


### PR DESCRIPTION
PYTHON-4356 Unskip spec tests for agg $out


The spec tests themselves were already updated in PYTHON-4576.