### PR TITLE
PYTHON-5193 & PYTHON-5192 Fix run-server usage

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -206,7 +206,7 @@ functions:
       params:
         binary: bash
         working_dir: "src"
-        include_expansions_in_env: [VERSION, TOPOLOGY, AUTH, SSL, ORCHESTRATION_FILE,
+        include_expansions_in_env: [VERSION, TOPOLOGY, AUTH, SSL, ORCHESTRATION_FILE, PYTHON_BINARY,
           STORAGE_ENGINE, REQUIRE_API_VERSION, DRIVERS_TOOLS, TEST_CRYPT_SHARED, AUTH_AWS, LOAD_BALANCER]
         args: [.evergreen/just.sh, run-server, "${TEST_NAME}"]
     - command: expansions.update

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -208,7 +208,7 @@ functions:
         working_dir: "src"
         include_expansions_in_env: [VERSION, TOPOLOGY, AUTH, SSL, ORCHESTRATION_FILE,
           STORAGE_ENGINE, REQUIRE_API_VERSION, DRIVERS_TOOLS, TEST_CRYPT_SHARED, AUTH_AWS, LOAD_BALANCER]
-        args: [.evergreen/just.sh, run-server, "${TEST_NAME}", "${SUB_TEST_NAME}"]
+        args: [.evergreen/just.sh, run-server, "${TEST_NAME}"]
     - command: expansions.update
       params:
         file: ${DRIVERS_TOOLS}/mo-expansion.yml

--- a/.evergreen/scripts/run-mod-wsgi-tests.sh
+++ b/.evergreen/scripts/run-mod-wsgi-tests.sh
@@ -22,7 +22,8 @@ PYTHON_VERSION=$(${PYTHON_BINARY} -c "import sys; sys.stdout.write('.'.join(str(
 ${PYTHON_BINARY} -m venv --system-site-packages .venv
 source .venv/bin/activate
 pip install -U pip
-python -m pip install -e .
+export PYMONGO_C_EXT_MUST_BUILD=1
+python -m pip install -v -e .
 
 export MOD_WSGI_SO=/opt/python/mod_wsgi/python_version/$PYTHON_VERSION/mod_wsgi_version/$MOD_WSGI_VERSION/mod_wsgi.so
 export PYTHONHOME=/opt/python/$PYTHON_VERSION


### PR DESCRIPTION
`run-server` does not take a sub test name, and needs `PYTHON_BINARY` because it is using `uv`.

Passing build for sub test name failures: https://spruce.mongodb.com/version/67ca55cc5be7690007c040b4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Passing build for mod_wsgi failure: https://spruce.mongodb.com/task/mongo_python_driver_mod_wsgi_ubuntu_22_python3.13_mod_wsgi_embedded_mode_replica_set_patch_f69e1f6f0485d0b6b99b5359c0291a562bfc0d7b_67ca5eba98f41500071a8983_25_03_07_02_49_38/logs?execution=0