### PR TITLE
PYTHON-5014 Tests that use HTTPSConnection should only use stdlib ssl

### DIFF
--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -98,7 +98,6 @@ from pymongo.errors import (
     WriteError,
 )
 from pymongo.operations import InsertOne, ReplaceOne, UpdateOne
-from pymongo.ssl_support import get_ssl_context
 from pymongo.write_concern import WriteConcern
 
 _IS_SYNC = False
@@ -2879,15 +2878,8 @@ class TestKmsRetryProse(AsyncEncryptionIntegrationTest):
     async def http_post(self, path, data=None):
         # Note, the connection to the mock server needs to be closed after
         # each request because the server is single threaded.
-        ctx: ssl.SSLContext = get_ssl_context(
-            CLIENT_PEM,  # certfile
-            None,  # passphrase
-            CA_PEM,  # ca_certs
-            None,  # crlfile
-            False,  # allow_invalid_certificates
-            False,  # allow_invalid_hostnames
-            False,  # disable_ocsp_endpoint_check
-        )
+        ctx = ssl.create_default_context(cafile=CA_PEM)
+        ctx.load_cert_chain(CLIENT_PEM)
         conn = http.client.HTTPSConnection("127.0.0.1:9003", context=ctx)
         try:
             if data is not None:

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -95,7 +95,6 @@ from pymongo.errors import (
     WriteError,
 )
 from pymongo.operations import InsertOne, ReplaceOne, UpdateOne
-from pymongo.ssl_support import get_ssl_context
 from pymongo.synchronous import encryption
 from pymongo.synchronous.encryption import Algorithm, ClientEncryption, QueryType
 from pymongo.synchronous.mongo_client import MongoClient
@@ -2861,15 +2860,8 @@ class TestKmsRetryProse(EncryptionIntegrationTest):
     def http_post(self, path, data=None):
         # Note, the connection to the mock server needs to be closed after
         # each request because the server is single threaded.
-        ctx: ssl.SSLContext = get_ssl_context(
-            CLIENT_PEM,  # certfile
-            None,  # passphrase
-            CA_PEM,  # ca_certs
-            None,  # crlfile
-            False,  # allow_invalid_certificates
-            False,  # allow_invalid_hostnames
-            False,  # disable_ocsp_endpoint_check
-        )
+        ctx = ssl.create_default_context(cafile=CA_PEM)
+        ctx.load_cert_chain(CLIENT_PEM)
         conn = http.client.HTTPSConnection("127.0.0.1:9003", context=ctx)
         try:
             if data is not None:


### PR DESCRIPTION
PYTHON-5014 Tests that use HTTPSConnection should only use stdlib ssl

Attempting to fix this test failure on pyopenssl+encryption:
```
 [2024/12/09 09:18:59.661] FAILURE: NotImplementedError: Cannot make file object of OpenSSL.SSL.Connection ()
 [2024/12/09 09:18:59.661] self = <test.asynchronous.test_encryption.TestKmsRetryProse testMethod=test_kms_retry>
 [2024/12/09 09:18:59.661]     async def test_kms_retry(self):
 [2024/12/09 09:18:59.661] >       await self._test("aws", {"region": "foo", "key": "bar", "endpoint": "127.0.0.1:9003"})
 [2024/12/09 09:18:59.661] test/asynchronous/test_encryption.py:2924: 
 [2024/12/09 09:18:59.661] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 [2024/12/09 09:18:59.661] test/asynchronous/test_encryption.py:2901: in _test
 [2024/12/09 09:18:59.661]     await self.http_post("/reset")
 [2024/12/09 09:18:59.661] test/asynchronous/test_encryption.py:2895: in http_post
 [2024/12/09 09:18:59.661]     res = conn.getresponse()
 [2024/12/09 09:18:59.661] /opt/python/3.13/lib/python3.13/http/client.py:1424: in getresponse
 [2024/12/09 09:18:59.661]     response = self.response_class(self.sock, method=self._method)
 [2024/12/09 09:18:59.661] /opt/python/3.13/lib/python3.13/http/client.py:269: in __init__
 [2024/12/09 09:18:59.661]     self.fp = sock.makefile("rb")
 [2024/12/09 09:18:59.661] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 [2024/12/09 09:18:59.661] self = <pymongo.pyopenssl_context._sslConn object at 0x7f96bc700f50>
 [2024/12/09 09:18:59.661] args = ('rb',), kwargs = {}
 [2024/12/09 09:18:59.661]     def makefile(self, *args: Any, **kwargs: Any) -> typing.NoReturn:
 [2024/12/09 09:18:59.661]         """
 [2024/12/09 09:18:59.661]         The makefile() method is not implemented, since there is no dup
 [2024/12/09 09:18:59.661]         semantics for SSL connections
 [2024/12/09 09:18:59.661]     
 [2024/12/09 09:18:59.661]         :raise: NotImplementedError
 [2024/12/09 09:18:59.661]         """
 [2024/12/09 09:18:59.661] >       raise NotImplementedError(
 [2024/12/09 09:18:59.661]             "Cannot make file object of OpenSSL.SSL.Connection"
 [2024/12/09 09:18:59.661]         )
 [2024/12/09 09:18:59.661] E       NotImplementedError: Cannot make file object of OpenSSL.SSL.Connection
 [2024/12/09 09:18:59.661] .hatch/data/env/virtual/test/lib/python3.13/site-packages/OpenSSL/SSL.py:2560: NotImplementedError
```
https://spruce.mongodb.com/task/mongo_python_driver_encryption_pyopenssl_rhel8_python3.13_test_4.4_replica_set_noauth_ssl_sync_async_ff2f95987f945fed483dcf802082ac3a173eb905_24_12_04_00_16_47/tests?execution=0&sortBy=STATUS&sortDir=ASC