### PR TITLE
PYTHON-5178 Make test_async_cancellation_closes_change_stream more robust

### DIFF
--- a/test/asynchronous/test_async_cancellation.py
+++ b/test/asynchronous/test_async_cancellation.py
@@ -102,6 +102,7 @@ class TestAsyncCancellation(AsyncIntegrationTest):
     async def test_async_cancellation_closes_change_stream(self):
         self.addAsyncCleanup(self.client.db.test.delete_many, {})
         change_stream = await self.client.db.test.watch(batch_size=2)
+        event = asyncio.Event()
 
         # Make sure getMore commands block
         fail_command = {
@@ -113,11 +114,12 @@ class TestAsyncCancellation(AsyncIntegrationTest):
         async def task():
             async with self.fail_point(fail_command):
                 await self.client.db.test.insert_many([{"x": 1}, {"x": 2}])
+                event.set()
                 await change_stream.next()
 
         task = asyncio.create_task(task())
 
-        await asyncio.sleep(0.1)
+        await event.wait()
 
         task.cancel()
         with self.assertRaises(asyncio.CancelledError):


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/67c60f7ab322260007412a36/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC