### PR TITLE
PYTHON-5126 Resync bson vector spec tests following additions

### DIFF
--- a/bson/binary.py
+++ b/bson/binary.py
@@ -450,6 +450,10 @@ class Binary(bytes):
                 raise ValueError(f"padding does not apply to {dtype=}")
         elif dtype == BinaryVectorDtype.PACKED_BIT:  # pack ints in [0, 255] as unsigned uint8
             format_str = "B"
+            if 0 <= padding > 7:
+                raise ValueError(f"{padding=}. It must be in [0,1, ..7].")
+            if padding and not vector:
+                raise ValueError("Empty vector with non-zero padding.")
         elif dtype == BinaryVectorDtype.FLOAT32:  # pack floats as float32
             format_str = "f"
             if padding:

--- a/test/bson_binary_vector/float32.json
+++ b/test/bson_binary_vector/float32.json
@@ -12,6 +12,15 @@
       "canonical_bson": "1C00000005766563746F72000A0000000927000000FE420000E04000"
     },
     {
+      "description": "Vector with decimals and negative value FLOAT32",
+      "valid": true,
+      "vector": [127.7, -7.7],
+      "dtype_hex": "0x27",
+      "dtype_alias": "FLOAT32",
+      "padding": 0,
+      "canonical_bson": "1C00000005766563746F72000A0000000927006666FF426666F6C000"
+    },
+    {
       "description": "Empty Vector FLOAT32",
       "valid": true,
       "vector": [],
@@ -35,8 +44,22 @@
       "vector": [127.0, 7.0],
       "dtype_hex": "0x27",
       "dtype_alias": "FLOAT32",
-      "padding": 3
+      "padding": 3,
+      "canonical_bson": "1C00000005766563746F72000A0000000927030000FE420000E04000"
+    },
+    {
+      "description": "Insufficient vector data with 3 bytes FLOAT32",
+      "valid": false,
+      "dtype_hex": "0x27",
+      "dtype_alias": "FLOAT32",
+      "canonical_bson": "1700000005766563746F7200050000000927002A2A2A00"
+    },
+    {
+      "description": "Insufficient vector data with 5 bytes FLOAT32",
+      "valid": false,
+      "dtype_hex": "0x27",
+      "dtype_alias": "FLOAT32",
+      "canonical_bson": "1900000005766563746F7200070000000927002A2A2A2A2A00"
     }
   ]
 }
-

--- a/test/bson_binary_vector/int8.json
+++ b/test/bson_binary_vector/int8.json
@@ -42,7 +42,8 @@
       "vector": [127, 7],
       "dtype_hex": "0x03",
       "dtype_alias": "INT8",
-      "padding": 3
+      "padding": 3,
+      "canonical_bson": "1600000005766563746F7200040000000903037F0700"
     },
     {
       "description": "INT8 with float inputs",
@@ -54,4 +55,3 @@
     }
   ]
 }
-

--- a/test/bson_binary_vector/packed_bit.json
+++ b/test/bson_binary_vector/packed_bit.json
@@ -3,6 +3,15 @@
   "test_key": "vector",
   "tests": [
     {
+      "description": "Padding specified with no vector data PACKED_BIT",
+      "valid": false,
+      "vector": [],
+      "dtype_hex": "0x10",
+      "dtype_alias": "PACKED_BIT",
+      "padding": 1,
+      "canonical_bson": "1400000005766563746F72000200000009100100"
+    },
+    {
       "description": "Simple Vector PACKED_BIT",
       "valid": true,
       "vector": [127, 7],
@@ -44,7 +53,31 @@
       "dtype_hex": "0x10",
       "dtype_alias": "PACKED_BIT",
       "padding": 0
+    },
+    {
+      "description": "Vector with float values PACKED_BIT",
+      "valid": false,
+      "vector": [127.5],
+      "dtype_hex": "0x10",
+      "dtype_alias": "PACKED_BIT",
+      "padding": 0
+    },
+    {
+      "description": "Exceeding maximum padding PACKED_BIT",
+      "valid": false,
+      "vector": [1],
+      "dtype_hex": "0x10",
+      "dtype_alias": "PACKED_BIT",
+      "padding": 8,
+      "canonical_bson": "1500000005766563746F7200030000000910080100"
+    },
+    {
+      "description": "Negative padding PACKED_BIT",
+      "valid": false,
+      "vector": [1],
+      "dtype_hex": "0x10",
+      "dtype_alias": "PACKED_BIT",
+      "padding": -1
     }
   ]
 }
-


### PR DESCRIPTION
Qingyang added more tests of invalidity. In particular, malformed BSON that won't decode.

https://github.com/mongodb/specifications/pull/1750