### PR TITLE
PYTHON-5181 Make it easier to set debugging logging in an Evergreen patch

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -262,7 +262,7 @@ functions:
       params:
         include_expansions_in_env: [AUTH, SSL, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
           AWS_SESSION_TOKEN, COVERAGE, PYTHON_BINARY, LIBMONGOCRYPT_URL, MONGODB_URI,
-          DISABLE_TEST_COMMANDS, GREEN_FRAMEWORK, NO_EXT, COMPRESSORS, MONGODB_API_VERSION]
+          DISABLE_TEST_COMMANDS, GREEN_FRAMEWORK, NO_EXT, COMPRESSORS, MONGODB_API_VERSION, DEBUG_LOG]
         binary: bash
         working_dir: "src"
         args: [.evergreen/just.sh, setup-tests, "${TEST_NAME}", "${SUB_TEST_NAME}"]

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -33,6 +33,6 @@ fi
 PIP_QUIET=0 uv run ${UV_ARGS} --with pip pip list
 
 # Start the test runner.
-uv run ${UV_ARGS} .evergreen/scripts/run_tests.py
+uv run ${UV_ARGS} .evergreen/scripts/run_tests.py "$@"
 
 popd

--- a/.evergreen/scripts/run_tests.py
+++ b/.evergreen/scripts/run_tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import platform
 import shutil
@@ -106,8 +107,11 @@ def run() -> None:
         test_kms_remote(SUB_TEST_NAME)
         return
 
+    if os.environ.get("DEBUG_LOG"):
+        TEST_ARGS.extend(f"-o log_cli_level={logging.DEBUG} -o log_cli=1".split())
+
     # Run local tests.
-    pytest.main(TEST_ARGS)
+    pytest.main(TEST_ARGS + sys.argv[1:])
 
     # Handle perf test post actions.
     if TEST_PERF:

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -26,7 +26,7 @@ from utils import (
 )
 
 # Passthrough environment variables.
-PASS_THROUGH_ENV = ["GREEN_FRAMEWORK", "NO_EXT", "MONGODB_API_VERSION"]
+PASS_THROUGH_ENV = ["GREEN_FRAMEWORK", "NO_EXT", "MONGODB_API_VERSION", "DEBUG_LOG"]
 
 # Map the test name to a test suite.
 TEST_SUITE_MAP = {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,8 @@ the pages will re-render and the browser will automatically refresh.
 ## Enable Debug Logs
 - Use `-o log_cli_level="DEBUG" -o log_cli=1` with `just test` or `pytest`.
 - Add `log_cli_level = "DEBUG` and `log_cli = 1` to the `tool.pytest.ini_options` section in `pyproject.toml` for Evergreen patches or to enable debug logs by default on your machine.
+- You can also set `DEBUG_LOG=1` and run either `just setup-tests` or `just-test`.
+- For evergreen patch builds, you can use `evergreen patch --param DEBUG_LOG=1` to enable debug logs for the patch.
 
 ## Re-sync Spec Tests
 


### PR DESCRIPTION
Build with logs: https://spruce.mongodb.com/task/mongo_python_driver_test_rhel8_python3.10_test_4.0_standalone_noauth_nossl_sync_async_patch_f1fe49784b5ec7364b009fe64ab17ff7f86e7111_67c6f0a1c9786e00074cd25e_25_03_04_12_23_03/logs?execution=0&sortBy=STATUS&sortDir=ASC