### PR TITLE
PYTHON-4999 Resync retryable writes tests

### DIFF
--- a/test/retryable_writes/unified/aggregate-out-merge.json
+++ b/test/retryable_writes/unified/aggregate-out-merge.json
@@ -1,6 +1,6 @@
 {
   "description": "aggregate with $out/$merge does not set txnNumber",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "3.6",
@@ -45,6 +45,11 @@
   "tests": [
     {
       "description": "aggregate with $out does not set txnNumber",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "object": "collection0",


### PR DESCRIPTION
PYTHON-4999 Resync retryable writes tests

Fixes one test failure on serverless.