### PR TITLE
PYTHON-5275 Fix handlig of FIPS build

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -67,7 +67,7 @@ functions:
         binary: bash
         working_dir: "src"
         include_expansions_in_env: [VERSION, TOPOLOGY, AUTH, SSL, ORCHESTRATION_FILE, PYTHON_BINARY, PYTHON_VERSION,
-          STORAGE_ENGINE, REQUIRE_API_VERSION, DRIVERS_TOOLS, TEST_CRYPT_SHARED, AUTH_AWS, LOAD_BALANCER, LOCAL_ATLAS]
+          STORAGE_ENGINE, REQUIRE_API_VERSION, DRIVERS_TOOLS, TEST_CRYPT_SHARED, AUTH_AWS, LOAD_BALANCER, LOCAL_ATLAS, NO_EXT]
         args: [.evergreen/just.sh, run-server, "${TEST_NAME}"]
     - command: expansions.update
       params:
@@ -89,7 +89,7 @@ functions:
         include_expansions_in_env: [AUTH, SSL, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
           AWS_SESSION_TOKEN, COVERAGE, PYTHON_BINARY, LIBMONGOCRYPT_URL, MONGODB_URI, PYTHON_VERSION,
           DISABLE_TEST_COMMANDS, GREEN_FRAMEWORK, NO_EXT, COMPRESSORS, MONGODB_API_VERSION, DEBUG_LOG,
-          ORCHESTRATION_FILE, OCSP_SERVER_TYPE, VERSION]
+          ORCHESTRATION_FILE, OCSP_SERVER_TYPE, VERSION, REQUIRE_FIPS]
         binary: bash
         working_dir: "src"
         args: [.evergreen/just.sh, setup-tests, "${TEST_NAME}", "${SUB_TEST_NAME}"]

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -18,6 +18,7 @@ buildvariants:
     batchtime: 10080
     expansions:
       NO_EXT: "1"
+      REQUIRE_FIPS: "1"
   - name: other-hosts-rhel8-zseries
     tasks:
       - name: .6.0 .standalone !.sync_async

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -25,9 +25,6 @@ else
   exit 1
 fi
 
-echo "REQUIRE_FIPS=${REQUIRE_FIPS:-}"
-exit 1
-
 # List the packages.
 uv sync ${UV_ARGS} --reinstall
 uv pip list

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -25,6 +25,9 @@ else
   exit 1
 fi
 
+echo "REQUIRE_FIPS=${REQUIRE_FIPS:-}"
+exit 1
+
 # List the packages.
 uv sync ${UV_ARGS} --reinstall
 uv pip list

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -800,10 +800,12 @@ def create_alternative_hosts_variants():
         )
     )
 
-    expansions = dict()
-    handle_c_ext(C_EXTS[0], expansions)
     for host_name in OTHER_HOSTS:
+        expansions = dict()
+        handle_c_ext(C_EXTS[0], expansions)
         host = HOSTS[host_name]
+        if "fips" in host_name.lower():
+            expansions["REQUIRE_FIPS"] = "1"
         tags = [".6.0 .standalone !.sync_async"]
         if host_name == "Amazon2023":
             tags = [f".latest !.sync_async {t}" for t in SUB_TASKS]

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -33,6 +33,7 @@ PASS_THROUGH_ENV = [
     "DEBUG_LOG",
     "PYTHON_BINARY",
     "PYTHON_VERSION",
+    "REQUIRE_FIPS",
 ]
 
 # Map the test name to test extra.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -389,6 +389,8 @@ class ClientContext:
             self._fips_enabled = True
         except (subprocess.SubprocessError, FileNotFoundError):
             self._fips_enabled = False
+        if os.environ.get("REQUIRE_FIPS") and not self._fips_enabled:
+            raise RuntimeError("Expected FIPS to be enabled")
         return self._fips_enabled
 
     def check_auth_type(self, auth_type):

--- a/test/asynchronous/__init__.py
+++ b/test/asynchronous/__init__.py
@@ -391,6 +391,8 @@ class AsyncClientContext:
             self._fips_enabled = True
         except (subprocess.SubprocessError, FileNotFoundError):
             self._fips_enabled = False
+        if os.environ.get("REQUIRE_FIPS") and not self._fips_enabled:
+            raise RuntimeError("Expected FIPS to be enabled")
         return self._fips_enabled
 
     def check_auth_type(self, auth_type):


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/67f4fecb653e930007aeeab7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

I verified in this [build](https://spruce.mongodb.com/task/mongo_python_driver_other_hosts_rhel9_fips_test_6.0_standalone_noauth_nossl_async_patch_92970d39fd0fd9060c95c35a6081676b7b6af548_67f5085ffabf21000785fb1c_25_04_08_11_28_39/logs?execution=0) that `[2025/04/08 06:31:42.362] REQUIRE_FIPS=1` is being set.

