### PR TITLE
PYTHON-5286 Create server version variants

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8032,7 +8032,7 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test-python3.9-standalone
+  - name: test-python3.9-standalone-noauth-nossl
     commands:
       - func: run server
         vars:
@@ -8044,7 +8044,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test-python3.9-replica-set
+  - name: test-python3.9-replica-set-noauth-ssl
     commands:
       - func: run server
         vars:
@@ -8056,7 +8056,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.9-sharded-cluster
+  - name: test-python3.9-sharded-cluster-auth-ssl
     commands:
       - func: run server
         vars:
@@ -8068,7 +8068,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.10-standalone
+  - name: test-python3.10-standalone-noauth-nossl
     commands:
       - func: run server
         vars:
@@ -8080,7 +8080,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test-python3.10-replica-set
+  - name: test-python3.10-replica-set-noauth-ssl
     commands:
       - func: run server
         vars:
@@ -8092,7 +8092,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.10-sharded-cluster
+  - name: test-python3.10-sharded-cluster-auth-ssl
     commands:
       - func: run server
         vars:
@@ -8104,7 +8104,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.11-standalone
+  - name: test-python3.11-standalone-noauth-nossl
     commands:
       - func: run server
         vars:
@@ -8116,7 +8116,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test-python3.11-replica-set
+  - name: test-python3.11-replica-set-noauth-ssl
     commands:
       - func: run server
         vars:
@@ -8128,7 +8128,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.11-sharded-cluster
+  - name: test-python3.11-sharded-cluster-auth-ssl
     commands:
       - func: run server
         vars:
@@ -8140,7 +8140,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.12-standalone
+  - name: test-python3.12-standalone-noauth-nossl
     commands:
       - func: run server
         vars:
@@ -8152,7 +8152,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test-python3.12-replica-set
+  - name: test-python3.12-replica-set-noauth-ssl
     commands:
       - func: run server
         vars:
@@ -8164,7 +8164,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.12-sharded-cluster
+  - name: test-python3.12-sharded-cluster-auth-ssl
     commands:
       - func: run server
         vars:
@@ -8176,7 +8176,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.13-standalone
+  - name: test-python3.13-standalone-noauth-nossl
     commands:
       - func: run server
         vars:
@@ -8188,7 +8188,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test-python3.13-replica-set
+  - name: test-python3.13-replica-set-noauth-ssl
     commands:
       - func: run server
         vars:
@@ -8200,7 +8200,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.13-sharded-cluster
+  - name: test-python3.13-sharded-cluster-auth-ssl
     commands:
       - func: run server
         vars:
@@ -8212,7 +8212,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test-pypy3.10-standalone
+  - name: test-pypy3.10-standalone-noauth-nossl
     commands:
       - func: run server
         vars:
@@ -8224,7 +8224,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test-pypy3.10-replica-set
+  - name: test-pypy3.10-replica-set-noauth-ssl
     commands:
       - func: run server
         vars:
@@ -8236,7 +8236,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test-pypy3.10-sharded-cluster
+  - name: test-pypy3.10-sharded-cluster-auth-ssl
     commands:
       - func: run server
         vars:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8032,149 +8032,173 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test-python3.9-sharded-cluster-auth-ssl
+  - name: test-python3.9-sharded-cluster-auth-ssl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          PYTHON_VERSION: "3.9"
     tags: [server-version]
-  - name: test-python3.10-sharded-cluster-auth-ssl
+  - name: test-python3.10-sharded-cluster-auth-ssl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          PYTHON_VERSION: "3.10"
     tags: [server-version]
-  - name: test-python3.11-sharded-cluster-auth-ssl
+  - name: test-python3.11-sharded-cluster-auth-ssl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          PYTHON_VERSION: "3.11"
     tags: [server-version]
-  - name: test-python3.12-sharded-cluster-auth-ssl
+  - name: test-python3.12-sharded-cluster-auth-ssl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          PYTHON_VERSION: "3.12"
     tags: [server-version]
-  - name: test-python3.13-sharded-cluster-auth-ssl
+  - name: test-python3.13-sharded-cluster-auth-ssl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          PYTHON_VERSION: "3.13"
     tags: [server-version]
-  - name: test-pypy3.10-sharded-cluster-auth-ssl
+  - name: test-pypy3.10-sharded-cluster-auth-ssl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          PYTHON_VERSION: pypy3.10
     tags: [server-version]
-  - name: test-python3.9-standalone-noauth-nossl
+  - name: test-python3.9-standalone-noauth-nossl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: standalone
           AUTH: noauth
           SSL: nossl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
+          PYTHON_VERSION: "3.9"
     tags: [server-version]
-  - name: test-python3.10-replica-set-noauth-ssl
+  - name: test-python3.10-replica-set-noauth-ssl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: replica_set
           AUTH: noauth
           SSL: ssl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
+          PYTHON_VERSION: "3.10"
     tags: [server-version]
-  - name: test-python3.11-standalone-noauth-nossl
+  - name: test-python3.11-standalone-noauth-nossl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: standalone
           AUTH: noauth
           SSL: nossl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
+          PYTHON_VERSION: "3.11"
     tags: [server-version]
-  - name: test-python3.12-replica-set-noauth-ssl
+  - name: test-python3.12-replica-set-noauth-ssl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: replica_set
           AUTH: noauth
           SSL: ssl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
+          PYTHON_VERSION: "3.12"
     tags: [server-version]
-  - name: test-python3.13-standalone-noauth-nossl
+  - name: test-python3.13-standalone-noauth-nossl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: standalone
           AUTH: noauth
           SSL: nossl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
+          PYTHON_VERSION: "3.13"
     tags: [server-version]
-  - name: test-pypy3.10-replica-set-noauth-ssl
+  - name: test-pypy3.10-replica-set-noauth-ssl-cov
     commands:
       - func: run server
         vars:
           TOPOLOGY: replica_set
           AUTH: noauth
           SSL: ssl
+          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
+          PYTHON_VERSION: pypy3.10
     tags: [server-version]
 
   # Serverless tests

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8032,7 +8032,7 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test--python3.9-standalone
+  - name: test-python3.9-standalone
     commands:
       - func: run server
         vars:
@@ -8044,7 +8044,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.9-replica-set
+  - name: test-python3.9-replica-set
     commands:
       - func: run server
         vars:
@@ -8056,7 +8056,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.9-sharded-cluster
+  - name: test-python3.9-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8068,7 +8068,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.10-standalone
+  - name: test-python3.10-standalone
     commands:
       - func: run server
         vars:
@@ -8080,7 +8080,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.10-replica-set
+  - name: test-python3.10-replica-set
     commands:
       - func: run server
         vars:
@@ -8092,7 +8092,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.10-sharded-cluster
+  - name: test-python3.10-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8104,7 +8104,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.11-standalone
+  - name: test-python3.11-standalone
     commands:
       - func: run server
         vars:
@@ -8116,7 +8116,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.11-replica-set
+  - name: test-python3.11-replica-set
     commands:
       - func: run server
         vars:
@@ -8128,7 +8128,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.11-sharded-cluster
+  - name: test-python3.11-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8140,7 +8140,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.12-standalone
+  - name: test-python3.12-standalone
     commands:
       - func: run server
         vars:
@@ -8152,7 +8152,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.12-replica-set
+  - name: test-python3.12-replica-set
     commands:
       - func: run server
         vars:
@@ -8164,7 +8164,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.12-sharded-cluster
+  - name: test-python3.12-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8176,7 +8176,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.13-standalone
+  - name: test-python3.13-standalone
     commands:
       - func: run server
         vars:
@@ -8188,7 +8188,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.13-replica-set
+  - name: test-python3.13-replica-set
     commands:
       - func: run server
         vars:
@@ -8200,7 +8200,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.13-sharded-cluster
+  - name: test-python3.13-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8212,7 +8212,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--pypy3.10-standalone
+  - name: test-pypy3.10-standalone
     commands:
       - func: run server
         vars:
@@ -8224,7 +8224,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--pypy3.10-replica-set
+  - name: test-pypy3.10-replica-set
     commands:
       - func: run server
         vars:
@@ -8236,7 +8236,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--pypy3.10-sharded-cluster
+  - name: test-pypy3.10-sharded-cluster
     commands:
       - func: run server
         vars:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8032,88 +8032,16 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test-python3.9-standalone-noauth-nossl
+  - name: test-python3.9-sharded-cluster-auth-ssl
     commands:
       - func: run server
         vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
-  - name: test-python3.10-standalone-noauth-nossl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
-  - name: test-python3.11-standalone-noauth-nossl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
-  - name: test-python3.12-standalone-noauth-nossl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
-  - name: test-python3.13-standalone-noauth-nossl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
-  - name: test-pypy3.10-standalone-noauth-nossl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
-  - name: test-python3.9-replica-set-noauth-ssl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: replica_set
-          AUTH: noauth
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
           SSL: ssl
       - func: run tests
         vars:
-          AUTH: noauth
+          AUTH: auth
           SSL: ssl
     tags: [server-version]
   - name: test-python3.10-sharded-cluster-auth-ssl
@@ -8128,16 +8056,16 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.11-replica-set-noauth-ssl
+  - name: test-python3.11-sharded-cluster-auth-ssl
     commands:
       - func: run server
         vars:
-          TOPOLOGY: replica_set
-          AUTH: noauth
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
           SSL: ssl
       - func: run tests
         vars:
-          AUTH: noauth
+          AUTH: auth
           SSL: ssl
     tags: [server-version]
   - name: test-python3.12-sharded-cluster-auth-ssl
@@ -8152,16 +8080,16 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.13-replica-set-noauth-ssl
+  - name: test-python3.13-sharded-cluster-auth-ssl
     commands:
       - func: run server
         vars:
-          TOPOLOGY: replica_set
-          AUTH: noauth
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
           SSL: ssl
       - func: run tests
         vars:
-          AUTH: noauth
+          AUTH: auth
           SSL: ssl
     tags: [server-version]
   - name: test-pypy3.10-sharded-cluster-auth-ssl
@@ -8174,6 +8102,78 @@ tasks:
       - func: run tests
         vars:
           AUTH: auth
+          SSL: ssl
+    tags: [server-version]
+  - name: test-python3.9-standalone-noauth-nossl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test-python3.10-replica-set-noauth-ssl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: replica_set
+          AUTH: noauth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+    tags: [server-version]
+  - name: test-python3.11-standalone-noauth-nossl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test-python3.12-replica-set-noauth-ssl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: replica_set
+          AUTH: noauth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+    tags: [server-version]
+  - name: test-python3.13-standalone-noauth-nossl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test-pypy3.10-replica-set-noauth-ssl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: replica_set
+          AUTH: noauth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: noauth
           SSL: ssl
     tags: [server-version]
 

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8032,7 +8032,7 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test--python3.9
+  - name: test--python3.9-standalone
     commands:
       - func: run server
         vars:
@@ -8044,7 +8044,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.9
+  - name: test--python3.9-replica-set
     commands:
       - func: run server
         vars:
@@ -8056,7 +8056,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.9
+  - name: test--python3.9-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8068,7 +8068,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.10
+  - name: test--python3.10-standalone
     commands:
       - func: run server
         vars:
@@ -8080,7 +8080,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.10
+  - name: test--python3.10-replica-set
     commands:
       - func: run server
         vars:
@@ -8092,7 +8092,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.10
+  - name: test--python3.10-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8104,7 +8104,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.11
+  - name: test--python3.11-standalone
     commands:
       - func: run server
         vars:
@@ -8116,7 +8116,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.11
+  - name: test--python3.11-replica-set
     commands:
       - func: run server
         vars:
@@ -8128,7 +8128,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.11
+  - name: test--python3.11-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8140,7 +8140,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.12
+  - name: test--python3.12-standalone
     commands:
       - func: run server
         vars:
@@ -8152,7 +8152,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.12
+  - name: test--python3.12-replica-set
     commands:
       - func: run server
         vars:
@@ -8164,7 +8164,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.12
+  - name: test--python3.12-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8176,7 +8176,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.13
+  - name: test--python3.13-standalone
     commands:
       - func: run server
         vars:
@@ -8188,7 +8188,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--python3.13
+  - name: test--python3.13-replica-set
     commands:
       - func: run server
         vars:
@@ -8200,7 +8200,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--python3.13
+  - name: test--python3.13-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8212,7 +8212,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test--pypy3.10
+  - name: test--pypy3.10-standalone
     commands:
       - func: run server
         vars:
@@ -8224,7 +8224,7 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test--pypy3.10
+  - name: test--pypy3.10-replica-set
     commands:
       - func: run server
         vars:
@@ -8236,7 +8236,7 @@ tasks:
           AUTH: noauth
           SSL: ssl
     tags: [server-version]
-  - name: test--pypy3.10
+  - name: test--pypy3.10-sharded-cluster
     commands:
       - func: run server
         vars:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8032,11 +8032,10 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test-python3.9-sharded-cluster-auth-ssl-cov
+  - name: test-python3.9-auth-ssl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
           COVERAGE: "1"
@@ -8044,13 +8043,13 @@ tasks:
         vars:
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.9"
     tags: [server-version]
-  - name: test-python3.10-sharded-cluster-auth-ssl-cov
+  - name: test-python3.10-auth-ssl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
           COVERAGE: "1"
@@ -8058,13 +8057,13 @@ tasks:
         vars:
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.10"
     tags: [server-version]
-  - name: test-python3.11-sharded-cluster-auth-ssl-cov
+  - name: test-python3.11-auth-ssl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
           COVERAGE: "1"
@@ -8072,13 +8071,13 @@ tasks:
         vars:
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.11"
     tags: [server-version]
-  - name: test-python3.12-sharded-cluster-auth-ssl-cov
+  - name: test-python3.12-auth-ssl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
           COVERAGE: "1"
@@ -8086,13 +8085,13 @@ tasks:
         vars:
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.12"
     tags: [server-version]
-  - name: test-python3.13-sharded-cluster-auth-ssl-cov
+  - name: test-python3.13-auth-ssl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
           COVERAGE: "1"
@@ -8100,27 +8099,25 @@ tasks:
         vars:
           AUTH: auth
           SSL: ssl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.13"
     tags: [server-version]
-  - name: test-pypy3.10-sharded-cluster-auth-ssl-cov
+  - name: test-pypy3.10-auth-ssl
     commands:
       - func: run server
         vars:
-          TOPOLOGY: sharded_cluster
           AUTH: auth
           SSL: ssl
-          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
           PYTHON_VERSION: pypy3.10
     tags: [server-version]
-  - name: test-python3.9-standalone-noauth-nossl-cov
+  - name: test-python3.9-noauth-nossl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: standalone
           AUTH: noauth
           SSL: nossl
           COVERAGE: "1"
@@ -8128,13 +8125,13 @@ tasks:
         vars:
           AUTH: noauth
           SSL: nossl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.9"
     tags: [server-version]
-  - name: test-python3.10-replica-set-noauth-ssl-cov
+  - name: test-python3.10-noauth-ssl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: replica_set
           AUTH: noauth
           SSL: ssl
           COVERAGE: "1"
@@ -8142,13 +8139,13 @@ tasks:
         vars:
           AUTH: noauth
           SSL: ssl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.10"
     tags: [server-version]
-  - name: test-python3.11-standalone-noauth-nossl-cov
+  - name: test-python3.11-noauth-nossl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: standalone
           AUTH: noauth
           SSL: nossl
           COVERAGE: "1"
@@ -8156,13 +8153,13 @@ tasks:
         vars:
           AUTH: noauth
           SSL: nossl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.11"
     tags: [server-version]
-  - name: test-python3.12-replica-set-noauth-ssl-cov
+  - name: test-python3.12-noauth-ssl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: replica_set
           AUTH: noauth
           SSL: ssl
           COVERAGE: "1"
@@ -8170,13 +8167,13 @@ tasks:
         vars:
           AUTH: noauth
           SSL: ssl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.12"
     tags: [server-version]
-  - name: test-python3.13-standalone-noauth-nossl-cov
+  - name: test-python3.13-noauth-nossl-cov
     commands:
       - func: run server
         vars:
-          TOPOLOGY: standalone
           AUTH: noauth
           SSL: nossl
           COVERAGE: "1"
@@ -8184,16 +8181,15 @@ tasks:
         vars:
           AUTH: noauth
           SSL: nossl
+          COVERAGE: "1"
           PYTHON_VERSION: "3.13"
     tags: [server-version]
-  - name: test-pypy3.10-replica-set-noauth-ssl-cov
+  - name: test-pypy3.10-noauth-ssl
     commands:
       - func: run server
         vars:
-          TOPOLOGY: replica_set
           AUTH: noauth
           SSL: ssl
-          COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8044,30 +8044,6 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test-python3.9-replica-set-noauth-ssl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: replica_set
-          AUTH: noauth
-          SSL: ssl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-    tags: [server-version]
-  - name: test-python3.9-sharded-cluster-auth-ssl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          SSL: ssl
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-    tags: [server-version]
   - name: test-python3.10-standalone-noauth-nossl
     commands:
       - func: run server
@@ -8080,7 +8056,55 @@ tasks:
           AUTH: noauth
           SSL: nossl
     tags: [server-version]
-  - name: test-python3.10-replica-set-noauth-ssl
+  - name: test-python3.11-standalone-noauth-nossl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test-python3.12-standalone-noauth-nossl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test-python3.13-standalone-noauth-nossl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test-pypy3.10-standalone-noauth-nossl
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test-python3.9-replica-set-noauth-ssl
     commands:
       - func: run server
         vars:
@@ -8104,55 +8128,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.11-standalone-noauth-nossl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
   - name: test-python3.11-replica-set-noauth-ssl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: replica_set
-          AUTH: noauth
-          SSL: ssl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-    tags: [server-version]
-  - name: test-python3.11-sharded-cluster-auth-ssl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          SSL: ssl
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-    tags: [server-version]
-  - name: test-python3.12-standalone-noauth-nossl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
-  - name: test-python3.12-replica-set-noauth-ssl
     commands:
       - func: run server
         vars:
@@ -8176,55 +8152,7 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [server-version]
-  - name: test-python3.13-standalone-noauth-nossl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
   - name: test-python3.13-replica-set-noauth-ssl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: replica_set
-          AUTH: noauth
-          SSL: ssl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-    tags: [server-version]
-  - name: test-python3.13-sharded-cluster-auth-ssl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          SSL: ssl
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-    tags: [server-version]
-  - name: test-pypy3.10-standalone-noauth-nossl
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: standalone
-          AUTH: noauth
-          SSL: nossl
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-    tags: [server-version]
-  - name: test-pypy3.10-replica-set-noauth-ssl
     commands:
       - func: run server
         vars:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8031,6 +8031,224 @@ tasks:
       - nossl
       - sync_async
 
+  # Server version tests
+  - name: test--python3.9
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test--python3.9
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: replica_set
+          AUTH: noauth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--python3.9
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--python3.10
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test--python3.10
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: replica_set
+          AUTH: noauth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--python3.10
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--python3.11
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test--python3.11
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: replica_set
+          AUTH: noauth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--python3.11
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--python3.12
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test--python3.12
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: replica_set
+          AUTH: noauth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--python3.12
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--python3.13
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test--python3.13
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: replica_set
+          AUTH: noauth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--python3.13
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--pypy3.10
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: standalone
+          AUTH: noauth
+          SSL: nossl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+    tags: [server-version]
+  - name: test--pypy3.10
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: replica_set
+          AUTH: noauth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+    tags: [server-version]
+  - name: test--pypy3.10
+    commands:
+      - func: run server
+        vars:
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+          SSL: ssl
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+    tags: [server-version]
+
   # Serverless tests
   - name: test-serverless
     commands:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8032,168 +8032,192 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test-python3.9-auth-ssl-cov
+  - name: test-python3.9-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.9"
     tags: [server-version]
-  - name: test-python3.10-auth-ssl-cov
+  - name: test-python3.10-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
     tags: [server-version]
-  - name: test-python3.11-auth-ssl-cov
+  - name: test-python3.11-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.11"
     tags: [server-version]
-  - name: test-python3.12-auth-ssl-cov
+  - name: test-python3.12-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.12"
     tags: [server-version]
-  - name: test-python3.13-auth-ssl-cov
+  - name: test-python3.13-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.13"
     tags: [server-version]
-  - name: test-pypy3.10-auth-ssl
+  - name: test-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
+          TOPOLOGY: sharded_cluster
           PYTHON_VERSION: pypy3.10
     tags: [server-version]
-  - name: test-python3.9-noauth-nossl-cov
+  - name: test-python3.9-noauth-nossl-standalone-cov
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: nossl
+          TOPOLOGY: standalone
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
+          TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.9"
     tags: [server-version]
-  - name: test-python3.10-noauth-ssl-cov
+  - name: test-python3.10-noauth-ssl-replica-set-cov
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
+          TOPOLOGY: replica_set
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
+          TOPOLOGY: replica_set
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
     tags: [server-version]
-  - name: test-python3.11-noauth-nossl-cov
+  - name: test-python3.11-noauth-nossl-standalone-cov
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: nossl
+          TOPOLOGY: standalone
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
+          TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.11"
     tags: [server-version]
-  - name: test-python3.12-noauth-ssl-cov
+  - name: test-python3.12-noauth-ssl-replica-set-cov
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
+          TOPOLOGY: replica_set
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
+          TOPOLOGY: replica_set
           COVERAGE: "1"
           PYTHON_VERSION: "3.12"
     tags: [server-version]
-  - name: test-python3.13-noauth-nossl-cov
+  - name: test-python3.13-noauth-nossl-standalone-cov
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: nossl
+          TOPOLOGY: standalone
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
+          TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.13"
     tags: [server-version]
-  - name: test-pypy3.10-noauth-ssl
+  - name: test-pypy3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
+          TOPOLOGY: replica_set
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
+          TOPOLOGY: replica_set
           PYTHON_VERSION: pypy3.10
     tags: [server-version]
 

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -805,114 +805,6 @@ buildvariants:
       PYTHON_BINARY: /opt/python/3.9/bin/python3
 
   # Server tests
-  - name: test-rhel8-python3.9-cov-no-c
-    tasks:
-      - name: .standalone .sync_async
-      - name: .replica_set .sync_async
-      - name: .sharded_cluster .sync_async
-    display_name: "* Test RHEL8 Python3.9 cov No C"
-    run_on:
-      - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-    tags: [coverage_tag]
-  - name: test-rhel8-python3.9-cov
-    tasks:
-      - name: .standalone .sync_async
-      - name: .replica_set .sync_async
-      - name: .sharded_cluster .sync_async
-    display_name: "* Test RHEL8 Python3.9 cov"
-    run_on:
-      - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
-    tags: [coverage_tag]
-  - name: test-rhel8-python3.13-cov-no-c
-    tasks:
-      - name: .standalone .sync_async
-      - name: .replica_set .sync_async
-      - name: .sharded_cluster .sync_async
-    display_name: "* Test RHEL8 Python3.13 cov No C"
-    run_on:
-      - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
-    tags: [coverage_tag]
-  - name: test-rhel8-python3.13-cov
-    tasks:
-      - name: .standalone .sync_async
-      - name: .replica_set .sync_async
-      - name: .sharded_cluster .sync_async
-    display_name: "* Test RHEL8 Python3.13 cov"
-    run_on:
-      - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.13/bin/python3
-    tags: [coverage_tag]
-  - name: test-rhel8-pypy3.10-cov-no-c
-    tasks:
-      - name: .standalone .sync_async
-      - name: .replica_set .sync_async
-      - name: .sharded_cluster .sync_async
-    display_name: "* Test RHEL8 PyPy3.10 cov No C"
-    run_on:
-      - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      NO_EXT: "1"
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-    tags: [coverage_tag]
-  - name: test-rhel8-pypy3.10-cov
-    tasks:
-      - name: .standalone .sync_async
-      - name: .replica_set .sync_async
-      - name: .sharded_cluster .sync_async
-    display_name: "* Test RHEL8 PyPy3.10 cov"
-    run_on:
-      - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
-    tags: [coverage_tag]
-  - name: test-rhel8-python3.10
-    tasks:
-      - name: .sharded_cluster .auth .ssl .sync_async
-      - name: .replica_set .noauth .ssl .sync_async
-      - name: .standalone .noauth .nossl .sync_async
-    display_name: "* Test RHEL8 Python3.10"
-    run_on:
-      - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.10/bin/python3
-  - name: test-rhel8-python3.11
-    tasks:
-      - name: .sharded_cluster .auth .ssl .sync_async
-      - name: .replica_set .noauth .ssl .sync_async
-      - name: .standalone .noauth .nossl .sync_async
-    display_name: "* Test RHEL8 Python3.11"
-    run_on:
-      - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.11/bin/python3
-  - name: test-rhel8-python3.12
-    tasks:
-      - name: .sharded_cluster .auth .ssl .sync_async
-      - name: .replica_set .noauth .ssl .sync_async
-      - name: .standalone .noauth .nossl .sync_async
-    display_name: "* Test RHEL8 Python3.12"
-    run_on:
-      - rhel87-small
-    expansions:
-      COVERAGE: coverage
-      PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: test-macos-python3.9
     tasks:
       - name: .sharded_cluster .auth .ssl !.sync_async
@@ -1017,6 +909,71 @@ buildvariants:
       - windows-64-vsMulti-small
     expansions:
       PYTHON_BINARY: C:/python/32/Python313/python.exe
+
+  # Server version tests
+  - name: mongodb-v4.0
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB v4.0"
+    run_on:
+      - rhel87-small
+    tags: [server-version]
+  - name: mongodb-v4.2
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB v4.2"
+    run_on:
+      - rhel87-small
+    tags: [server-version]
+  - name: mongodb-v4.4
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB v4.4"
+    run_on:
+      - rhel87-small
+    tags: [server-version]
+  - name: mongodb-v5.0
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB v5.0"
+    run_on:
+      - rhel87-small
+    tags: [server-version]
+  - name: mongodb-v6.0
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB v6.0"
+    run_on:
+      - rhel87-small
+    tags: [server-version]
+  - name: mongodb-v7.0
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB v7.0"
+    run_on:
+      - rhel87-small
+    tags: [server-version]
+  - name: mongodb-v8.0
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB v8.0"
+    run_on:
+      - rhel87-small
+    tags: [server-version]
+  - name: mongodb-rapid
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB rapid"
+    run_on:
+      - rhel87-small
+    tags: [server-version]
+  - name: mongodb-latest
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB latest"
+    run_on:
+      - rhel87-small
+    tags: [server-version]
 
   # Serverless tests
   - name: serverless-rhel8-python3.9

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -917,63 +917,63 @@ buildvariants:
     display_name: "* MongoDB v4.0"
     run_on:
       - rhel87-small
-    tags: [server-version]
+    tags: [coverage_tag]
   - name: mongodb-v4.2
     tasks:
       - name: .server-version
     display_name: "* MongoDB v4.2"
     run_on:
       - rhel87-small
-    tags: [server-version]
+    tags: [coverage_tag]
   - name: mongodb-v4.4
     tasks:
       - name: .server-version
     display_name: "* MongoDB v4.4"
     run_on:
       - rhel87-small
-    tags: [server-version]
+    tags: [coverage_tag]
   - name: mongodb-v5.0
     tasks:
       - name: .server-version
     display_name: "* MongoDB v5.0"
     run_on:
       - rhel87-small
-    tags: [server-version]
+    tags: [coverage_tag]
   - name: mongodb-v6.0
     tasks:
       - name: .server-version
     display_name: "* MongoDB v6.0"
     run_on:
       - rhel87-small
-    tags: [server-version]
+    tags: [coverage_tag]
   - name: mongodb-v7.0
     tasks:
       - name: .server-version
     display_name: "* MongoDB v7.0"
     run_on:
       - rhel87-small
-    tags: [server-version]
+    tags: [coverage_tag]
   - name: mongodb-v8.0
     tasks:
       - name: .server-version
     display_name: "* MongoDB v8.0"
     run_on:
       - rhel87-small
-    tags: [server-version]
+    tags: [coverage_tag]
   - name: mongodb-rapid
     tasks:
       - name: .server-version
     display_name: "* MongoDB rapid"
     run_on:
       - rhel87-small
-    tags: [server-version]
+    tags: [coverage_tag]
   - name: mongodb-latest
     tasks:
       - name: .server-version
     display_name: "* MongoDB latest"
     run_on:
       - rhel87-small
-    tags: [server-version]
+    tags: [coverage_tag]
 
   # Serverless tests
   - name: serverless-rhel8-python3.9

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -580,8 +580,8 @@ def create_aws_lambda_variants():
 
 def create_server_version_tasks():
     tasks = []
-    variants = [(p, "standalone") for p in ALL_PYTHONS]
-    for python, topology in zip_cycle(ALL_PYTHONS, ["replica_set", "sharded_cluster"]):
+    variants = [(p, "sharded_cluster") for p in ALL_PYTHONS]
+    for python, topology in zip_cycle(ALL_PYTHONS, ["standalone", "replica_set"]):
         variants.append((python, topology))
     for python, topology in variants:
         tags = ["server-version"]

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -592,7 +592,7 @@ def create_server_version_tasks():
         else:
             auth = "auth"
             ssl = "ssl"
-        name = get_task_name("test", python=python, topology=topology)
+        name = get_task_name("test", python=python, topology=topology, auth=auth, ssl=ssl)
         server_vars = dict(TOPOLOGY=topology, AUTH=auth, SSL=ssl)
         server_func = FunctionCall(func="run server", vars=server_vars)
         test_vars = dict(AUTH=auth, SSL=ssl)

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -594,10 +594,12 @@ def create_server_version_tasks():
         else:
             auth = "auth"
             ssl = "ssl"
-        name = get_task_name("test", python=python, topology=topology, auth=auth, ssl=ssl)
-        server_vars = dict(TOPOLOGY=topology, AUTH=auth, SSL=ssl)
+        name = get_task_name(
+            "test", python=python, topology=topology, auth=auth, ssl=ssl, coverage="coverage"
+        )
+        server_vars = dict(TOPOLOGY=topology, AUTH=auth, SSL=ssl, COVERAGE="1")
         server_func = FunctionCall(func="run server", vars=server_vars)
-        test_vars = dict(AUTH=auth, SSL=ssl)
+        test_vars = dict(AUTH=auth, SSL=ssl, PYTHON_VERSION=python)
         test_func = FunctionCall(func="run tests", vars=test_vars)
         tasks.append(EvgTask(name=name, tags=tags, commands=[server_func, test_func]))
     return tasks

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -594,12 +594,13 @@ def create_server_version_tasks():
         else:
             auth = "auth"
             ssl = "ssl"
-        name = get_task_name(
-            "test", python=python, topology=topology, auth=auth, ssl=ssl, coverage="coverage"
-        )
-        server_vars = dict(TOPOLOGY=topology, AUTH=auth, SSL=ssl, COVERAGE="1")
-        server_func = FunctionCall(func="run server", vars=server_vars)
-        test_vars = dict(AUTH=auth, SSL=ssl, PYTHON_VERSION=python)
+        expansions = dict(AUTH=auth, SSL=ssl)
+        if python not in PYPYS:
+            expansions["COVERAGE"] = "1"
+        name = get_task_name("test", python=python, **expansions)
+        server_func = FunctionCall(func="run server", vars=expansions)
+        test_vars = expansions.copy()
+        test_vars["PYTHON_VERSION"] = python
         test_func = FunctionCall(func="run tests", vars=test_vars)
         tasks.append(EvgTask(name=name, tags=tags, commands=[server_func, test_func]))
     return tasks

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -592,7 +592,7 @@ def create_server_version_tasks():
         else:
             auth = "auth"
             ssl = "ssl"
-        name = get_task_name("test-", python=python, topology=topology)
+        name = get_task_name("test", python=python, topology=topology)
         server_vars = dict(TOPOLOGY=topology, AUTH=auth, SSL=ssl)
         server_func = FunctionCall(func="run server", vars=server_vars)
         test_vars = dict(AUTH=auth, SSL=ssl)

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -71,7 +71,7 @@ def create_server_version_variants() -> list[BuildVariant]:
     for version in ALL_VERSIONS:
         display_name = get_variant_name("* MongoDB", version=version)
         variant = create_variant(
-            [".server-version"], display_name, host=DEFAULT_HOST, tags=["server-version"]
+            [".server-version"], display_name, host=DEFAULT_HOST, tags=["coverage_tag"]
         )
         variants.append(variant)
     return variants

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -580,9 +580,11 @@ def create_aws_lambda_variants():
 
 def create_server_version_tasks():
     tasks = []
-    for python, topology in product(ALL_PYTHONS, TOPOLOGIES):
+    variants = [(p, "standalone") for p in ALL_PYTHONS]
+    for python, topology in zip_cycle(ALL_PYTHONS, ["replica_set", "sharded_cluster"]):
+        variants.append((python, topology))
+    for python, topology in variants:
         tags = ["server-version"]
-
         if topology == "standalone":
             auth = "noauth"
             ssl = "nossl"

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -580,10 +580,10 @@ def create_aws_lambda_variants():
 
 def create_server_version_tasks():
     tasks = []
-    variants = [(p, "sharded_cluster") for p in ALL_PYTHONS]
+    task_types = [(p, "sharded_cluster") for p in ALL_PYTHONS]
     for python, topology in zip_cycle(ALL_PYTHONS, ["standalone", "replica_set"]):
-        variants.append((python, topology))
-    for python, topology in variants:
+        task_types.append((python, topology))
+    for python, topology in task_types:
         tags = ["server-version"]
         if topology == "standalone":
             auth = "noauth"

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -594,7 +594,7 @@ def create_server_version_tasks():
         else:
             auth = "auth"
             ssl = "ssl"
-        expansions = dict(AUTH=auth, SSL=ssl)
+        expansions = dict(AUTH=auth, SSL=ssl, TOPOLOGY=topology)
         if python not in PYPYS:
             expansions["COVERAGE"] = "1"
         name = get_task_name("test", python=python, **expansions)

--- a/.evergreen/scripts/generate_config_utils.py
+++ b/.evergreen/scripts/generate_config_utils.py
@@ -40,6 +40,9 @@ SYNCS = ["sync", "async", "sync_async"]
 DISPLAY_LOOKUP = dict(
     ssl=dict(ssl="SSL", nossl="NoSSL"),
     auth=dict(auth="Auth", noauth="NoAuth"),
+    topology=dict(
+        standalone="Standalone", replica_set="Replica Set", sharded_cluster="Sharded Cluster"
+    ),
     test_suites=dict(default="Sync", default_async="Async"),
     coverage=dict(coverage="cov"),
     no_ext={"1": "No C"},

--- a/.evergreen/scripts/generate_config_utils.py
+++ b/.evergreen/scripts/generate_config_utils.py
@@ -44,7 +44,7 @@ DISPLAY_LOOKUP = dict(
         standalone="Standalone", replica_set="Replica Set", sharded_cluster="Sharded Cluster"
     ),
     test_suites=dict(default="Sync", default_async="Async"),
-    coverage=dict(coverage="cov"),
+    coverage={"1": "cov"},
     no_ext={"1": "No C"},
 )
 HOSTS = dict()


### PR DESCRIPTION
Passing build: https://spruce.mongodb.com/version/67f5cdac57d78e0007baa69d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Before: 567 tasks across 9 build variants (we had No C in two places).
After: 108 tasks across 9 build variants

I also disabled coverage on PyPy, which seems to have reduced its flakiness.  The only consistent failure is the one fixed by https://github.com/mongodb/mongo-python-driver/pull/2268.

I decided to reduce the matrix by only testing all Python versions on sharded_cluster, and then sprinkling the python versions across the other topologies so each version of python gets tested with two topologies.

<img width="179" alt="image" src="https://github.com/user-attachments/assets/96bbd899-37db-436b-909e-243f3aacfd11" />

<img width="851" alt="image" src="https://github.com/user-attachments/assets/c2c82378-badf-45db-836d-d0105f5aef33" />

I'll update the default PR tasks after merging.
