### PR TITLE
PYTHON-5326 - Skip serverless tests with known issue

### DIFF
--- a/test/asynchronous/unified_format.py
+++ b/test/asynchronous/unified_format.py
@@ -551,6 +551,12 @@ class UnifiedSpecTestMixinV1(AsyncIntegrationTest):
             self.skipTest("PYTHON-5170 tests are flakey")
         if "Driver extends timeout while streaming" in spec["description"] and not _IS_SYNC:
             self.skipTest("PYTHON-5174 tests are flakey")
+        if (
+            "inserting _id with type null via clientBulkWrite" in spec["description"]
+            or "commitTransaction fails after Interrupted" in spec["description"]
+            or "commit is not retried after MaxTimeMSExpired error" in spec["description"]
+        ) and async_client_context.serverless:
+            self.skipTest("PYTHON-5326 known serverless failures")
 
         class_name = self.__class__.__name__.lower()
         description = spec["description"].lower()

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -550,6 +550,12 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             self.skipTest("PYTHON-5170 tests are flakey")
         if "Driver extends timeout while streaming" in spec["description"] and not _IS_SYNC:
             self.skipTest("PYTHON-5174 tests are flakey")
+        if (
+            "inserting _id with type null via clientBulkWrite" in spec["description"]
+            or "commitTransaction fails after Interrupted" in spec["description"]
+            or "commit is not retried after MaxTimeMSExpired error" in spec["description"]
+        ) and client_context.serverless:
+            self.skipTest("PYTHON-5326 known serverless failures")
 
         class_name = self.__class__.__name__.lower()
         description = spec["description"].lower()


### PR DESCRIPTION
Passing build: https://spruce.mongodb.com/version/67ffef75cb71cc0007dc3e03/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC