### PR TITLE
PYTHON-4865 - Re-enable TestBulkWriteConcern tests

### DIFF
--- a/test/asynchronous/test_bulk.py
+++ b/test/asynchronous/test_bulk.py
@@ -961,7 +961,6 @@ class AsyncTestBulkWriteConcern(AsyncBulkTestBase):
     @async_client_context.require_replica_set
     @async_client_context.require_secondaries_count(1)
     async def test_write_concern_failure_ordered(self):
-        self.skipTest("Skipping until PYTHON-4865 is resolved.")
         details = None
 
         # Ensure we don't raise on wnote.

--- a/test/test_bulk.py
+++ b/test/test_bulk.py
@@ -959,7 +959,6 @@ class TestBulkWriteConcern(BulkTestBase):
     @client_context.require_replica_set
     @client_context.require_secondaries_count(1)
     def test_write_concern_failure_ordered(self):
-        self.skipTest("Skipping until PYTHON-4865 is resolved.")
         details = None
 
         # Ensure we don't raise on wnote.


### PR DESCRIPTION
I'm unable to reproduce the failure, re-enabling to monitor longer-term.

Four consecutive passing runs: https://spruce.mongodb.com/version/67ab92982d7b8f00077af4aa/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC.