### PR TITLE
PYTHON-5183 Fix C Extension building for Windows spawn hosts

### DIFF
--- a/.evergreen/scripts/setup-dev-env.sh
+++ b/.evergreen/scripts/setup-dev-env.sh
@@ -43,8 +43,18 @@ if [ -z "${PYMONGO_BIN_DIR:-}" ]; then
   export PATH="$PATH:$HOME/.local/bin"
 fi
 
+# Set up venv, making sure c extensions build unless disabled.
+if [ -z "${NO_EXT:-}" ]; then
+  export PYMONGO_C_EXT_MUST_BUILD=1
+fi
+# Set up visual studio env on Windows spawn hosts.
+if [ -f $HOME/.visualStudioEnv.sh ]; then
+  set +u
+  SSH_TTY=1 source $HOME/.visualStudioEnv.sh
+  set -u
+fi
 uv sync --frozen
-uv run --frozen --with pip pip install -e .
+
 echo "Setting up python environment... done."
 
 # Ensure there is a pre-commit hook if there is a git checkout.


### PR DESCRIPTION
Passing build: https://spruce.mongodb.com/version/67c705106ab08300078cb3c6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

```bash
Administrator@EC2AMAZ-UCP10AK ~/mongo-python-driver
$  ls pymongo | grep pyd
_cmessage.cp39-win_amd64.pyd
```