### PR TITLE
PYTHON-5168 Use logging for client background task errors

### DIFF
--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -88,7 +88,7 @@ from pymongo.lock import (
     _async_create_lock,
     _release_locks,
 )
-from pymongo.logger import _CLIENT_LOGGER, _log_or_warn
+from pymongo.logger import _CLIENT_LOGGER, _log_client_error, _log_or_warn
 from pymongo.message import _CursorAddress, _GetMore, _Query
 from pymongo.monitoring import ConnectionClosedReason
 from pymongo.operations import (
@@ -2049,7 +2049,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
                     # can be caught in _process_periodic_tasks
                     raise
                 else:
-                    helpers_shared._handle_exception()
+                    _log_client_error()
 
         # Don't re-open topology if it's closed and there's no pending cursors.
         if address_to_cursor_ids:
@@ -2061,7 +2061,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
                     if isinstance(exc, InvalidOperation) and self._topology._closed:
                         raise
                     else:
-                        helpers_shared._handle_exception()
+                        _log_client_error()
 
     # This method is run periodically by a background thread.
     async def _process_periodic_tasks(self) -> None:
@@ -2075,7 +2075,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
             if isinstance(exc, InvalidOperation) and self._topology._closed:
                 return
             else:
-                helpers_shared._handle_exception()
+                _log_client_error()
 
     def _return_server_session(
         self, server_session: Union[_ServerSession, _EmptyServerSession]

--- a/pymongo/logger.py
+++ b/pymongo/logger.py
@@ -96,6 +96,12 @@ _VERBOSE_CONNECTION_ERROR_REASONS = {
 }
 
 
+def _log_client_error() -> None:
+    logger = _CLIENT_LOGGER
+    if logger:
+        logger.exception("MongoClient background task encountered an error:")
+
+
 def _debug_log(logger: logging.Logger, **fields: Any) -> None:
     logger.debug(LogMessage(**fields))
 

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -80,7 +80,7 @@ from pymongo.lock import (
     _create_lock,
     _release_locks,
 )
-from pymongo.logger import _CLIENT_LOGGER, _log_or_warn
+from pymongo.logger import _CLIENT_LOGGER, _log_client_error, _log_or_warn
 from pymongo.message import _CursorAddress, _GetMore, _Query
 from pymongo.monitoring import ConnectionClosedReason
 from pymongo.operations import (
@@ -2043,7 +2043,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
                     # can be caught in _process_periodic_tasks
                     raise
                 else:
-                    helpers_shared._handle_exception()
+                    _log_client_error()
 
         # Don't re-open topology if it's closed and there's no pending cursors.
         if address_to_cursor_ids:
@@ -2055,7 +2055,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
                     if isinstance(exc, InvalidOperation) and self._topology._closed:
                         raise
                     else:
-                        helpers_shared._handle_exception()
+                        _log_client_error()
 
     # This method is run periodically by a background thread.
     def _process_periodic_tasks(self) -> None:
@@ -2069,7 +2069,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
             if isinstance(exc, InvalidOperation) and self._topology._closed:
                 return
             else:
-                helpers_shared._handle_exception()
+                _log_client_error()
 
     def _return_server_session(
         self, server_session: Union[_ServerSession, _EmptyServerSession]

--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -1790,6 +1790,29 @@ class TestClient(AsyncIntegrationTest):
             # Each ping command should not take more than 2 seconds
             self.assertLess(total, 2)
 
+    async def test_background_connections_log_on_error(self):
+        with self.assertLogs("pymongo.client", level="ERROR") as cm:
+            client = await self.async_rs_or_single_client(minPoolSize=1)
+            # Create a single connection in the pool.
+            await client.admin.command("ping")
+
+            # Cause new connections to fail.
+            pool = await async_get_pool(client)
+
+            async def fail_connect(*args, **kwargs):
+                raise Exception("failed to connect")
+
+            pool.connect = fail_connect
+            # Un-patch Pool.connect to break the cyclic reference.
+            self.addCleanup(delattr, pool, "connect")
+
+            await pool.reset_without_pause()
+
+            await async_wait_until(lambda: len(cm.records) > 0, "start creating connections")
+            log_output = "".join(cm.output)
+            self.assertIn("failed to connect", log_output)
+            self.assertIn("MongoClient background task encountered an error", log_output)
+
     @async_client_context.require_replica_set
     async def test_direct_connection(self):
         # direct_connection=True should result in Single topology.

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1747,6 +1747,29 @@ class TestClient(IntegrationTest):
             # Each ping command should not take more than 2 seconds
             self.assertLess(total, 2)
 
+    def test_background_connections_log_on_error(self):
+        with self.assertLogs("pymongo.client", level="ERROR") as cm:
+            client = self.rs_or_single_client(minPoolSize=1)
+            # Create a single connection in the pool.
+            client.admin.command("ping")
+
+            # Cause new connections to fail.
+            pool = get_pool(client)
+
+            def fail_connect(*args, **kwargs):
+                raise Exception("failed to connect")
+
+            pool.connect = fail_connect
+            # Un-patch Pool.connect to break the cyclic reference.
+            self.addCleanup(delattr, pool, "connect")
+
+            pool.reset_without_pause()
+
+            wait_until(lambda: len(cm.records) > 0, "start creating connections")
+            log_output = "".join(cm.output)
+            self.assertIn("failed to connect", log_output)
+            self.assertIn("MongoClient background task encountered an error", log_output)
+
     @client_context.require_replica_set
     def test_direct_connection(self):
         # direct_connection=True should result in Single topology.


### PR DESCRIPTION
PYTHON-5168 Use logging for client background task errors

Old behavior we printed to sys.stderr:
```python
Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/pymongo/asynchronous/mongo_client.py", line 2073, in _process_periodic_tasks
    await self._topology.update_pool()
  File "/Users/shane/git/mongo-python-driver/pymongo/asynchronous/topology.py", line 692, in update_pool
    await server.pool.remove_stale_sockets(generation)
  File "/Users/shane/git/mongo-python-driver/pymongo/asynchronous/pool.py", line 1219, in remove_stale_sockets
    conn = await self.connect()
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/shane/git/mongo-python-driver/test/asynchronous/test_client.py", line 1803, in fail_connect
    raise Exception("failed to connect")
```

New behavior we log via logging.exception():
```python
ERROR:pymongo.client:MongoClient background task encountered an error:
Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/pymongo/asynchronous/mongo_client.py", line 2073, in _process_periodic_tasks
    await self._topology.update_pool()
  File "/Users/shane/git/mongo-python-driver/pymongo/asynchronous/topology.py", line 692, in update_pool
    await server.pool.remove_stale_sockets(generation)
  File "/Users/shane/git/mongo-python-driver/pymongo/asynchronous/pool.py", line 1219, in remove_stale_sockets
    conn = await self.connect()
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/shane/git/mongo-python-driver/test/asynchronous/test_client.py", line 1803, in fail_connect
    raise Exception("failed to connect")
Exception: failed to connect
```