### PR TITLE
PYTHON-5295 Update lockfile for compat with older versions of uv

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -998,6 +998,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/07/e9/ae44ea7d7605df9e5
 
 [[package]]
 name = "pymongo"
+version = "4.13.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/task/mongo_python_driver_test_macos_arm64_python3.13_test_6.0_replica_set_noauth_ssl_async_patch_fafa00e9e3448cf44f1504c907e6400b24612cb8_67f697241800d5000758bf5b_25_04_09_15_50_25/logs?execution=0