### PR TITLE
PYTHON-5006 Skip test_kms_retry when using PyOpenSSL

### DIFF
--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -41,7 +41,11 @@ import pytest
 from pymongo.asynchronous.collection import AsyncCollection
 from pymongo.asynchronous.helpers import anext
 from pymongo.daemon import _spawn_daemon
-from pymongo.ssl_context import _ssl
+
+try:
+    from pymongo.pyopenssl_context import IS_PYOPENSSL
+except ImportError:
+    IS_PYOPENSSL = False
 
 sys.path[0:0] = [""]
 
@@ -2922,7 +2926,7 @@ class TestKmsRetryProse(AsyncEncryptionIntegrationTest):
             await self.client_encryption.create_data_key(provider, master_key=master_key)
 
     async def test_kms_retry(self):
-        if _ssl.IS_PYOPENSSL:
+        if IS_PYOPENSSL:
             self.skipTest(
                 "PyOpenSSL does not support a required method for this test, Connection.makefile"
             )

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -41,7 +41,7 @@ import pytest
 from pymongo.asynchronous.collection import AsyncCollection
 from pymongo.asynchronous.helpers import anext
 from pymongo.daemon import _spawn_daemon
-from pymongo.pyopenssl_context import IS_PYOPENSSL
+from pymongo.ssl_context import _ssl
 
 sys.path[0:0] = [""]
 
@@ -2922,7 +2922,7 @@ class TestKmsRetryProse(AsyncEncryptionIntegrationTest):
             await self.client_encryption.create_data_key(provider, master_key=master_key)
 
     async def test_kms_retry(self):
-        if IS_PYOPENSSL:
+        if _ssl.IS_PYOPENSSL:
             self.skipTest(
                 "PyOpenSSL does not support a required method for this test, Connection.makefile"
             )

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -2861,7 +2861,6 @@ class TestKmsRetryProse(AsyncEncryptionIntegrationTest):
     @unittest.skipUnless(any(AWS_CREDS.values()), "AWS environment credentials are not set")
     async def asyncSetUp(self):
         await super().asyncSetUp()
-
         # 1, create client with only tlsCAFile.
         providers: dict = copy.deepcopy(ALL_KMS_PROVIDERS)
         providers["azure"]["identityPlatformEndpoint"] = "127.0.0.1:9003"

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -39,7 +39,7 @@ from typing import Any, Dict, Mapping, Optional
 import pytest
 
 from pymongo.daemon import _spawn_daemon
-from pymongo.pyopenssl_context import IS_PYOPENSSL
+from pymongo.ssl_context import _ssl
 from pymongo.synchronous.collection import Collection
 from pymongo.synchronous.helpers import next
 
@@ -2904,7 +2904,7 @@ class TestKmsRetryProse(EncryptionIntegrationTest):
             self.client_encryption.create_data_key(provider, master_key=master_key)
 
     def test_kms_retry(self):
-        if IS_PYOPENSSL:
+        if _ssl.IS_PYOPENSSL:
             self.skipTest(
                 "PyOpenSSL does not support a required method for this test, Connection.makefile"
             )

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -39,6 +39,7 @@ from typing import Any, Dict, Mapping, Optional
 import pytest
 
 from pymongo.daemon import _spawn_daemon
+from pymongo.pyopenssl_context import IS_PYOPENSSL
 from pymongo.synchronous.collection import Collection
 from pymongo.synchronous.helpers import next
 
@@ -2842,6 +2843,7 @@ class TestKmsRetryProse(EncryptionIntegrationTest):
     @unittest.skipUnless(any(AWS_CREDS.values()), "AWS environment credentials are not set")
     def setUp(self):
         super().setUp()
+
         # 1, create client with only tlsCAFile.
         providers: dict = copy.deepcopy(ALL_KMS_PROVIDERS)
         providers["azure"]["identityPlatformEndpoint"] = "127.0.0.1:9003"
@@ -2903,6 +2905,10 @@ class TestKmsRetryProse(EncryptionIntegrationTest):
             self.client_encryption.create_data_key(provider, master_key=master_key)
 
     def test_kms_retry(self):
+        if IS_PYOPENSSL:
+            self.skipTest(
+                "PyOpenSSL does not support a required method for this test, Connection.makefile"
+            )
         self._test("aws", {"region": "foo", "key": "bar", "endpoint": "127.0.0.1:9003"})
         self._test("azure", {"keyVaultEndpoint": "127.0.0.1:9003", "keyName": "foo"})
         self._test(

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -2843,7 +2843,6 @@ class TestKmsRetryProse(EncryptionIntegrationTest):
     @unittest.skipUnless(any(AWS_CREDS.values()), "AWS environment credentials are not set")
     def setUp(self):
         super().setUp()
-
         # 1, create client with only tlsCAFile.
         providers: dict = copy.deepcopy(ALL_KMS_PROVIDERS)
         providers["azure"]["identityPlatformEndpoint"] = "127.0.0.1:9003"

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -39,9 +39,13 @@ from typing import Any, Dict, Mapping, Optional
 import pytest
 
 from pymongo.daemon import _spawn_daemon
-from pymongo.ssl_context import _ssl
 from pymongo.synchronous.collection import Collection
 from pymongo.synchronous.helpers import next
+
+try:
+    from pymongo.pyopenssl_context import IS_PYOPENSSL
+except ImportError:
+    IS_PYOPENSSL = False
 
 sys.path[0:0] = [""]
 
@@ -2904,7 +2908,7 @@ class TestKmsRetryProse(EncryptionIntegrationTest):
             self.client_encryption.create_data_key(provider, master_key=master_key)
 
     def test_kms_retry(self):
-        if _ssl.IS_PYOPENSSL:
+        if IS_PYOPENSSL:
             self.skipTest(
                 "PyOpenSSL does not support a required method for this test, Connection.makefile"
             )


### PR DESCRIPTION
Passing build: https://spruce.mongodb.com/version/675076633360e3000745b3c6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC