### PR TITLE
PYTHON-5038 Resolve certificate verify failed: Missing Authority Key Identifier

### DIFF
--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -2884,6 +2884,7 @@ class TestKmsRetryProse(AsyncEncryptionIntegrationTest):
         # each request because the server is single threaded.
         ctx = ssl.create_default_context(cafile=CA_PEM)
         ctx.load_cert_chain(CLIENT_PEM)
+        ctx.verify_mode = ssl.CERT_NONE
         conn = http.client.HTTPSConnection("127.0.0.1:9003", context=ctx)
         try:
             if data is not None:

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -2884,6 +2884,7 @@ class TestKmsRetryProse(AsyncEncryptionIntegrationTest):
         # each request because the server is single threaded.
         ctx = ssl.create_default_context(cafile=CA_PEM)
         ctx.load_cert_chain(CLIENT_PEM)
+        ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         conn = http.client.HTTPSConnection("127.0.0.1:9003", context=ctx)
         try:

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -2866,6 +2866,7 @@ class TestKmsRetryProse(EncryptionIntegrationTest):
         # each request because the server is single threaded.
         ctx = ssl.create_default_context(cafile=CA_PEM)
         ctx.load_cert_chain(CLIENT_PEM)
+        ctx.verify_mode = ssl.CERT_NONE
         conn = http.client.HTTPSConnection("127.0.0.1:9003", context=ctx)
         try:
             if data is not None:

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -2866,6 +2866,7 @@ class TestKmsRetryProse(EncryptionIntegrationTest):
         # each request because the server is single threaded.
         ctx = ssl.create_default_context(cafile=CA_PEM)
         ctx.load_cert_chain(CLIENT_PEM)
+        ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         conn = http.client.HTTPSConnection("127.0.0.1:9003", context=ctx)
         try:


### PR DESCRIPTION
PYTHON-5038 Resolve "certificate verify failed: Missing Authority Key Identifier" errors.