### PR TITLE
PYTHON-5167 Properly cleanup test SocketGetter tasks

### DIFF
--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -123,9 +123,12 @@ class SocketGetter(MongoTask):
 
         self.state = "connection"
 
-    def __del__(self):
+    async def release_conn(self):
         if self.sock:
-            self.sock.close_conn(None)
+            await self.sock.unpin()
+            self.sock = None
+            return True
+        return False
 
 
 async def run_cases(client, cases):
@@ -352,6 +355,10 @@ class TestPooling(_TestPoolingBase):
 
         self.assertEqual(t.state, "connection")
         self.assertEqual(t.sock, s1)
+        # Cleanup
+        await t.release_conn()
+        await t.join()
+        await pool.close()
 
     async def test_checkout_more_than_max_pool_size(self):
         pool = await self.create_pool(max_pool_size=2)
@@ -364,16 +371,26 @@ class TestPooling(_TestPoolingBase):
                 socks.append(sock)
 
         tasks = []
-        for _ in range(30):
+        for _ in range(10):
             t = SocketGetter(self.c, pool)
             await t.start()
             tasks.append(t)
         await asyncio.sleep(1)
         for t in tasks:
             self.assertEqual(t.state, "get_socket")
-
+        # Cleanup
         for socket_info in socks:
-            socket_info.close_conn(None)
+            await socket_info.unpin()
+        while tasks:
+            to_remove = []
+            for t in tasks:
+                if await t.release_conn():
+                    to_remove.append(t)
+                    await t.join()
+            for t in to_remove:
+                tasks.remove(t)
+            await asyncio.sleep(0.05)
+        await pool.close()
 
     async def test_maxConnecting(self):
         client = await self.async_rs_or_single_client()

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -123,9 +123,12 @@ class SocketGetter(MongoTask):
 
         self.state = "connection"
 
-    def __del__(self):
+    def release_conn(self):
         if self.sock:
-            self.sock.close_conn(None)
+            self.sock.unpin()
+            self.sock = None
+            return True
+        return False
 
 
 def run_cases(client, cases):
@@ -352,6 +355,10 @@ class TestPooling(_TestPoolingBase):
 
         self.assertEqual(t.state, "connection")
         self.assertEqual(t.sock, s1)
+        # Cleanup
+        t.release_conn()
+        t.join()
+        pool.close()
 
     def test_checkout_more_than_max_pool_size(self):
         pool = self.create_pool(max_pool_size=2)
@@ -364,16 +371,26 @@ class TestPooling(_TestPoolingBase):
                 socks.append(sock)
 
         tasks = []
-        for _ in range(30):
+        for _ in range(10):
             t = SocketGetter(self.c, pool)
             t.start()
             tasks.append(t)
         time.sleep(1)
         for t in tasks:
             self.assertEqual(t.state, "get_socket")
-
+        # Cleanup
         for socket_info in socks:
-            socket_info.close_conn(None)
+            socket_info.unpin()
+        while tasks:
+            to_remove = []
+            for t in tasks:
+                if t.release_conn():
+                    to_remove.append(t)
+                    t.join()
+            for t in to_remove:
+                tasks.remove(t)
+            time.sleep(0.05)
+        pool.close()
 
     def test_maxConnecting(self):
         client = self.rs_or_single_client()


### PR DESCRIPTION
PYTHON-5167 Properly cleanup test SocketGetter tasks

Should resolve one of the errors seen in SocketGetter.run_mongo_thread:
```
FAILED test/asynchronous/test_session.py::TestSession::test_end_sessions - pytest.PytestUnraisableExceptionWarning: Exception ignored in: <coroutine object SocketGetter.run_mongo_thread at 0x4dc35c00a00>

Traceback (most recent call last):
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/asynchronous/pool.py", line 1474, in _get_conn
    if not await _async_cond_wait(self.size_cond, timeout):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
GeneratorExit

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/test/asynchronous/test_pooling.py", line 120, in run_mongo_thread
    async with self.pool.checkout() as sock:
               ~~~~~~~~~~~~~~~~~~^^
  File "/home/runner/.local/share/uv/python/cpython-3.13.2+freethreaded-linux-x86_64-gnu/lib/python3.13t/contextlib.py", line 214, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/asynchronous/pool.py", line 1355, in checkout
    conn = await self._get_conn(checkout_started_time, handler=handler)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/mongo-python-driver/mongo-python-driver/pymongo/asynchronous/pool.py", line 1470, in _get_conn
    async with self.size_cond:
               ^^^^^^^^^^^^^^
  File "/home/runner/.local/share/uv/python/cpython-3.13.2+freethreaded-linux-x86_64-gnu/lib/python3.13t/asyncio/locks.py", line 20, in __aexit__
    self.release()
    ~~~~~~~~~~~~^^
  File "/home/runner/.local/share/uv/python/cpython-3.13.2+freethreaded-linux-x86_64-gnu/lib/python3.13t/asyncio/locks.py", line 142, in release
Error:     raise RuntimeError('Lock is not acquired.')
RuntimeError: Lock is not acquired.
```
