### PR TITLE
PYTHON-5311 Create standard linux evergreen tasks

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -727,95 +727,6 @@ tasks:
           working_dir: src
         type: test
 
-  # Compression tests
-  - name: test-compression-v4.0-python3.9
-    commands:
-      - func: run server
-        vars:
-          VERSION: "4.0"
-      - func: run tests
-    tags: [compression, "4.0"]
-  - name: test-compression-v4.2-python3.9
-    commands:
-      - func: run server
-        vars:
-          VERSION: "4.2"
-      - func: run tests
-    tags: [compression, "4.2"]
-  - name: test-compression-v4.4-python3.9
-    commands:
-      - func: run server
-        vars:
-          VERSION: "4.4"
-      - func: run tests
-    tags: [compression, "4.4"]
-  - name: test-compression-v5.0-python3.9
-    commands:
-      - func: run server
-        vars:
-          VERSION: "5.0"
-      - func: run tests
-    tags: [compression, "5.0"]
-  - name: test-compression-v6.0-python3.9
-    commands:
-      - func: run server
-        vars:
-          VERSION: "6.0"
-      - func: run tests
-    tags: [compression, "6.0"]
-  - name: test-compression-v7.0-python3.9
-    commands:
-      - func: run server
-        vars:
-          VERSION: "7.0"
-      - func: run tests
-    tags: [compression, "7.0"]
-  - name: test-compression-v8.0-python3.9
-    commands:
-      - func: run server
-        vars:
-          VERSION: "8.0"
-      - func: run tests
-    tags: [compression, "8.0"]
-  - name: test-compression-rapid-python3.9
-    commands:
-      - func: run server
-        vars:
-          VERSION: rapid
-      - func: run tests
-    tags: [compression, rapid]
-  - name: test-compression-latest-python3.9
-    commands:
-      - func: run server
-        vars:
-          VERSION: latest
-      - func: run tests
-    tags: [compression, latest]
-  - name: test-compression-latest-python3.13-no-c
-    commands:
-      - func: run server
-        vars:
-          VERSION: latest
-      - func: run tests
-        vars:
-          NO_EXT: "1"
-    tags: [compression, latest]
-  - name: test-compression-latest-python3.13
-    commands:
-      - func: run server
-        vars:
-          VERSION: latest
-      - func: run tests
-        vars: {}
-    tags: [compression, latest]
-  - name: test-compression-latest-pypy3.10
-    commands:
-      - func: run server
-        vars:
-          VERSION: latest
-      - func: run tests
-    tags: [compression, latest]
-
   # Coverage report tests
   - name: coverage-report
     commands:
@@ -8296,6 +8207,548 @@ tasks:
           AUTH: auth
           SSL: ssl
     tags: [serverless]
+
+  # Standard linux tests
+  - name: test-v4.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - standard-linux
+      - server-4.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-v4.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - standard-linux
+      - server-4.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-v4.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - standard-linux
+      - server-4.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-v4.2-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - standard-linux
+      - server-4.2
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-v4.2-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - standard-linux
+      - server-4.2
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-v4.2-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - standard-linux
+      - server-4.2
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+  - name: test-v4.4-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - standard-linux
+      - server-4.4
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-v4.4-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - standard-linux
+      - server-4.4
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-v4.4-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - standard-linux
+      - server-4.4
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-v5.0-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - standard-linux
+      - server-5.0
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-v5.0-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - standard-linux
+      - server-5.0
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-v5.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - standard-linux
+      - server-5.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+  - name: test-v6.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - standard-linux
+      - server-6.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-v6.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - standard-linux
+      - server-6.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-v6.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - standard-linux
+      - server-6.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-v7.0-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - standard-linux
+      - server-7.0
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-v7.0-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - standard-linux
+      - server-7.0
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-v7.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - standard-linux
+      - server-7.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+  - name: test-v8.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - standard-linux
+      - server-8.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-v8.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - standard-linux
+      - server-8.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-v8.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - standard-linux
+      - server-8.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-rapid-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.12"
+    tags:
+      - standard-linux
+      - server-rapid
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-rapid-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.13"
+    tags:
+      - standard-linux
+      - server-rapid
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-rapid-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - standard-linux
+      - server-rapid
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+  - name: test-latest-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.9"
+    tags:
+      - standard-linux
+      - server-latest
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-latest-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.10"
+    tags:
+      - standard-linux
+      - server-latest
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-latest-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.11"
+    tags:
+      - standard-linux
+      - server-latest
+      - python-3.11
+      - sharded_cluster-auth-ssl
 
   # Standard non linux tests
   - name: test-v4.0-python3.9-sync-noauth-nossl-standalone

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -163,7 +163,7 @@ buildvariants:
   # Compression tests
   - name: compression-snappy-rhel8
     tasks:
-      - name: .compression
+      - name: .standard-linux
     display_name: Compression snappy RHEL8
     run_on:
       - rhel87-small
@@ -171,7 +171,7 @@ buildvariants:
       COMPRESSOR: snappy
   - name: compression-zlib-rhel8
     tasks:
-      - name: .compression
+      - name: .standard-linux
     display_name: Compression zlib RHEL8
     run_on:
       - rhel87-small
@@ -179,7 +179,7 @@ buildvariants:
       COMPRESSOR: zlib
   - name: compression-zstd-rhel8
     tasks:
-      - name: .compression !.4.0
+      - name: .standard-linux !.server-4.0
     display_name: Compression zstd RHEL8
     run_on:
       - rhel87-small


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/67fd13625ee31c0007ce6dec/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Before: 35 tasks across 3 build variants
After: 78 tasks across 3 build variants