### PR TITLE
PYTHON-5337 Evergreen PyOpenSSL variants should use PyOpenSSL

### DIFF
--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -620,7 +620,7 @@ buildvariants:
       - macos-14
     batchtime: 10080
     expansions:
-      TEST_NAME: pyopenssl
+      SUB_TEST_NAME: pyopenssl
       PYTHON_BINARY: /Library/Frameworks/Python.Framework/Versions/3.9/bin/python3
   - name: pyopenssl-rhel8-python3.10
     tasks:
@@ -631,7 +631,7 @@ buildvariants:
       - rhel87-small
     batchtime: 10080
     expansions:
-      TEST_NAME: pyopenssl
+      SUB_TEST_NAME: pyopenssl
       PYTHON_BINARY: /opt/python/3.10/bin/python3
   - name: pyopenssl-rhel8-python3.11
     tasks:
@@ -642,7 +642,7 @@ buildvariants:
       - rhel87-small
     batchtime: 10080
     expansions:
-      TEST_NAME: pyopenssl
+      SUB_TEST_NAME: pyopenssl
       PYTHON_BINARY: /opt/python/3.11/bin/python3
   - name: pyopenssl-rhel8-python3.12
     tasks:
@@ -653,7 +653,7 @@ buildvariants:
       - rhel87-small
     batchtime: 10080
     expansions:
-      TEST_NAME: pyopenssl
+      SUB_TEST_NAME: pyopenssl
       PYTHON_BINARY: /opt/python/3.12/bin/python3
   - name: pyopenssl-win64-python3.13
     tasks:
@@ -664,7 +664,7 @@ buildvariants:
       - windows-64-vsMulti-small
     batchtime: 10080
     expansions:
-      TEST_NAME: pyopenssl
+      SUB_TEST_NAME: pyopenssl
       PYTHON_BINARY: C:/python/Python313/python.exe
   - name: pyopenssl-rhel8-pypy3.10
     tasks:
@@ -675,7 +675,7 @@ buildvariants:
       - rhel87-small
     batchtime: 10080
     expansions:
-      TEST_NAME: pyopenssl
+      SUB_TEST_NAME: pyopenssl
       PYTHON_BINARY: /opt/python/pypy3.10/bin/python3
 
   # Search index tests

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -250,7 +250,7 @@ def create_enterprise_auth_variants():
 def create_pyopenssl_variants():
     base_name = "PyOpenSSL"
     batchtime = BATCHTIME_WEEK
-    expansions = dict(TEST_NAME="pyopenssl")
+    expansions = dict(SUB_TEST_NAME="pyopenssl")
     variants = []
 
     for python in ALL_PYTHONS:

--- a/.evergreen/scripts/setup-tests.sh
+++ b/.evergreen/scripts/setup-tests.sh
@@ -20,4 +20,6 @@ if [ -f $SCRIPT_DIR/env.sh ]; then
   source $SCRIPT_DIR/env.sh
 fi
 
+echo "Setting up tests with args \"$@\"..."
 uv run $SCRIPT_DIR/setup_tests.py "$@"
+echo "Setting up tests with args \"$@\"... done."

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -394,8 +394,8 @@ def handle_test_env() -> None:
         load_config_from_file(csfle_dir / "secrets-export.sh")
         run_command(f"bash {csfle_dir.as_posix()}/start-servers.sh")
 
-        if sub_test_name == "pyopenssl":
-            UV_ARGS.append("--extra ocsp")
+    if sub_test_name == "pyopenssl":
+        UV_ARGS.append("--extra ocsp")
 
     if is_set("TEST_CRYPT_SHARED") or opts.crypt_shared:
         config = read_env(f"{DRIVERS_TOOLS}/mo-expansion.sh")

--- a/.evergreen/scripts/utils.py
+++ b/.evergreen/scripts/utils.py
@@ -43,7 +43,6 @@ TEST_SUITE_MAP = {
     "kms": "kms",
     "load_balancer": "load_balancer",
     "mockupdb": "mockupdb",
-    "pyopenssl": "",
     "ocsp": "ocsp",
     "perf": "perf",
     "serverless": "",


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/6803ec600cf5b90007a890b5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC