### PR TITLE
PYTHON-4982 Remove redundant configureFailPoint

### DIFF
--- a/test/asynchronous/test_retryable_reads.py
+++ b/test/asynchronous/test_retryable_reads.py
@@ -174,9 +174,8 @@ class TestRetryableReads(AsyncIntegrationTest):
             retryReads=True,
         )
 
-        async with self.fail_point(fail_command):
-            with self.assertRaises(AutoReconnect):
-                await client.t.t.find_one({})
+        with self.assertRaises(AutoReconnect):
+            await client.t.t.find_one({})
 
         # Disable failpoints on each mongos
         for client in mongos_clients:

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -174,9 +174,8 @@ class TestRetryableReads(IntegrationTest):
             retryReads=True,
         )
 
-        with self.fail_point(fail_command):
-            with self.assertRaises(AutoReconnect):
-                client.t.t.find_one({})
+        with self.assertRaises(AutoReconnect):
+            client.t.t.find_one({})
 
         # Disable failpoints on each mongos
         for client in mongos_clients:


### PR DESCRIPTION
PYTHON-4982 Remove redundant configureFailPoint

This shouldn't resolve all the issues but it's worth removing the redundant code.