### PR TITLE
PYTHON-5194 Test secondary with IPv6 literal in SDAM

### DIFF
--- a/test/discovery_and_monitoring/rs/secondary_ipv6_literal.json
+++ b/test/discovery_and_monitoring/rs/secondary_ipv6_literal.json
@@ -1,0 +1,38 @@
+{
+  "description": "Secondary with IPv6 literal",
+  "uri": "mongodb://[::1]/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "[::1]:27017",
+          {
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": false,
+            "secondary": true,
+            "setName": "rs",
+            "me": "[::1]:27017",
+            "hosts": [
+              "[::1]:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 26
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "[::1]:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
PYTHON-5194 Test secondary with IPv6 literal in SDAM