### PR TITLE
PYTHON-4414 interruptInUseConnections should cancel pending connections too

### DIFF
--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -1296,8 +1296,8 @@ class Pool:
 
         conn = AsyncConnection(sock, self, self.address, conn_id)  # type: ignore[arg-type]
         async with self.lock:
-            self.active_contexts.discard(tmp_context)
             self.active_contexts.add(conn.cancel_context)
+            self.active_contexts.discard(tmp_context)
         if tmp_context.cancelled:
             conn.cancel_context.cancel()
         try:

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -1290,8 +1290,8 @@ class Pool:
 
         conn = Connection(sock, self, self.address, conn_id)  # type: ignore[arg-type]
         with self.lock:
-            self.active_contexts.discard(tmp_context)
             self.active_contexts.add(conn.cancel_context)
+            self.active_contexts.discard(tmp_context)
         if tmp_context.cancelled:
             conn.cancel_context.cancel()
         try:

--- a/test/test_connection_monitoring.py
+++ b/test/test_connection_monitoring.py
@@ -216,11 +216,6 @@ class TestCMAP(IntegrationTest):
 
     def run_scenario(self, scenario_def, test):
         """Run a CMAP spec test."""
-        if (
-            scenario_def["description"]
-            == "clear with interruptInUseConnections = true closes pending connections"
-        ):
-            self.skipTest("Skip pending PYTHON-4414")
         self.logs: list = []
         self.assertEqual(scenario_def["version"], 1)
         self.assertIn(scenario_def["style"], ["unit", "integration"])


### PR DESCRIPTION
PYTHON-4414 interruptInUseConnections should cancel pending connections too

Judging from the test logs, this appears to be a minor bug in the implementation of interruptInUseConnections added in PYTHON-3175. If the pool is cleared simultaneously while a thread is creating a connection, the pending connection is not cancelled or closed. Instead the connection is created normally and added to the pool as shown in the log of the failed test:
```
Events:
 [2024/04/29 03:44:47.090] PoolCreatedEvent(('localhost', 27017), {})
 [2024/04/29 03:44:47.090] PoolReadyEvent(('localhost', 27017))
 [2024/04/29 03:44:47.090] ConnectionCheckOutStartedEvent(('localhost', 27017))
 [2024/04/29 03:44:47.090] ConnectionCreatedEvent(('localhost', 27017), 1)
 [2024/04/29 03:44:47.090] PoolClearedEvent(('localhost', 27017), None, True)
 [2024/04/29 03:44:47.090] ConnectionReadyEvent(('localhost', 27017), 1, 10.015425856999968)
 [2024/04/29 03:44:47.090] ConnectionCheckedOutEvent(('localhost', 27017), 1, 10.018921869999986)
```

The fix is to ensure that pending connections are interrupted as well.