### PR TITLE
PYTHON-5047 Fix dry run logic in releases again

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -23,7 +23,7 @@ env:
   SILK_ASSET_GROUP: mongodb-python-driver
   EVERGREEN_PROJECT: mongo-python-driver
   # Constant
-  DRY_RUN: ${{ inputs.dry_run == 'true' }}
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'true' }}
   FOLLOWING_VERSION: ${{ inputs.following_version || '' }}
   VERSION: ${{ inputs.version || '10.10.10.10' }}
 


### PR DESCRIPTION
Tested on my fork to confirm the behavior: https://github.com/blink1073/mongo-python-driver/actions/runs/9552412608