### PR TITLE
PYTHON-4833 - Add Collection bulk_write benchmarks

### DIFF
--- a/test/performance/async_perf_test.py
+++ b/test/performance/async_perf_test.py
@@ -362,6 +362,17 @@ class TestSmallDocBulkInsert(SmallDocInsertTest, AsyncPyMongoTestCase):
         await self.corpus.insert_many(self.documents, ordered=True)
 
 
+class TestSmallDocCollectionBulkInsert(SmallDocInsertTest, AsyncPyMongoTestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.models = []
+        for doc in self.documents:
+            self.models.append(InsertOne(namespace="perftest.corpus", document=doc))
+
+    async def do_task(self):
+        await self.client.corpus.bulk_write(self.models, ordered=True)
+
+
 class TestSmallDocClientBulkInsert(SmallDocInsertTest, AsyncPyMongoTestCase):
     @async_client_context.require_version_min(8, 0, 0, -24)
     async def asyncSetUp(self):
@@ -410,6 +421,17 @@ class TestSmallDocClientBulkMixedOps(SmallDocMixedTest, AsyncPyMongoTestCase):
 class TestLargeDocBulkInsert(LargeDocInsertTest, AsyncPyMongoTestCase):
     async def do_task(self):
         await self.corpus.insert_many(self.documents, ordered=True)
+
+
+class TestLargeDocCollectionBulkInsert(LargeDocInsertTest, AsyncPyMongoTestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.models = []
+        for doc in self.documents:
+            self.models.append(InsertOne(namespace="perftest.corpus", document=doc))
+
+    async def do_task(self):
+        await self.client.corpus.bulk_write(self.models, ordered=True)
 
 
 class TestLargeDocClientBulkInsert(LargeDocInsertTest, AsyncPyMongoTestCase):

--- a/test/performance/async_perf_test.py
+++ b/test/performance/async_perf_test.py
@@ -370,7 +370,7 @@ class TestSmallDocCollectionBulkInsert(SmallDocInsertTest, AsyncPyMongoTestCase)
             self.models.append(InsertOne(namespace="perftest.corpus", document=doc))
 
     async def do_task(self):
-        await self.client.corpus.bulk_write(self.models, ordered=True)
+        await self.corpus.bulk_write(self.models, ordered=True)
 
 
 class TestSmallDocClientBulkInsert(SmallDocInsertTest, AsyncPyMongoTestCase):
@@ -431,7 +431,7 @@ class TestLargeDocCollectionBulkInsert(LargeDocInsertTest, AsyncPyMongoTestCase)
             self.models.append(InsertOne(namespace="perftest.corpus", document=doc))
 
     async def do_task(self):
-        await self.client.corpus.bulk_write(self.models, ordered=True)
+        await self.corpus.bulk_write(self.models, ordered=True)
 
 
 class TestLargeDocClientBulkInsert(LargeDocInsertTest, AsyncPyMongoTestCase):

--- a/test/performance/perf_test.py
+++ b/test/performance/perf_test.py
@@ -443,6 +443,17 @@ class TestSmallDocBulkInsert(SmallDocInsertTest, unittest.TestCase):
         self.corpus.insert_many(self.documents, ordered=True)
 
 
+class TestSmallDocCollectionBulkInsert(SmallDocInsertTest, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.models = []
+        for doc in self.documents:
+            self.models.append(InsertOne(namespace="perftest.corpus", document=doc))
+
+    def do_task(self):
+        self.client.corpus.bulk_write(self.models, ordered=True)
+
+
 class TestSmallDocClientBulkInsert(SmallDocInsertTest, unittest.TestCase):
     @client_context.require_version_min(8, 0, 0, -24)
     def setUp(self):
@@ -491,6 +502,17 @@ class TestSmallDocClientBulkMixedOps(SmallDocMixedTest, unittest.TestCase):
 class TestLargeDocBulkInsert(LargeDocInsertTest, unittest.TestCase):
     def do_task(self):
         self.corpus.insert_many(self.documents, ordered=True)
+
+
+class TestLargeDocCollectionBulkInsert(LargeDocInsertTest, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.models = []
+        for doc in self.documents:
+            self.models.append(InsertOne(namespace="perftest.corpus", document=doc))
+
+    def do_task(self):
+        self.client.corpus.bulk_write(self.models, ordered=True)
 
 
 class TestLargeDocClientBulkInsert(LargeDocInsertTest, unittest.TestCase):

--- a/test/performance/perf_test.py
+++ b/test/performance/perf_test.py
@@ -451,7 +451,7 @@ class TestSmallDocCollectionBulkInsert(SmallDocInsertTest, unittest.TestCase):
             self.models.append(InsertOne(namespace="perftest.corpus", document=doc))
 
     def do_task(self):
-        self.client.corpus.bulk_write(self.models, ordered=True)
+        self.corpus.bulk_write(self.models, ordered=True)
 
 
 class TestSmallDocClientBulkInsert(SmallDocInsertTest, unittest.TestCase):
@@ -512,7 +512,7 @@ class TestLargeDocCollectionBulkInsert(LargeDocInsertTest, unittest.TestCase):
             self.models.append(InsertOne(namespace="perftest.corpus", document=doc))
 
     def do_task(self):
-        self.client.corpus.bulk_write(self.models, ordered=True)
+        self.corpus.bulk_write(self.models, ordered=True)
 
 
 class TestLargeDocClientBulkInsert(LargeDocInsertTest, unittest.TestCase):


### PR DESCRIPTION
Shruti had already written the client bulk_write benchmarks, so only the non-mixed collection ones needed to be added.