### PR TITLE
PYTHON-5346: [v4.12] test_init_disconnected_with_srv cannot run against sharded Topologies (#2304)

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -824,6 +824,58 @@ class TestClient(IntegrationTest):
         with self.assertRaises(ConnectionFailure):
             c.pymongo_test.test.find_one()
 
+    @client_context.require_replica_set
+    @client_context.require_no_load_balancer
+    @client_context.require_tls
+    def test_init_disconnected_with_srv(self):
+        c = self.rs_or_single_client(
+            "mongodb+srv://test1.test.build.10gen.cc", connect=False, tlsInsecure=True
+        )
+        # nodes returns an empty set if not connected
+        self.assertEqual(c.nodes, frozenset())
+        # topology_description returns the initial seed description if not connected
+        topology_description = c.topology_description
+        self.assertEqual(topology_description.topology_type, TOPOLOGY_TYPE.Unknown)
+        self.assertEqual(
+            {
+                ("test1.test.build.10gen.cc", None): ServerDescription(
+                    ("test1.test.build.10gen.cc", None)
+                )
+            },
+            topology_description.server_descriptions(),
+        )
+
+        # address causes client to block until connected
+        self.assertIsNotNone(c.address)
+        # Initial seed topology and connected topology have the same ID
+        self.assertEqual(
+            c._topology._topology_id, topology_description._topology_settings._topology_id
+        )
+        c.close()
+
+        c = self.rs_or_single_client(
+            "mongodb+srv://test1.test.build.10gen.cc", connect=False, tlsInsecure=True
+        )
+        # primary causes client to block until connected
+        c.primary
+        self.assertIsNotNone(c._topology)
+        c.close()
+
+        c = self.rs_or_single_client(
+            "mongodb+srv://test1.test.build.10gen.cc", connect=False, tlsInsecure=True
+        )
+        # secondaries causes client to block until connected
+        c.secondaries
+        self.assertIsNotNone(c._topology)
+        c.close()
+
+        c = self.rs_or_single_client(
+            "mongodb+srv://test1.test.build.10gen.cc", connect=False, tlsInsecure=True
+        )
+        # arbiters causes client to block until connected
+        c.arbiters
+        self.assertIsNotNone(c._topology)
+
     def test_equality(self):
         seed = "{}:{}".format(*list(self.client._topology_settings.seeds)[0])
         c = self.rs_or_single_client(seed, connect=False)


### PR DESCRIPTION
(cherry picked from commit https://github.com/mongodb/mongo-python-driver/commit/34f7d7ee4c2cbe8ba23c91a489a938af2cb46386)