### PR TITLE
PYTHON-5270 Server selection should log remainingTimeMS as milliseconds

### DIFF
--- a/pymongo/asynchronous/topology.py
+++ b/pymongo/asynchronous/topology.py
@@ -354,7 +354,7 @@ class Topology:
                     operationId=operation_id,
                     topologyDescription=self.description,
                     clientId=self.description._topology_settings._topology_id,
-                    remainingTimeMS=int(end_time - time.monotonic()),
+                    remainingTimeMS=int(1000 * (end_time - time.monotonic())),
                 )
                 logged_waiting = True
 

--- a/pymongo/synchronous/topology.py
+++ b/pymongo/synchronous/topology.py
@@ -354,7 +354,7 @@ class Topology:
                     operationId=operation_id,
                     topologyDescription=self.description,
                     clientId=self.description._topology_settings._topology_id,
-                    remainingTimeMS=int(end_time - time.monotonic()),
+                    remainingTimeMS=int(1000 * (end_time - time.monotonic())),
                 )
                 logged_waiting = True
 


### PR DESCRIPTION
PYTHON-5270 Server selection should log remainingTimeMS as milliseconds