### PR TITLE
PYTHON-4942 & PYTHON-4936 Test that isClientError considers network errors and operations may be an empty array

### DIFF
--- a/test/retryable_reads/unified/estimatedDocumentCount.json
+++ b/test/retryable_reads/unified/estimatedDocumentCount.json
@@ -195,7 +195,7 @@
           "object": "collection1",
           "name": "estimatedDocumentCount",
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -241,7 +241,7 @@
           "object": "collection0",
           "name": "estimatedDocumentCount",
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],

--- a/test/unified-test-format/valid-pass/expectedError-isClientError.json
+++ b/test/unified-test-format/valid-pass/expectedError-isClientError.json
@@ -1,0 +1,74 @@
+{
+  "description": "expectedError-isClientError",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "isClientError considers network errors",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "ping"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unified-test-format/valid-pass/operation-empty_array.json
+++ b/test/unified-test-format/valid-pass/operation-empty_array.json
@@ -1,0 +1,10 @@
+{
+  "description": "operation-empty_array",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "Empty operations array",
+      "operations": []
+    }
+  ]
+}


### PR DESCRIPTION
These two had overlapping changed files.