### PR TITLE
PYTHON-4983 - Restore no C extension coverage variants

### DIFF
--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1079,6 +1079,19 @@ buildvariants:
       PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Server tests
+  - name: test-rhel8-python3.9-cov-no-c
+    tasks:
+      - name: .standalone .sync_async
+      - name: .replica_set .sync_async
+      - name: .sharded_cluster .sync_async
+    display_name: "* Test RHEL8 Python3.9 cov No C"
+    run_on:
+      - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.9/bin/python3
+    tags: [coverage_tag]
   - name: test-rhel8-python3.9-cov
     tasks:
       - name: .standalone .sync_async
@@ -1091,6 +1104,19 @@ buildvariants:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.9/bin/python3
     tags: [coverage_tag]
+  - name: test-rhel8-python3.13-cov-no-c
+    tasks:
+      - name: .standalone .sync_async
+      - name: .replica_set .sync_async
+      - name: .sharded_cluster .sync_async
+    display_name: "* Test RHEL8 Python3.13 cov No C"
+    run_on:
+      - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/3.13/bin/python3
+    tags: [coverage_tag]
   - name: test-rhel8-python3.13-cov
     tasks:
       - name: .standalone .sync_async
@@ -1102,6 +1128,19 @@ buildvariants:
     expansions:
       COVERAGE: coverage
       PYTHON_BINARY: /opt/python/3.13/bin/python3
+    tags: [coverage_tag]
+  - name: test-rhel8-pypy3.10-cov-no-c
+    tasks:
+      - name: .standalone .sync_async
+      - name: .replica_set .sync_async
+      - name: .sharded_cluster .sync_async
+    display_name: "* Test RHEL8 PyPy3.10 cov No C"
+    run_on:
+      - rhel87-small
+    expansions:
+      COVERAGE: coverage
+      NO_EXT: "1"
+      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
     tags: [coverage_tag]
   - name: test-rhel8-pypy3.10-cov
     tasks:

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -279,8 +279,9 @@ def create_server_variants() -> list[BuildVariant]:
     host = DEFAULT_HOST
     # Prefix the display name with an asterisk so it is sorted first.
     base_display_name = "* Test"
-    for python in [*MIN_MAX_PYTHON, PYPYS[-1]]:
+    for python, c_ext in product([*MIN_MAX_PYTHON, PYPYS[-1]], C_EXTS):
         expansions = dict(COVERAGE="coverage")
+        handle_c_ext(c_ext, expansions)
         display_name = get_display_name(base_display_name, host, python=python, **expansions)
         variant = create_variant(
             [f".{t} .sync_async" for t in TOPOLOGIES],


### PR DESCRIPTION
Patch build with coverage report: https://spruce.mongodb.com/version/67ab6f0adec6760007b1e6f8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Report:
![Screenshot 2025-02-11 at 11 56 37 AM](https://github.com/user-attachments/assets/afb25f38-58ac-4221-923f-75b1fb0c9340)

