### PR TITLE
PYTHON-5111 Update datetime_conversion in docstrings of MongoClients

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ documentation including narrative docs, and the [Sphinx docstring format](https:
 You can build the documentation locally by running:
 
 ```bash
-just docs-build
+just docs
 ```
 
 When updating docs, it can be helpful to run the live docs server as:

--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -276,7 +276,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
         :param type_registry: instance of
             :class:`~bson.codec_options.TypeRegistry` to enable encoding
             and decoding of custom types.
-        :param kwargs: Additional optional parameters available as keyword arguments
+        :param kwargs: **Additional optional parameters available as keyword arguments:**
 
           - `datetime_conversion` (optional): Specifies how UTC datetimes should be decoded
             within BSON. Valid options include 'datetime_ms' to return as a

--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -276,9 +276,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
         :param type_registry: instance of
             :class:`~bson.codec_options.TypeRegistry` to enable encoding
             and decoding of custom types.
-        :param kwargs: ...
-
-          | **Other optional parameters can be passed as keyword arguments:**
+        :param kwargs: Additional optional parameters available as keyword arguments
 
           - `datetime_conversion` (optional): Specifies how UTC datetimes should be decoded
             within BSON. Valid options include 'datetime_ms' to return as a

--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -276,7 +276,11 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
         :param type_registry: instance of
             :class:`~bson.codec_options.TypeRegistry` to enable encoding
             and decoding of custom types.
-        :param datetime_conversion: Specifies how UTC datetimes should be decoded
+        :param kwargs: ...
+
+          | **Other optional parameters can be passed as keyword arguments:**
+
+          - `datetime_conversion` (optional): Specifies how UTC datetimes should be decoded
             within BSON. Valid options include 'datetime_ms' to return as a
             DatetimeMS, 'datetime' to return as a datetime.datetime and
             raising a ValueError for out-of-range values, 'datetime_auto' to
@@ -284,9 +288,6 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
             out-of-range and 'datetime_clamp' to clamp to the minimum and
             maximum possible datetimes. Defaults to 'datetime'. See
             :ref:`handling-out-of-range-datetimes` for details.
-
-          | **Other optional parameters can be passed as keyword arguments:**
-
           - `directConnection` (optional): if ``True``, forces this client to
              connect directly to the specified MongoDB host as a standalone.
              If ``false``, the client connects to the entire replica set of

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -274,7 +274,11 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
         :param type_registry: instance of
             :class:`~bson.codec_options.TypeRegistry` to enable encoding
             and decoding of custom types.
-        :param datetime_conversion: Specifies how UTC datetimes should be decoded
+        :param kwargs: ...
+
+          | **Other optional parameters can be passed as keyword arguments:**
+
+          - `datetime_conversion` (optional): Specifies how UTC datetimes should be decoded
             within BSON. Valid options include 'datetime_ms' to return as a
             DatetimeMS, 'datetime' to return as a datetime.datetime and
             raising a ValueError for out-of-range values, 'datetime_auto' to
@@ -282,9 +286,6 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
             out-of-range and 'datetime_clamp' to clamp to the minimum and
             maximum possible datetimes. Defaults to 'datetime'. See
             :ref:`handling-out-of-range-datetimes` for details.
-
-          | **Other optional parameters can be passed as keyword arguments:**
-
           - `directConnection` (optional): if ``True``, forces this client to
              connect directly to the specified MongoDB host as a standalone.
              If ``false``, the client connects to the entire replica set of

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -274,7 +274,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
         :param type_registry: instance of
             :class:`~bson.codec_options.TypeRegistry` to enable encoding
             and decoding of custom types.
-        :param kwargs: Additional optional parameters available as keyword arguments
+        :param kwargs: **Additional optional parameters available as keyword arguments:**
 
           - `datetime_conversion` (optional): Specifies how UTC datetimes should be decoded
             within BSON. Valid options include 'datetime_ms' to return as a

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -274,9 +274,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
         :param type_registry: instance of
             :class:`~bson.codec_options.TypeRegistry` to enable encoding
             and decoding of custom types.
-        :param kwargs: ...
-
-          | **Other optional parameters can be passed as keyword arguments:**
+        :param kwargs: Additional optional parameters available as keyword arguments
 
           - `datetime_conversion` (optional): Specifies how UTC datetimes should be decoded
             within BSON. Valid options include 'datetime_ms' to return as a


### PR DESCRIPTION
Reflects the fact that it is now in kwargs.