### PR TITLE
PYTHON-5059 Update default maxMessageSizeBytes and maxWriteBatchSize

### DIFF
--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -60,10 +60,10 @@ ORDERED_TYPES: Sequence[Type] = (SON, OrderedDict)
 
 # Defaults until we connect to a server and get updated limits.
 MAX_BSON_SIZE = 16 * (1024**2)
-MAX_MESSAGE_SIZE: int = 2 * MAX_BSON_SIZE
+MAX_MESSAGE_SIZE = 48 * 1000 * 1000
 MIN_WIRE_VERSION = 0
 MAX_WIRE_VERSION = 0
-MAX_WRITE_BATCH_SIZE = 1000
+MAX_WRITE_BATCH_SIZE = 100000
 
 # What this version of PyMongo supports.
 MIN_SUPPORTED_SERVER_VERSION = "4.0"

--- a/pymongo/hello.py
+++ b/pymongo/hello.py
@@ -133,7 +133,7 @@ class Hello(Generic[_DocumentType]):
 
     @property
     def max_message_size(self) -> int:
-        return self._doc.get("maxMessageSizeBytes", 2 * self.max_bson_size)
+        return self._doc.get("maxMessageSizeBytes", common.MAX_MESSAGE_SIZE)
 
     @property
     def max_write_batch_size(self) -> int:

--- a/test/test_server_description.py
+++ b/test/test_server_description.py
@@ -23,6 +23,7 @@ from test import unittest
 
 from bson.int64 import Int64
 from bson.objectid import ObjectId
+from pymongo import common
 from pymongo.hello import Hello, HelloCompat
 from pymongo.server_description import ServerDescription
 from pymongo.server_type import SERVER_TYPE
@@ -132,11 +133,13 @@ class TestServerDescription(unittest.TestCase):
         self.assertEqual(4, s.min_wire_version)
         self.assertEqual(25, s.max_wire_version)
 
-    def test_default_max_message_size(self):
-        s = parse_hello_response({"ok": 1, HelloCompat.LEGACY_CMD: True, "maxBsonObjectSize": 2})
-
-        # Twice max_bson_size.
-        self.assertEqual(4, s.max_message_size)
+    def test_defaults(self):
+        s = parse_hello_response({"ok": 1, HelloCompat.LEGACY_CMD: True})
+        self.assertEqual(common.MAX_BSON_SIZE, s.max_bson_size)
+        self.assertEqual(common.MAX_MESSAGE_SIZE, s.max_message_size)
+        self.assertEqual(common.MIN_WIRE_VERSION, s.min_wire_version)
+        self.assertEqual(common.MAX_WIRE_VERSION, s.max_wire_version)
+        self.assertEqual(common.MAX_WRITE_BATCH_SIZE, s.max_write_batch_size)
 
     def test_standalone(self):
         s = parse_hello_response({"ok": 1, HelloCompat.LEGACY_CMD: True})


### PR DESCRIPTION
PYTHON-5059 Update default maxMessageSizeBytes and maxWriteBatchSize

Now that we only support MongoDB 4.0+, we know the server's 
maxMessageSizeBytes is always 48MB and maxWriteBatchSize is always 100,000.