### PR TITLE
PYTHON-5058 Restore alternate architecture builds

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -62,7 +62,11 @@ jobs:
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: all
+          # setup-qemu-action by default uses `tonistiigi/binfmt:latest` image,
+          # which is out of date. This causes seg faults during build.
+          # Here we manually fix the version.
+          image: tonistiigi/binfmt:qemu-v8.1.5
+          platforms: arm64
 
       - name: Install cibuildwheel
         # Note: the default manylinux is manylinux2014

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -35,10 +35,9 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
         - [ubuntu-20.04, "manylinux_x86_64", "cp3*-manylinux_x86_64"]
-        - [ubuntu-24.04-arm, "manylinux_aarch64", "cp3*-manylinux_aarch64"]
-        # Disabled pending PYTHON-5058
-        # - [ubuntu-24.04, "manylinux_ppc64le", "cp3*-manylinux_ppc64le"]
-        # - [ubuntu-24.04, "manylinux_s390x", "cp3*-manylinux_s390x"]
+        - [ubuntu-20.04, "manylinux_aarch64", "cp3*-manylinux_aarch64"]
+        - [ubuntu-20.04, "manylinux_ppc64le", "cp3*-manylinux_ppc64le"]
+        - [ubuntu-20.04, "manylinux_s390x", "cp3*-manylinux_s390x"]
         - [ubuntu-20.04, "manylinux_i686", "cp3*-manylinux_i686"]
         - [windows-2019, "win_amd6", "cp3*-win_amd64"]
         - [windows-2019, "win32", "cp3*-win32"]

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -66,7 +66,7 @@ jobs:
           # which is out of date. This causes seg faults during build.
           # Here we manually fix the version.
           image: tonistiigi/binfmt:qemu-v8.1.5
-          platforms: arm64
+          platforms: all
 
       - name: Install cibuildwheel
         # Note: the default manylinux is manylinux2014

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,7 +11,6 @@ Changes in Version 4.11.0 (YYYY/MM/DD)
    A future minor release of PyMongo will raise the minimum supported MongoDB Server version from 4.0 to 4.2.
    This is in accordance with [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
    **Support for MongoDB Server 4.0 will be dropped in a future release!**
-.. warning:: This version does not include wheels for ``ppc64le`` or ``s390x`` architectures, see `PYTHON-5058`_ for more information.
 
 PyMongo 4.11 brings a number of changes including:
 
@@ -50,7 +49,6 @@ in this release.
 .. _PyMongo 4.11 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=40784
 .. _PYTHON-5027: https://jira.mongodb.org/browse/PYTHON-5027
 .. _PYTHON-5024: https://jira.mongodb.org/browse/PYTHON-5024
-.. _PYTHON-5058: https://jira.mongodb.org/browse/PYTHON-5058
 
 Changes in Version 4.10.1 (2024/10/01)
 --------------------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,6 +11,7 @@ Changes in Version 4.11.0 (YYYY/MM/DD)
    A future minor release of PyMongo will raise the minimum supported MongoDB Server version from 4.0 to 4.2.
    This is in accordance with [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles).
    **Support for MongoDB Server 4.0 will be dropped in a future release!**
+.. warning:: This version does not include wheels for ``ppc64le`` or ``s390x`` architectures, see `PYTHON-5058`_ for more information.
 
 PyMongo 4.11 brings a number of changes including:
 
@@ -49,6 +50,7 @@ in this release.
 .. _PyMongo 4.11 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=40784
 .. _PYTHON-5027: https://jira.mongodb.org/browse/PYTHON-5027
 .. _PYTHON-5024: https://jira.mongodb.org/browse/PYTHON-5024
+.. _PYTHON-5058: https://jira.mongodb.org/browse/PYTHON-5058
 
 Changes in Version 4.10.1 (2024/10/01)
 --------------------------------------


### PR DESCRIPTION
Uses approach from https://github.com/PennyLaneAI/pennylane-lightning/pull/1056/files to select a newer version of the binfmt image.

Stop using the aarch64 runners as well because they are randomly crashing during the checkout phase, when it tries to remove credentials.