### PR TITLE
PYTHON-5142 Sync `non-lb-connection-establishment` test

### DIFF
--- a/test/load_balancer/non-lb-connection-establishment.json
+++ b/test/load_balancer/non-lb-connection-establishment.json
@@ -57,6 +57,19 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.0.99",
+          "topologies": [
+            "single"
+          ]
+        },
+        {
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",


### PR DESCRIPTION
Sync `non-lb-connection-establishment` test to https://github.com/mongodb/specifications/commit/d05c33e0a6124ee7d1a9de665084d540b2ff06c5

This is intended to proactively avoid tests failure once drivers start testing 8.1 builds. See DRIVERS-3108. Drivers are not-yet testing 8.1 (see [slack](https://mongodb.slack.com/archives/C72LB5RPV/p1739884710850709)).

Verified with this patch build: https://spruce.mongodb.com/version/67b4d8cb3b14bd0007c52456/