### PR TITLE
PYTHON-4940 - Add index hint as an explicit parameter for distinct command.

### DIFF
--- a/pymongo/asynchronous/collection.py
+++ b/pymongo/asynchronous/collection.py
@@ -3111,6 +3111,7 @@ class AsyncCollection(common.BaseObject, Generic[_DocumentType]):
         filter: Optional[Mapping[str, Any]] = None,
         session: Optional[AsyncClientSession] = None,
         comment: Optional[Any] = None,
+        hint: Optional[_IndexKeyHint] = None,
         **kwargs: Any,
     ) -> list:
         """Get a list of distinct values for `key` among all documents
@@ -3138,7 +3139,14 @@ class AsyncCollection(common.BaseObject, Generic[_DocumentType]):
             :class:`~pymongo.asynchronous.client_session.AsyncClientSession`.
         :param comment: A user-provided comment to attach to this
             command.
+        :param hint: An index to use to support the query
+            predicate specified either by its string name, or in the same
+            format as passed to :meth:`~pymongo.asynchronous.collection.AsyncCollection.create_index`
+            (e.g. ``[('field', ASCENDING)]``).
         :param kwargs: See list of options above.
+
+        .. versionchanged:: 4.12
+           Added ``hint`` parameter.
 
         .. versionchanged:: 3.6
            Added ``session`` parameter.
@@ -3158,6 +3166,10 @@ class AsyncCollection(common.BaseObject, Generic[_DocumentType]):
         cmd.update(kwargs)
         if comment is not None:
             cmd["comment"] = comment
+        if hint is not None:
+            if not isinstance(hint, str):
+                hint = helpers_shared._index_document(hint)
+            cmd["hint"] = hint
 
         async def _cmd(
             session: Optional[AsyncClientSession],

--- a/pymongo/synchronous/collection.py
+++ b/pymongo/synchronous/collection.py
@@ -3104,6 +3104,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         filter: Optional[Mapping[str, Any]] = None,
         session: Optional[ClientSession] = None,
         comment: Optional[Any] = None,
+        hint: Optional[_IndexKeyHint] = None,
         **kwargs: Any,
     ) -> list:
         """Get a list of distinct values for `key` among all documents
@@ -3131,7 +3132,14 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
             :class:`~pymongo.client_session.ClientSession`.
         :param comment: A user-provided comment to attach to this
             command.
+        :param hint: An index to use to support the query
+            predicate specified either by its string name, or in the same
+            format as passed to :meth:`~pymongo.collection.Collection.create_index`
+            (e.g. ``[('field', ASCENDING)]``).
         :param kwargs: See list of options above.
+
+        .. versionchanged:: 4.12
+           Added ``hint`` parameter.
 
         .. versionchanged:: 3.6
            Added ``session`` parameter.
@@ -3151,6 +3159,10 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
         cmd.update(kwargs)
         if comment is not None:
             cmd["comment"] = comment
+        if hint is not None:
+            if not isinstance(hint, str):
+                hint = helpers_shared._index_document(hint)
+            cmd["hint"] = hint
 
         def _cmd(
             session: Optional[ClientSession],


### PR DESCRIPTION
We already supported `hint` for `distinct()` through `kwargs`, but we didn't mention it. Now we explicitly support it similarly to the other `Collection` methods.