### PR TITLE
PYTHON-5297 [v4.12] AsyncMongoClient connection error causes UnboundLocalError

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+
+Changes in Version 4.12.1 (XXXX/XX/XX)
+--------------------------------------
+
+Version 4.12.1 is a bug fix release.
+
+- Fixed a bug that could raise ``UnboundLocalError`` when creating asynchronous connections over SSL.
+- Fixed a bug causing SRV hostname validation to fail when resolver and resolved hostnames are identical with three domain levels.
+
+Issues Resolved
+...............
+
+See the `PyMongo 4.12.1 release notes in JIRA`_ for the list of resolved issues
+in this release.
+
+.. _PyMongo 4.12.1 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=43094
+
 Changes in Version 4.12.0 (2025/04/08)
 --------------------------------------
 

--- a/pymongo/pool_shared.py
+++ b/pymongo/pool_shared.py
@@ -346,12 +346,10 @@ async def _configured_protocol_interface(
             ssl=ssl_context,
         )
     except _CertificateError:
-        transport.abort()
         # Raise _CertificateError directly like we do after match_hostname
         # below.
         raise
     except (OSError, SSLError) as exc:
-        transport.abort()
         # We raise AutoReconnect for transient and permanent SSL handshake
         # failures alike. Permanent handshake failures, like protocol
         # mismatch, will be turned into ServerSelectionTimeoutErrors later.


### PR DESCRIPTION
(cherry picked from commit 5b0862e)