### PR TITLE
Update common.py

### DIFF
--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -36,7 +36,7 @@ from typing import (
 )
 from urllib.parse import unquote_plus
 
-from bson import SON
+from bson.som import SON
 from bson.binary import UuidRepresentation
 from bson.codec_options import CodecOptions, DatetimeConversion, TypeRegistry
 from bson.raw_bson import RawBSONDocument


### PR DESCRIPTION
when the common.py tries to import SOM from bson it fails due to the fact the import needs to be from bson.som import SOM.

This is actually referenced correctly later on in some of the exception handling where it mentions bson.som.SOM