### PR TITLE
PYTHON-5135 - Rename WriteConcernFailed code name to WriteConcernTimeout

### DIFF
--- a/pymongo/asynchronous/client_session.py
+++ b/pymongo/asynchronous/client_session.py
@@ -458,10 +458,10 @@ def _max_time_expired_error(exc: PyMongoError) -> bool:
 
 
 # From the transactions spec, all the retryable writes errors plus
-# WriteConcernTimedOut.
+# WriteConcernTimeout.
 _UNKNOWN_COMMIT_ERROR_CODES: frozenset = _RETRYABLE_ERROR_CODES | frozenset(
     [
-        64,  # WriteConcernTimedOut
+        64,  # WriteConcernTimeout
         50,  # MaxTimeMSExpired
     ]
 )

--- a/pymongo/asynchronous/client_session.py
+++ b/pymongo/asynchronous/client_session.py
@@ -458,10 +458,10 @@ def _max_time_expired_error(exc: PyMongoError) -> bool:
 
 
 # From the transactions spec, all the retryable writes errors plus
-# WriteConcernFailed.
+# WriteConcernTimedOut.
 _UNKNOWN_COMMIT_ERROR_CODES: frozenset = _RETRYABLE_ERROR_CODES | frozenset(
     [
-        64,  # WriteConcernFailed
+        64,  # WriteConcernTimedOut
         50,  # MaxTimeMSExpired
     ]
 )

--- a/pymongo/synchronous/client_session.py
+++ b/pymongo/synchronous/client_session.py
@@ -457,10 +457,10 @@ def _max_time_expired_error(exc: PyMongoError) -> bool:
 
 
 # From the transactions spec, all the retryable writes errors plus
-# WriteConcernFailed.
+# WriteConcernTimedOut.
 _UNKNOWN_COMMIT_ERROR_CODES: frozenset = _RETRYABLE_ERROR_CODES | frozenset(
     [
-        64,  # WriteConcernFailed
+        64,  # WriteConcernTimedOut
         50,  # MaxTimeMSExpired
     ]
 )

--- a/pymongo/synchronous/client_session.py
+++ b/pymongo/synchronous/client_session.py
@@ -457,10 +457,10 @@ def _max_time_expired_error(exc: PyMongoError) -> bool:
 
 
 # From the transactions spec, all the retryable writes errors plus
-# WriteConcernTimedOut.
+# WriteConcernTimeout.
 _UNKNOWN_COMMIT_ERROR_CODES: frozenset = _RETRYABLE_ERROR_CODES | frozenset(
     [
-        64,  # WriteConcernTimedOut
+        64,  # WriteConcernTimeout
         50,  # MaxTimeMSExpired
     ]
 )

--- a/test/retryable_writes/unified/insertOne-serverErrors.json
+++ b/test/retryable_writes/unified/insertOne-serverErrors.json
@@ -739,7 +739,7 @@
       ]
     },
     {
-      "description": "InsertOne fails after WriteConcernError WriteConcernFailed",
+      "description": "InsertOne fails after WriteConcernError WriteConcernTimeout",
       "operations": [
         {
           "name": "failPoint",
@@ -757,7 +757,6 @@
                 ],
                 "writeConcernError": {
                   "code": 64,
-                  "codeName": "WriteConcernFailed",
                   "errmsg": "waiting for replication timed out",
                   "errInfo": {
                     "wtimeout": true

--- a/test/transactions-convenient-api/unified/commit-writeconcernerror.json
+++ b/test/transactions-convenient-api/unified/commit-writeconcernerror.json
@@ -56,7 +56,7 @@
   ],
   "tests": [
     {
-      "description": "commitTransaction is retried after WriteConcernFailed timeout error",
+      "description": "commitTransaction is retried after WriteConcernTimeout timeout error",
       "operations": [
         {
           "name": "failPoint",
@@ -74,7 +74,6 @@
                 ],
                 "writeConcernError": {
                   "code": 64,
-                  "codeName": "WriteConcernFailed",
                   "errmsg": "waiting for replication timed out",
                   "errInfo": {
                     "wtimeout": true
@@ -236,7 +235,7 @@
       ]
     },
     {
-      "description": "commitTransaction is retried after WriteConcernFailed non-timeout error",
+      "description": "commitTransaction is retried after WriteConcernTimeout non-timeout error",
       "operations": [
         {
           "name": "failPoint",
@@ -254,7 +253,6 @@
                 ],
                 "writeConcernError": {
                   "code": 64,
-                  "codeName": "WriteConcernFailed",
                   "errmsg": "multiple errors reported"
                 }
               }

--- a/test/transactions/unified/error-labels.json
+++ b/test/transactions/unified/error-labels.json
@@ -1176,7 +1176,7 @@
       ]
     },
     {
-      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernTimeout",
       "operations": [
         {
           "object": "testRunner",
@@ -1338,7 +1338,7 @@
       ]
     },
     {
-      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed with wtimeout",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernTimeout with wtimeout",
       "operations": [
         {
           "object": "testRunner",
@@ -1356,7 +1356,6 @@
                 ],
                 "writeConcernError": {
                   "code": 64,
-                  "codeName": "WriteConcernFailed",
                   "errmsg": "waiting for replication timed out",
                   "errInfo": {
                     "wtimeout": true


### PR DESCRIPTION
We already did a chunk of this work in February, but the spec tests hadn't been fully updated yet.