### PR TITLE
PYTHON-5199 Fix handling of MongoDB version in run-server

### DIFF
--- a/.evergreen/scripts/run_server.py
+++ b/.evergreen/scripts/run_server.py
@@ -18,6 +18,10 @@ def start_server():
     )
     test_name = opts.test_name
 
+    # drivers-evergreen-tools expects the version variable to be named MONGOD_VERSION.
+    if "VERSION" in os.environ:
+        os.environ["MONGODB_VERSION"] = os.environ["VERSION"]
+
     if opts.auth:
         extra_opts.append("--auth")
 

--- a/.evergreen/scripts/run_server.py
+++ b/.evergreen/scripts/run_server.py
@@ -18,7 +18,7 @@ def start_server():
     )
     test_name = opts.test_name
 
-    # drivers-evergreen-tools expects the version variable to be named MONGOD_VERSION.
+    # drivers-evergreen-tools expects the version variable to be named MONGODB_VERSION.
     if "VERSION" in os.environ:
         os.environ["MONGODB_VERSION"] = os.environ["VERSION"]
 


### PR DESCRIPTION
```bash
VERSION=8.0 just run-server
bash .evergreen/scripts/run-server.sh
Sourcing env file
INFO     Running command 'bash /Users/steve.silvester/workspace/drivers-evergreen-tools/.evergreen/run-orchestration.sh'...
Ensuring python binary...
Ensuring python binary... done.
Creating virtual environment 'venv'...
Creating virtual environment 'venv'... done.
uv is /opt/homebrew/bin/uv
INFO     Running orchestration...
INFO     Downloading mongodb 8.0...
```