### PR TITLE
PYTHON-5184 Revert skip to non-lb-connection-establishment

### DIFF
--- a/test/load_balancer/non-lb-connection-establishment.json
+++ b/test/load_balancer/non-lb-connection-establishment.json
@@ -57,19 +57,6 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "8.0.99",
-          "topologies": [
-            "single"
-          ]
-        },
-        {
-          "topologies": [
-            "sharded"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "runCommand",


### PR DESCRIPTION
This reverts commit 5456f1ec045beaeee3a9b008b9522266fc9f43c1.