### PR TITLE
PYTHON-5167 Async Condition.wait has to reacquire the lock even after a timeout

### DIFF
--- a/pymongo/lock.py
+++ b/pymongo/lock.py
@@ -82,9 +82,11 @@ def _release_locks() -> None:
 
 
 async def _async_cond_wait(condition: Condition, timeout: Optional[float]) -> bool:
+    fut = asyncio.ensure_future(condition.wait())
     try:
-        return await wait_for(condition.wait(), timeout)
+        return await wait_for(fut, timeout)
     except asyncio.TimeoutError:
+        await fut
         return False
 
 

--- a/pymongo/lock.py
+++ b/pymongo/lock.py
@@ -84,7 +84,7 @@ def _release_locks() -> None:
 async def _async_cond_wait(condition: Condition, timeout: Optional[float]) -> bool:
     fut = asyncio.ensure_future(condition.wait())
     try:
-        return await wait_for(fut, timeout)
+        return await wait_for(asyncio.shield(fut), timeout)
     except asyncio.TimeoutError:
         await fut
         return False


### PR DESCRIPTION
PYTHON-5167 Async Condition.wait has to reacquire the lock even after a timeout

Testing out a theory. 