### PR TITLE
PYTHON-5314 Fix default imports

### DIFF
--- a/pymongo/__init__.py
+++ b/pymongo/__init__.py
@@ -106,7 +106,14 @@ from pymongo.synchronous.mongo_client import MongoClient
 from pymongo.write_concern import WriteConcern
 
 # Public module compatibility imports
-import pymongo.uri_parser  # noqa: F401 # isort: skip
+# isort: off
+import pymongo.uri_parser  # noqa: F401
+import pymongo.change_stream  # noqa: F401
+import pymongo.client_session  # noqa: F401
+import pymongo.collection  # noqa: F401
+import pymongo.command_cursor  # noqa: F401
+import pymongo.database  # noqa: F401
+# isort: on
 
 version = __version__
 """Current version of PyMongo."""

--- a/pymongo/__init__.py
+++ b/pymongo/__init__.py
@@ -107,12 +107,12 @@ from pymongo.write_concern import WriteConcern
 
 # Public module compatibility imports
 # isort: off
-import pymongo.uri_parser  # noqa: F401
-import pymongo.change_stream  # noqa: F401
-import pymongo.client_session  # noqa: F401
-import pymongo.collection  # noqa: F401
-import pymongo.command_cursor  # noqa: F401
-import pymongo.database  # noqa: F401
+from pymongo import uri_parser  # noqa: F401
+from pymongo import change_stream  # noqa: F401
+from pymongo import client_session  # noqa: F401
+from pymongo import collection  # noqa: F401
+from pymongo import command_cursor  # noqa: F401
+from pymongo import database  # noqa: F401
 # isort: on
 
 version = __version__

--- a/test/test_default_exports.py
+++ b/test/test_default_exports.py
@@ -215,6 +215,12 @@ class TestDefaultExports(unittest.TestCase):
         self.assertTrue(hasattr(pymongo, "uri_parser"))
         self.assertTrue(pymongo.uri_parser)
         self.assertTrue(pymongo.uri_parser.parse_uri)
+        self.assertTrue(pymongo.change_stream)
+        self.assertTrue(pymongo.client_session)
+        self.assertTrue(pymongo.collection)
+        self.assertTrue(pymongo.cursor)
+        self.assertTrue(pymongo.command_cursor)
+        self.assertTrue(pymongo.database)
 
     def test_gridfs_imports(self):
         import gridfs


### PR DESCRIPTION
PYTHON-5314 Fix default imports

Oddly, ruff complained about the existing code 
```
# Public module compatibility imports
import pymongo.uri_parser  # noqa: F401 # isort: skip
import pymongo.change_stream  # noqa: F401 # isort: skip
...
```

precommit fails:
```
ruff.....................................................................Failed
- hook id: ruff
- exit code: 1
pymongo/__init__.py:110:28: RUF100 Unused `noqa` directive (unused: `F401`)
...
pymongo/__init__.py:116:26: RUF100 Unused `noqa` directive (unused: `F401`)
(edited)
4 replies
```

But if I remove the noqa comment, ruff will delete the imports because it thinks they're unused...

The only way I found to avoid this was to change the imports to `from pymongo import uri_parser`.