### PR TITLE
PYTHON-5020 Fix behavior of network timeouts on pyopenssl connections

### DIFF
--- a/pymongo/pyopenssl_context.py
+++ b/pymongo/pyopenssl_context.py
@@ -125,7 +125,8 @@ class _sslConn(_SSL.Connection):
             try:
                 return call(*args, **kwargs)
             except BLOCKING_IO_ERRORS as exc:
-                if is_async:
+                # Do not retry if the connection is in non-blocking mode.
+                if is_async or timeout == 0:
                     raise exc
                 # Check for closed socket.
                 if self.fileno() == -1:


### PR DESCRIPTION
PYTHON-5020 Fix behavior of network timeouts on pyopenssl connections


The explanation is that previous to PYTHON-4292 we never put the connection in non-blocking mode so this bug in our pyopenssl wrapper code was never noticed.