### PR TITLE
PYTHON-5314 [v4.12] Fix default imports for modules that worked in v4.8 (#2300)

### DIFF
--- a/pymongo/__init__.py
+++ b/pymongo/__init__.py
@@ -106,7 +106,14 @@ from pymongo.synchronous.mongo_client import MongoClient
 from pymongo.write_concern import WriteConcern
 
 # Public module compatibility imports
-import pymongo.uri_parser  # noqa: F401 # isort: skip
+# isort: off
+from pymongo import uri_parser  # noqa: F401
+from pymongo import change_stream  # noqa: F401
+from pymongo import client_session  # noqa: F401
+from pymongo import collection  # noqa: F401
+from pymongo import command_cursor  # noqa: F401
+from pymongo import database  # noqa: F401
+# isort: on
 
 version = __version__
 """Current version of PyMongo."""

--- a/test/test_default_exports.py
+++ b/test/test_default_exports.py
@@ -215,6 +215,12 @@ class TestDefaultExports(unittest.TestCase):
         self.assertTrue(hasattr(pymongo, "uri_parser"))
         self.assertTrue(pymongo.uri_parser)
         self.assertTrue(pymongo.uri_parser.parse_uri)
+        self.assertTrue(pymongo.change_stream)
+        self.assertTrue(pymongo.client_session)
+        self.assertTrue(pymongo.collection)
+        self.assertTrue(pymongo.cursor)
+        self.assertTrue(pymongo.command_cursor)
+        self.assertTrue(pymongo.database)
 
     def test_gridfs_imports(self):
         import gridfs


### PR DESCRIPTION
(cherry picked from commit e2e673edeb711e24d7feb620e7552a2a7af2f0b0)