### PR TITLE
PYTHON-3674 Simplify transaction options in convenient API doc example code

### DIFF
--- a/test/asynchronous/test_examples.py
+++ b/test/asynchronous/test_examples.py
@@ -1163,12 +1163,7 @@ class TestTransactionExamples(AsyncIntegrationTest):
         # Step 2: Start a client session.
         async with client.start_session() as session:
             # Step 3: Use with_transaction to start a transaction, execute the callback, and commit (or abort on error).
-            await session.with_transaction(
-                callback,
-                read_concern=ReadConcern("local"),
-                write_concern=wc_majority,
-                read_preference=ReadPreference.PRIMARY,
-            )
+            await session.with_transaction(callback)
 
         # End Transactions withTxn API Example 1
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1161,12 +1161,7 @@ class TestTransactionExamples(IntegrationTest):
         # Step 2: Start a client session.
         with client.start_session() as session:
             # Step 3: Use with_transaction to start a transaction, execute the callback, and commit (or abort on error).
-            session.with_transaction(
-                callback,
-                read_concern=ReadConcern("local"),
-                write_concern=wc_majority,
-                read_preference=ReadPreference.PRIMARY,
-            )
+            session.with_transaction(callback)
 
         # End Transactions withTxn API Example 1
 


### PR DESCRIPTION
From the ticket: "The [Convenient API for Transactions](https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.rst) [examples in the MongoDB manual](https://www.mongodb.com/docs/manual/core/transactions/) use the following options:

"local" read concern
"primary" read preference
"majority" write concern with wTimeoutMS=1000
These no longer seem relevant and I propose removing them."
