### PR TITLE
PYTHON-5016 Create spawn host helper scripts

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-set -o xtrace   # Write all commands first to stderr
-set -o errexit  # Exit the script with error if any of the commands fail
+set -eu
 
 # Copy PyMongo's test certificates over driver-evergreen-tools'
 cp ${PROJECT_DIRECTORY}/test/certificates/* ${DRIVERS_TOOLS}/.evergreen/x509gen/
@@ -9,7 +8,7 @@ cp ${PROJECT_DIRECTORY}/test/certificates/* ${DRIVERS_TOOLS}/.evergreen/x509gen/
 cp ${PROJECT_DIRECTORY}/test/certificates/client.pem ${MONGO_ORCHESTRATION_HOME}/lib/client.pem
 
 # Ensure hatch is installed.
-bash ${PROJECT_DIRECTORY}/scripts/ensure-hatch.sh
+bash ${PROJECT_DIRECTORY}/.evergreen/scripts/ensure-hatch.sh
 
 if [ -w /etc/hosts ]; then
   SUDO=""

--- a/.evergreen/scripts/configure-env.sh
+++ b/.evergreen/scripts/configure-env.sh
@@ -1,8 +1,10 @@
-#!/bin/bash -eux
+#!/bin/bash
+
+set -eu
 
 # Get the current unique version of this checkout
 # shellcheck disable=SC2154
-if [ "$is_patch" = "true" ]; then
+if [ "${is_patch:-}" = "true" ]; then
     # shellcheck disable=SC2154
     CURRENT_VERSION="$(git describe)-patch-$version_id"
 else
@@ -14,7 +16,7 @@ DRIVERS_TOOLS="$(dirname $PROJECT_DIRECTORY)/drivers-tools"
 CARGO_HOME=${CARGO_HOME:-${DRIVERS_TOOLS}/.cargo}
 
 # Python has cygwin path problems on Windows. Detect prospective mongo-orchestration home directory
-if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
+if [ "Windows_NT" = "${OS:-}" ]; then # Magic variable in cygwin
     DRIVERS_TOOLS=$(cygpath -m $DRIVERS_TOOLS)
     PROJECT_DIRECTORY=$(cygpath -m $PROJECT_DIRECTORY)
     CARGO_HOME=$(cygpath -m $CARGO_HOME)

--- a/.evergreen/scripts/configure-env.sh
+++ b/.evergreen/scripts/configure-env.sh
@@ -61,7 +61,7 @@ export CARGO_HOME="$CARGO_HOME"
 export TMPDIR="$MONGO_ORCHESTRATION_HOME/db"
 export PATH="$MONGODB_BINARIES:$PATH"
 # shellcheck disable=SC2154
-export PROJECT="$project"
+export PROJECT="${project:-mongo-python-driver}"
 export PIP_QUIET=1
 EOT
 

--- a/.evergreen/scripts/prepare-resources.sh
+++ b/.evergreen/scripts/prepare-resources.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+set -eu
 
-. src/.evergreen/scripts/env.sh
-set -o xtrace
+HERE=$(dirname ${BASH_SOURCE:-$0})
+pushd $HERE
+. env.sh
+
 rm -rf $DRIVERS_TOOLS
 if [ "$PROJECT" = "drivers-tools" ]; then
     # If this was a patch build, doing a fresh clone would not actually test the patch
@@ -10,3 +13,5 @@ else
     git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
 fi
 echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" >$MONGO_ORCHESTRATION_HOME/orchestration.config
+
+popd

--- a/.evergreen/scripts/setup-system.sh
+++ b/.evergreen/scripts/setup-system.sh
@@ -3,7 +3,7 @@
 set -eu
 
 HERE=$(dirname ${BASH_SOURCE:-$0})
-pushd $(dirname $(dirname $HERE))
+pushd "$(dirname "$(dirname $HERE)")"
 echo "Setting up system..."
 bash .evergreen/scripts/configure-env.sh
 source .evergreen/scripts/env.sh

--- a/.evergreen/scripts/setup-system.sh
+++ b/.evergreen/scripts/setup-system.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+HERE=$(dirname ${BASH_SOURCE:-$0})
+pushd $(dirname $(dirname $HERE))
+echo "Setting up system..."
+bash .evergreen/scripts/configure-env.sh
+source .evergreen/scripts/env.sh
+bash .evergreen/scripts/prepare-resources.sh
+bash $DRIVERS_TOOLS/.evergreen/setup.sh
+bash .evergreen/scripts/install-dependencies.sh
+popd
+echo "Setting up system... done."

--- a/.evergreen/setup-spawn-host.sh
+++ b/.evergreen/setup-spawn-host.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu
+
+if [ -z "$1" ]
+  then
+    echo "Must supply a spawn host URL!"
+fi
+
+target=$1
+
+echo "Copying files to $target..."
+rsync -az -e ssh --exclude '.git' --filter=':- .gitignore' -r . $target:/home/ec2-user/mongo-python-driver
+echo "Copying files to $target... done"
+
+ssh $target /home/ec2-user/mongo-python-driver/.evergreen/scripts/setup-system.sh

--- a/.evergreen/sync-spawn-host.sh
+++ b/.evergreen/sync-spawn-host.sh
@@ -8,5 +8,6 @@ fi
 target=$1
 
 echo "Syncing files to $target..."
+# shellcheck disable=SC2034
 fswatch -o . | while read f; do rsync -hazv -e ssh --exclude '.git' --filter=':- .gitignore' -r . $target:/home/ec2-user/mongo-python-driver; done
 echo "Syncing files to $target... done."

--- a/.evergreen/sync-spawn-host.sh
+++ b/.evergreen/sync-spawn-host.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+  then
+    echo "Must supply a spawn host URL!"
+fi
+
+target=$1
+
+echo "Syncing files to $target..."
+fswatch -o . | while read f; do rsync -hazv -e ssh --exclude '.git' --filter=':- .gitignore' -r . $target:/home/ec2-user/mongo-python-driver; done
+echo "Syncing files to $target... done."


### PR DESCRIPTION
Once this is merged I can update the team wiki with suggested usage:

- Ensure `fswatch` is installed using `brew`
- Create a spawn host
- Run `bash .evergreen/setup-spawn-host.sh <url>`
- Run `bash .evergreen/sync-spawn-host.sh <url>`
- Start server on the spawn host - drivers tools is in `~/drivers-tools`
- Develop locally and watch as changes sync.
- Run tests on remote machine.  Env variables can be sourced using `source ~/mongo-python-driver/.evergreen/scripts/env.sh`

