### PR TITLE
PYTHON-5268 Fix handling of PYTHON_BINARY

### DIFF
--- a/.evergreen/scripts/install-dependencies.sh
+++ b/.evergreen/scripts/install-dependencies.sh
@@ -39,7 +39,7 @@ function _pip_install() {
 
 
 # Ensure just is installed.
-if ! command -v just 2>/dev/null; then
+if ! command -v just >/dev/null 2>&1; then
   # On most systems we can install directly.
   _TARGET=""
   if [ "Windows_NT" = "${OS:-}" ]; then
@@ -54,7 +54,7 @@ if ! command -v just 2>/dev/null; then
 fi
 
 # Install uv.
-if ! command -v uv 2>/dev/null; then
+if ! command -v uv >/dev/null 2>&1; then
   echo "Installing uv..."
   # On most systems we can install directly.
   curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="$_BIN_DIR" INSTALLER_NO_MODIFY_PATH=1 sh || {

--- a/.evergreen/scripts/setup-dev-env.sh
+++ b/.evergreen/scripts/setup-dev-env.sh
@@ -11,7 +11,7 @@ pushd $ROOT > /dev/null
 if [ -f $HERE/env.sh ]; then
   . $HERE/env.sh
 fi
-# PYTHON_BINARY may be defined in test-env.sh.
+# PYTHON_BINARY or PYTHON_VERSION may be defined in test-env.sh.
 if [ -f $HERE/test-env.sh ]; then
   . $HERE/test-env.sh
 fi
@@ -31,7 +31,6 @@ if [ -z "${PYTHON_BINARY:-}" ]; then
     fi
 fi
 export UV_PYTHON=${PYTHON_BINARY}
-echo "export PYTHON_BINARY=$PYTHON_BINARY" >> $HERE/env.sh
 echo "Using python $UV_PYTHON"
 
 # Add the default install path to the path if needed.

--- a/.evergreen/scripts/setup-dev-env.sh
+++ b/.evergreen/scripts/setup-dev-env.sh
@@ -21,7 +21,6 @@ bash $HERE/install-dependencies.sh
 
 # Get the appropriate UV_PYTHON.
 . $ROOT/.evergreen/utils.sh
-set -x
 
 if [ -z "${PYTHON_BINARY:-}" ]; then
     if [ -n "${PYTHON_VERSION:-}" ]; then

--- a/.evergreen/scripts/setup-dev-env.sh
+++ b/.evergreen/scripts/setup-dev-env.sh
@@ -31,7 +31,7 @@ if [ -z "${PYTHON_BINARY:-}" ]; then
     fi
 fi
 export UV_PYTHON=${PYTHON_BINARY}
-echo "export UV_PYTHON=$UV_PYTHON" >> $HERE/env.sh
+echo "export PYTHON_BINARY=$PYTHON_BINARY" >> $HERE/env.sh
 echo "Using python $UV_PYTHON"
 
 # Add the default install path to the path if needed.

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -171,8 +171,8 @@ def handle_test_env() -> None:
 
     # Handle pass through env vars.
     for var in PASS_THROUGH_ENV:
-        if is_set(var) or getattr(opts, var.lower()):
-            write_env(var, os.environ[var])
+        if is_set(var) or getattr(opts, var.lower(), None):
+            write_env(var, os.environ.get(var, "1"))
 
     if extra := EXTRAS_MAP.get(test_name, ""):
         UV_ARGS.append(f"--extra {extra}")

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -171,7 +171,7 @@ def handle_test_env() -> None:
 
     # Handle pass through env vars.
     for var in PASS_THROUGH_ENV:
-        if is_set(var) or getattr(opts, var.lower()):
+        if is_set(var) or getattr(opts, var.lower(), ""):
             write_env(var, os.environ.get(var, getattr(opts, var.lower(), "")))
 
     if extra := EXTRAS_MAP.get(test_name, ""):

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -172,7 +172,7 @@ def handle_test_env() -> None:
     # Handle pass through env vars.
     for var in PASS_THROUGH_ENV:
         if is_set(var) or getattr(opts, var.lower()):
-            write_env(var, os.environ.get(var, getattr(opts, var.lower())))
+            write_env(var, os.environ.get(var, getattr(opts, var.lower(), "")))
 
     if extra := EXTRAS_MAP.get(test_name, ""):
         UV_ARGS.append(f"--extra {extra}")

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -26,7 +26,14 @@ from utils import (
 )
 
 # Passthrough environment variables.
-PASS_THROUGH_ENV = ["GREEN_FRAMEWORK", "NO_EXT", "MONGODB_API_VERSION", "DEBUG_LOG"]
+PASS_THROUGH_ENV = [
+    "GREEN_FRAMEWORK",
+    "NO_EXT",
+    "MONGODB_API_VERSION",
+    "DEBUG_LOG",
+    "PYTHON_BINARY",
+    "PYTHON_VERSION",
+]
 
 # Map the test name to test extra.
 EXTRAS_MAP = {


### PR DESCRIPTION
I verified that the correct Python version is used for setup, test, and teardown in https://spruce.mongodb.com/task/mongo_python_driver_test_rhel8_python3.10_test_4.0_standalone_noauth_nossl_sync_async_patch_bf0aa56fbbfa33c3bfbdf3c03a4ab55aceb0cda4_67f0881dcc09ba0007a35717_25_04_05_01_32_20/logs?execution=0 (Python 3.10).