### PR TITLE
PYTHON-1752 bulk_write should be able to accept a generator

### DIFF
--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -24,6 +24,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Generator,
     Iterator,
     Mapping,
     MutableMapping,
@@ -528,6 +529,13 @@ def validate_list(option: str, value: Any) -> list:
     if not isinstance(value, list):
         raise TypeError(f"{option} must be a list, not {type(value)}")
     return value
+
+
+def validate_list_or_generator(option: str, value: Any) -> Union[list, Generator]:
+    """Validates that 'value' is a list or generator."""
+    if isinstance(value, Generator):
+        return value
+    return validate_list(option, value)
 
 
 def validate_list_or_none(option: Any, value: Any) -> Optional[list]:

--- a/pymongo/synchronous/bulk.py
+++ b/pymongo/synchronous/bulk.py
@@ -26,6 +26,7 @@ from itertools import islice
 from typing import (
     TYPE_CHECKING,
     Any,
+    Generator,
     Iterator,
     Mapping,
     Optional,
@@ -72,7 +73,7 @@ from pymongo.synchronous.helpers import _handle_reauth
 from pymongo.write_concern import WriteConcern
 
 if TYPE_CHECKING:
-    from pymongo.synchronous.collection import Collection
+    from pymongo.synchronous.collection import Collection, _WriteOp
     from pymongo.synchronous.mongo_client import MongoClient
     from pymongo.synchronous.pool import Connection
     from pymongo.typings import _DocumentOut, _DocumentType, _Pipeline
@@ -214,28 +215,45 @@ class _Bulk:
             self.is_retryable = False
         self.ops.append((_DELETE, cmd))
 
-    def gen_ordered(self) -> Iterator[Optional[_Run]]:
+    def gen_ordered(self, requests) -> Iterator[Optional[_Run]]:
         """Generate batches of operations, batched by type of
         operation, in the order **provided**.
         """
         run = None
-        for idx, (op_type, operation) in enumerate(self.ops):
+        for idx, request in enumerate(requests):
+            try:
+                request._add_to_bulk(self)
+            except AttributeError:
+                raise TypeError(f"{request!r} is not a valid request") from None
+            (op_type, operation) = self.ops[idx]
             if run is None:
                 run = _Run(op_type)
             elif run.op_type != op_type:
                 yield run
                 run = _Run(op_type)
             run.add(idx, operation)
+        if run is None:
+            raise InvalidOperation("No operations to execute")
         yield run
 
-    def gen_unordered(self) -> Iterator[_Run]:
+    def gen_unordered(self, requests) -> Iterator[_Run]:
         """Generate batches of operations, batched by type of
         operation, in arbitrary order.
         """
         operations = [_Run(_INSERT), _Run(_UPDATE), _Run(_DELETE)]
-        for idx, (op_type, operation) in enumerate(self.ops):
+        for idx, request in enumerate(requests):
+            try:
+                request._add_to_bulk(self)
+            except AttributeError:
+                raise TypeError(f"{request!r} is not a valid request") from None
+            (op_type, operation) = self.ops[idx]
             operations[op_type].add(idx, operation)
-
+        if (
+            len(operations[_INSERT].ops) == 0
+            and len(operations[_UPDATE].ops) == 0
+            and len(operations[_DELETE].ops) == 0
+        ):
+            raise InvalidOperation("No operations to execute")
         for run in operations:
             if run.ops:
                 yield run
@@ -724,13 +742,12 @@ class _Bulk:
 
     def execute(
         self,
+        generator: Generator[_WriteOp[_DocumentType]],
         write_concern: WriteConcern,
         session: Optional[ClientSession],
         operation: str,
     ) -> Any:
         """Execute operations."""
-        if not self.ops:
-            raise InvalidOperation("No operations to execute")
         if self.executed:
             raise InvalidOperation("Bulk operations can only be executed once.")
         self.executed = True
@@ -738,9 +755,9 @@ class _Bulk:
         session = _validate_session_write_concern(session, write_concern)
 
         if self.ordered:
-            generator = self.gen_ordered()
+            generator = self.gen_ordered(generator)
         else:
-            generator = self.gen_unordered()
+            generator = self.gen_unordered(generator)
 
         client = self.collection.database.client
         if not write_concern.acknowledged:

--- a/test/asynchronous/test_bulk.py
+++ b/test/asynchronous/test_bulk.py
@@ -299,6 +299,21 @@ class AsyncTestBulk(AsyncBulkTestBase):
         self.assertEqual(n_docs, result.inserted_count)
         self.assertEqual(n_docs, await self.coll.count_documents({}))
 
+    async def test_numerous_inserts_generator(self):
+        # Ensure we don't exceed server's maxWriteBatchSize size limit.
+        n_docs = await async_client_context.max_write_batch_size + 100
+        requests = (InsertOne[dict]({}) for _ in range(n_docs))
+        result = await self.coll.bulk_write(requests, ordered=False)
+        self.assertEqual(n_docs, result.inserted_count)
+        self.assertEqual(n_docs, await self.coll.count_documents({}))
+
+        # Same with ordered bulk.
+        await self.coll.drop()
+        requests = (InsertOne[dict]({}) for _ in range(n_docs))
+        result = await self.coll.bulk_write(requests)
+        self.assertEqual(n_docs, result.inserted_count)
+        self.assertEqual(n_docs, await self.coll.count_documents({}))
+
     async def test_bulk_max_message_size(self):
         await self.coll.delete_many({})
         self.addAsyncCleanup(self.coll.delete_many, {})


### PR DESCRIPTION
Notes: 
- I only did this for collection.bulk_write, if we like how it was done, i'd be happy to replicate the change for client.bulk_write, but didn't wanna make the change until I knew we liked how it was done here
- if a user passes in a generator and doesn't care about ordering, i currently still consume the generator to sort the group the requests by type...the user can pass in a generator and insist on original ordering which wouldn't consume the generator. I was thinking of maybe changing this so that we only consume part of the generator (like maybe up until max_batch_size instead of the whole generator but this seemed to require creating an _AsyncBulk class for each batch which felt...wrong? I was probably going about this incorrectly? Not sure. 
- the test that i picked to duplicate to check generators was a bit arbitrary, but it felt like a good one to pick. If we want more, I'm happy to do so and open to suggestions for which tests specifically. 