### PR TITLE
PYTHON-5071 Workaround PyPy SSL bug again

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -934,9 +934,12 @@ class PyMongoTestCase(unittest.TestCase):
         self.assertEqual(sanitize_reply(expected), sanitize_reply(actual), msg)
 
     @staticmethod
-    def configure_fail_point(client, command_args):
+    def configure_fail_point(client, command_args, off=False):
         cmd = {"configureFailPoint": "failCommand"}
         cmd.update(command_args)
+        if off:
+            cmd["mode"] = "off"
+            cmd.pop("data", None)
         try:
             client.admin.command(cmd)
             return
@@ -949,13 +952,11 @@ class PyMongoTestCase(unittest.TestCase):
 
     @contextmanager
     def fail_point(self, command_args):
-        name = command_args.get("configureFailPoint", "failCommand")
         self.configure_fail_point(client_context.client, command_args)
         try:
             yield
         finally:
-            cmd_off = {"configureFailPoint": name, "mode": "off"}
-            self.configure_fail_point(client_context.client, cmd_off)
+            self.configure_fail_point(client_context.client, command_args, off=True)
 
     @contextmanager
     def fork(

--- a/test/asynchronous/test_transactions.py
+++ b/test/asynchronous/test_transactions.py
@@ -410,15 +410,10 @@ class TestTransactionsConvenientAPI(AsyncTransactionsBase):
             for address in async_client_context.mongoses:
                 self.mongos_clients.append(await self.async_single_client("{}:{}".format(*address)))
 
-    async def _set_fail_point(self, client, command_args):
-        cmd = {"configureFailPoint": "failCommand"}
-        cmd.update(command_args)
-        await client.admin.command(cmd)
-
     async def set_fail_point(self, command_args):
         clients = self.mongos_clients if self.mongos_clients else [self.client]
         for client in clients:
-            await self._set_fail_point(client, command_args)
+            await self.configure_fail_point(client, command_args)
 
     @async_client_context.require_transactions
     async def test_callback_raises_custom_error(self):

--- a/test/asynchronous/unified_format.py
+++ b/test/asynchronous/unified_format.py
@@ -1008,12 +1008,8 @@ class UnifiedSpecTestMixinV1(AsyncIntegrationTest):
         if not async_client_context.test_commands_enabled:
             self.skipTest("Test commands must be enabled")
 
-        cmd_on = SON([("configureFailPoint", "failCommand")])
-        cmd_on.update(command_args)
-        await client.admin.command(cmd_on)
-        self.addAsyncCleanup(
-            client.admin.command, "configureFailPoint", cmd_on["configureFailPoint"], mode="off"
-        )
+        await self.configure_fail_point(client, command_args)
+        self.addAsyncCleanup(self.configure_fail_point, client, command_args, off=True)
 
     async def _testOperation_failPoint(self, spec):
         await self.__set_fail_point(

--- a/test/asynchronous/utils_spec_runner.py
+++ b/test/asynchronous/utils_spec_runner.py
@@ -265,15 +265,10 @@ class AsyncSpecRunner(AsyncIntegrationTest):
     async def asyncTearDown(self) -> None:
         self.knobs.disable()
 
-    async def _set_fail_point(self, client, command_args):
-        cmd = SON([("configureFailPoint", "failCommand")])
-        cmd.update(command_args)
-        await client.admin.command(cmd)
-
     async def set_fail_point(self, command_args):
         clients = self.mongos_clients if self.mongos_clients else [self.client]
         for client in clients:
-            await self._set_fail_point(client, command_args)
+            await self.configure_fail_point(client, command_args)
 
     async def targeted_fail_point(self, session, fail_point):
         """Run the targetedFailPoint test operation.
@@ -282,7 +277,7 @@ class AsyncSpecRunner(AsyncIntegrationTest):
         """
         clients = {c.address: c for c in self.mongos_clients}
         client = clients[session._pinned_address]
-        await self._set_fail_point(client, fail_point)
+        await self.configure_fail_point(client, fail_point)
         self.addAsyncCleanup(self.set_fail_point, {"mode": "off"})
 
     def assert_session_pinned(self, session):

--- a/test/test_connection_monitoring.py
+++ b/test/test_connection_monitoring.py
@@ -204,15 +204,10 @@ class TestCMAP(IntegrationTest):
         self.check_object(actual, expected)
         self.assertIn(message, str(actual))
 
-    def _set_fail_point(self, client, command_args):
-        cmd = SON([("configureFailPoint", "failCommand")])
-        cmd.update(command_args)
-        client.admin.command(cmd)
-
     def set_fail_point(self, command_args):
         if not client_context.supports_failCommand_fail_point:
             self.skipTest("failCommand fail point must be supported")
-        self._set_fail_point(self.client, command_args)
+        self.configure_fail_point(self.client, command_args)
 
     def run_scenario(self, scenario_def, test):
         """Run a CMAP spec test."""

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -402,15 +402,10 @@ class TestTransactionsConvenientAPI(TransactionsBase):
             for address in client_context.mongoses:
                 self.mongos_clients.append(self.single_client("{}:{}".format(*address)))
 
-    def _set_fail_point(self, client, command_args):
-        cmd = {"configureFailPoint": "failCommand"}
-        cmd.update(command_args)
-        client.admin.command(cmd)
-
     def set_fail_point(self, command_args):
         clients = self.mongos_clients if self.mongos_clients else [self.client]
         for client in clients:
-            self._set_fail_point(client, command_args)
+            self.configure_fail_point(client, command_args)
 
     @client_context.require_transactions
     def test_callback_raises_custom_error(self):

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -999,12 +999,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         if not client_context.test_commands_enabled:
             self.skipTest("Test commands must be enabled")
 
-        cmd_on = SON([("configureFailPoint", "failCommand")])
-        cmd_on.update(command_args)
-        client.admin.command(cmd_on)
-        self.addCleanup(
-            client.admin.command, "configureFailPoint", cmd_on["configureFailPoint"], mode="off"
-        )
+        self.configure_fail_point(client, command_args)
+        self.addCleanup(self.configure_fail_point, client, command_args, off=True)
 
     def _testOperation_failPoint(self, spec):
         self.__set_fail_point(

--- a/test/utils_spec_runner.py
+++ b/test/utils_spec_runner.py
@@ -265,15 +265,10 @@ class SpecRunner(IntegrationTest):
     def tearDown(self) -> None:
         self.knobs.disable()
 
-    def _set_fail_point(self, client, command_args):
-        cmd = SON([("configureFailPoint", "failCommand")])
-        cmd.update(command_args)
-        client.admin.command(cmd)
-
     def set_fail_point(self, command_args):
         clients = self.mongos_clients if self.mongos_clients else [self.client]
         for client in clients:
-            self._set_fail_point(client, command_args)
+            self.configure_fail_point(client, command_args)
 
     def targeted_fail_point(self, session, fail_point):
         """Run the targetedFailPoint test operation.
@@ -282,7 +277,7 @@ class SpecRunner(IntegrationTest):
         """
         clients = {c.address: c for c in self.mongos_clients}
         client = clients[session._pinned_address]
-        self._set_fail_point(client, fail_point)
+        self.configure_fail_point(client, fail_point)
         self.addCleanup(self.set_fail_point, {"mode": "off"})
 
     def assert_session_pinned(self, session):


### PR DESCRIPTION
The previous changes in PYTHON-5071 somehow made the issue in PYTHON-5011 crop up more frequently. This change attempts to reduce the test failures caused by that pypy ssl bug.