### PR TITLE
PYTHON-5166 Allow Database.command to run bulkWrite commands (#2164) [v4.11]

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,7 +1,21 @@
 Changelog
 =========
 
-Changes in Version 4.11.1 (2025/MM/DD)
+Changes in Version 4.11.2 (YYYY/MM/DD)
+--------------------------------------
+
+Version 4.11.2 is a bug fix release.
+
+- Fixed a bug where :meth:`~pymongo.database.Database.command` would fail when attempting to run the bulkWrite command.
+
+Issues Resolved
+...............
+
+See the `PyMongo 4.11.2 release notes in JIRA`_ for the list of resolved issues in this release.
+
+.. _PyMongo 4.11.2 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=42506
+
+Changes in Version 4.11.1 (2025/02/10)
 --------------------------------------
 
 - Fixed support for prebuilt ``ppc64le`` and ``s390x`` wheels.

--- a/pymongo/message.py
+++ b/pymongo/message.py
@@ -105,7 +105,7 @@ _FIELD_MAP = {
     "insert": "documents",
     "update": "updates",
     "delete": "deletes",
-    "bulkWrite": "bulkWrite",
+    "bulkWrite": "ops",
 }
 
 _UNICODE_REPLACE_CODEC_OPTIONS: CodecOptions[Mapping[str, Any]] = CodecOptions(

--- a/test/asynchronous/test_database.py
+++ b/test/asynchronous/test_database.py
@@ -430,6 +430,21 @@ class TestDatabase(AsyncIntegrationTest):
         for doc in result["cursor"]["firstBatch"]:
             self.assertTrue(isinstance(doc["r"], Regex))
 
+    async def test_command_bulkWrite(self):
+        # Ensure bulk write commands can be run directly via db.command().
+        if async_client_context.version.at_least(8, 0):
+            await self.client.admin.command(
+                {
+                    "bulkWrite": 1,
+                    "nsInfo": [{"ns": self.db.test.full_name}],
+                    "ops": [{"insert": 0, "document": {}}],
+                }
+            )
+        await self.db.command({"insert": "test", "documents": [{}]})
+        await self.db.command({"update": "test", "updates": [{"q": {}, "u": {"$set": {"x": 1}}}]})
+        await self.db.command({"delete": "test", "deletes": [{"q": {}, "limit": 1}]})
+        await self.db.test.drop()
+
     async def test_cursor_command(self):
         db = self.client.pymongo_test
         await db.test.drop()

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -425,6 +425,21 @@ class TestDatabase(IntegrationTest):
         for doc in result["cursor"]["firstBatch"]:
             self.assertTrue(isinstance(doc["r"], Regex))
 
+    def test_command_bulkWrite(self):
+        # Ensure bulk write commands can be run directly via db.command().
+        if client_context.version.at_least(8, 0):
+            self.client.admin.command(
+                {
+                    "bulkWrite": 1,
+                    "nsInfo": [{"ns": self.db.test.full_name}],
+                    "ops": [{"insert": 0, "document": {}}],
+                }
+            )
+        self.db.command({"insert": "test", "documents": [{}]})
+        self.db.command({"update": "test", "updates": [{"q": {}, "u": {"$set": {"x": 1}}}]})
+        self.db.command({"delete": "test", "deletes": [{"q": {}, "limit": 1}]})
+        self.db.test.drop()
+
     def test_cursor_command(self):
         db = self.client.pymongo_test
         db.test.drop()


### PR DESCRIPTION
PYTHON-5166 Allow Database.command to run bulkWrite commands (https://github.com/mongodb/mongo-python-driver/pull/2164) [v4.11]