### PR TITLE
PYTHON-5105 - Convert test.test_srv_polling to async

### DIFF
--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -226,6 +226,7 @@ converted_tests = [
     "test_retryable_writes.py",
     "test_retryable_writes_unified.py",
     "test_session.py",
+    "test_srv_polling.py",
     "test_transactions.py",
     "unified_format.py",
 ]


### PR DESCRIPTION
I've opened https://jira.mongodb.org/browse/PYTHON-5119 to track refactoring `AsyncPymongoTestCase` to be asynchronous.