### PR TITLE
PYTHON-5345 Streamline the standard tasks

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -312,21 +312,21 @@ tasks:
       - func: run tests
         vars:
           PYTHON_VERSION: "3.9"
-    tags: [no-orchestration, python-3.9]
+    tags: [test-no-orchestration, python-3.9]
   - name: test-no-orchestration-python3.13
     commands:
       - func: assume ec2 role
       - func: run tests
         vars:
           PYTHON_VERSION: "3.13"
-    tags: [no-orchestration, python-3.13]
+    tags: [test-no-orchestration, python-3.13]
   - name: test-no-orchestration-pypy3.10
     commands:
       - func: assume ec2 role
       - func: run tests
         vars:
           PYTHON_VERSION: pypy3.10
-    tags: [no-orchestration, python-pypy3.10]
+    tags: [test-no-orchestration, python-pypy3.10]
 
   # No toolchain tests
   - name: test-no-toolchain-sync-noauth-nossl-standalone
@@ -7482,7 +7482,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-4.0
       - python-3.9
       - standalone-noauth-nossl
@@ -7504,7 +7504,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-4.0
       - python-3.10
       - replica_set-noauth-ssl
@@ -7526,7 +7526,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-4.0
       - python-3.11
       - sharded_cluster-auth-ssl
@@ -7548,7 +7548,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-4.2
       - python-3.12
       - standalone-noauth-nossl
@@ -7570,7 +7570,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-4.2
       - python-3.13
       - replica_set-noauth-ssl
@@ -7592,7 +7592,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-4.2
       - python-3.9
       - sharded_cluster-auth-ssl
@@ -7614,7 +7614,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-4.4
       - python-3.10
       - standalone-noauth-nossl
@@ -7636,7 +7636,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-4.4
       - python-3.11
       - replica_set-noauth-ssl
@@ -7658,7 +7658,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-4.4
       - python-3.12
       - sharded_cluster-auth-ssl
@@ -7680,7 +7680,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-5.0
       - python-3.13
       - standalone-noauth-nossl
@@ -7702,7 +7702,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-5.0
       - python-3.9
       - replica_set-noauth-ssl
@@ -7724,7 +7724,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-5.0
       - python-3.10
       - sharded_cluster-auth-ssl
@@ -7746,7 +7746,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-6.0
       - python-3.11
       - standalone-noauth-nossl
@@ -7768,7 +7768,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-6.0
       - python-3.12
       - replica_set-noauth-ssl
@@ -7790,7 +7790,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-6.0
       - python-3.13
       - sharded_cluster-auth-ssl
@@ -7812,7 +7812,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-7.0
       - python-3.9
       - standalone-noauth-nossl
@@ -7834,7 +7834,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-7.0
       - python-3.10
       - replica_set-noauth-ssl
@@ -7856,7 +7856,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-7.0
       - python-3.11
       - sharded_cluster-auth-ssl
@@ -7878,7 +7878,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-8.0
       - python-3.12
       - standalone-noauth-nossl
@@ -7900,7 +7900,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-8.0
       - python-3.13
       - replica_set-noauth-ssl
@@ -7922,7 +7922,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-8.0
       - python-3.9
       - sharded_cluster-auth-ssl
@@ -7944,7 +7944,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-rapid
       - python-3.10
       - standalone-noauth-nossl
@@ -7966,7 +7966,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-rapid
       - python-3.11
       - replica_set-noauth-ssl
@@ -7988,7 +7988,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-rapid
       - python-3.12
       - sharded_cluster-auth-ssl
@@ -8010,7 +8010,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-latest
       - python-3.13
       - standalone-noauth-nossl
@@ -8032,7 +8032,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-latest
       - python-3.9
       - replica_set-noauth-ssl
@@ -8054,7 +8054,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-latest
       - python-3.10
       - sharded_cluster-auth-ssl
@@ -8076,7 +8076,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-4.0
       - python-pypy3.10
       - standalone-noauth-nossl
@@ -8099,7 +8099,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-4.2
       - python-pypy3.10
       - replica_set-noauth-ssl
@@ -8122,7 +8122,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-4.4
       - python-pypy3.10
       - sharded_cluster-auth-ssl
@@ -8145,7 +8145,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-5.0
       - python-pypy3.10
       - standalone-noauth-nossl
@@ -8168,7 +8168,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-6.0
       - python-pypy3.10
       - replica_set-noauth-ssl
@@ -8191,7 +8191,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-7.0
       - python-pypy3.10
       - sharded_cluster-auth-ssl
@@ -8214,7 +8214,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-8.0
       - python-pypy3.10
       - standalone-noauth-nossl
@@ -8237,7 +8237,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
     tags:
-      - standard
+      - test-standard
       - server-rapid
       - python-pypy3.10
       - replica_set-noauth-ssl
@@ -8260,7 +8260,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
-      - standard
+      - test-standard
       - server-latest
       - python-pypy3.10
       - sharded_cluster-auth-ssl

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8041,6 +8041,127 @@ tasks:
       - server-4.0
       - python-3.9
       - standalone-noauth-nossl
+  - name: test-named-v4.0-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v4.0-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.11
+      - standalone-noauth-nossl
+  - name: test-named-v4.0-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-named-v4.0-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-v4.0-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-v4.0-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.9
+      - replica_set-noauth-ssl
   - name: test-named-v4.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8061,6 +8182,127 @@ tasks:
       - server-4.0
       - python-3.10
       - replica_set-noauth-ssl
+  - name: test-named-v4.0-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-v4.0-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.12
+      - replica_set-noauth-ssl
+  - name: test-named-v4.0-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-v4.0-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.0
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-v4.0-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.0-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
   - name: test-named-v4.0-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -8081,6 +8323,127 @@ tasks:
       - server-4.0
       - python-3.11
       - sharded_cluster-auth-ssl
+  - name: test-named-v4.0-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.0-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+  - name: test-named-v4.2-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-named-v4.2-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v4.2-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.11
+      - standalone-noauth-nossl
   - name: test-named-v4.2-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
@@ -8101,6 +8464,127 @@ tasks:
       - server-4.2
       - python-3.12
       - standalone-noauth-nossl
+  - name: test-named-v4.2-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-v4.2-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.2
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-v4.2-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.9
+      - replica_set-noauth-ssl
+  - name: test-named-v4.2-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-named-v4.2-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-v4.2-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.12
+      - replica_set-noauth-ssl
   - name: test-named-v4.2-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8121,6 +8605,127 @@ tasks:
       - server-4.2
       - python-3.13
       - replica_set-noauth-ssl
+  - name: test-named-v4.2-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.2
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-v4.2-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.2-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.10
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.2-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.2-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.2-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.13
+      - sharded_cluster-auth-ssl
   - name: test-named-v4.2-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -8162,6 +8767,127 @@ tasks:
       - server-4.4
       - python-3.9
       - standalone-noauth-nossl
+  - name: test-named-v4.4-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v4.4-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.11
+      - standalone-noauth-nossl
+  - name: test-named-v4.4-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-named-v4.4-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-v4.4-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.4
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-v4.4-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.9
+      - replica_set-noauth-ssl
   - name: test-named-v4.4-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8182,6 +8908,127 @@ tasks:
       - server-4.4
       - python-3.10
       - replica_set-noauth-ssl
+  - name: test-named-v4.4-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-v4.4-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.12
+      - replica_set-noauth-ssl
+  - name: test-named-v4.4-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-v4.4-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.4
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-v4.4-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.4-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.10
+      - sharded_cluster-auth-ssl
   - name: test-named-v4.4-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -8202,6 +9049,127 @@ tasks:
       - server-4.4
       - python-3.11
       - sharded_cluster-auth-ssl
+  - name: test-named-v4.4-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.4-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.13
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.4-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.4
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+  - name: test-named-v5.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-named-v5.0-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v5.0-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.11
+      - standalone-noauth-nossl
   - name: test-named-v5.0-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
@@ -8222,6 +9190,127 @@ tasks:
       - server-5.0
       - python-3.12
       - standalone-noauth-nossl
+  - name: test-named-v5.0-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-v5.0-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-5.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-v5.0-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.9
+      - replica_set-noauth-ssl
+  - name: test-named-v5.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-named-v5.0-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-v5.0-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.12
+      - replica_set-noauth-ssl
   - name: test-named-v5.0-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8242,6 +9331,127 @@ tasks:
       - server-5.0
       - python-3.13
       - replica_set-noauth-ssl
+  - name: test-named-v5.0-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-5.0
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-v5.0-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v5.0-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+  - name: test-named-v5.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-named-v5.0-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v5.0-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
   - name: test-named-v5.0-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -8283,6 +9493,127 @@ tasks:
       - server-6.0
       - python-3.9
       - standalone-noauth-nossl
+  - name: test-named-v6.0-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v6.0-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.11
+      - standalone-noauth-nossl
+  - name: test-named-v6.0-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-named-v6.0-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-v6.0-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-6.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-v6.0-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.9
+      - replica_set-noauth-ssl
   - name: test-named-v6.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8303,6 +9634,127 @@ tasks:
       - server-6.0
       - python-3.10
       - replica_set-noauth-ssl
+  - name: test-named-v6.0-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-v6.0-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.12
+      - replica_set-noauth-ssl
+  - name: test-named-v6.0-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-v6.0-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-6.0
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-v6.0-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v6.0-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
   - name: test-named-v6.0-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -8323,6 +9775,127 @@ tasks:
       - server-6.0
       - python-3.11
       - sharded_cluster-auth-ssl
+  - name: test-named-v6.0-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v6.0-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+  - name: test-named-v6.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-6.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+  - name: test-named-v7.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-named-v7.0-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v7.0-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.11
+      - standalone-noauth-nossl
   - name: test-named-v7.0-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
@@ -8343,6 +9916,127 @@ tasks:
       - server-7.0
       - python-3.12
       - standalone-noauth-nossl
+  - name: test-named-v7.0-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-v7.0-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-7.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-v7.0-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.9
+      - replica_set-noauth-ssl
+  - name: test-named-v7.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-named-v7.0-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-v7.0-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.12
+      - replica_set-noauth-ssl
   - name: test-named-v7.0-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8363,6 +10057,127 @@ tasks:
       - server-7.0
       - python-3.13
       - replica_set-noauth-ssl
+  - name: test-named-v7.0-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-7.0
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-v7.0-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v7.0-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+  - name: test-named-v7.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-named-v7.0-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v7.0-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
   - name: test-named-v7.0-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -8404,6 +10219,127 @@ tasks:
       - server-8.0
       - python-3.9
       - standalone-noauth-nossl
+  - name: test-named-v8.0-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v8.0-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.11
+      - standalone-noauth-nossl
+  - name: test-named-v8.0-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-named-v8.0-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-v8.0-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-8.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-v8.0-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.9
+      - replica_set-noauth-ssl
   - name: test-named-v8.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8424,6 +10360,127 @@ tasks:
       - server-8.0
       - python-3.10
       - replica_set-noauth-ssl
+  - name: test-named-v8.0-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-v8.0-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.12
+      - replica_set-noauth-ssl
+  - name: test-named-v8.0-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-v8.0-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-8.0
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-v8.0-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v8.0-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
   - name: test-named-v8.0-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -8444,6 +10501,127 @@ tasks:
       - server-8.0
       - python-3.11
       - sharded_cluster-auth-ssl
+  - name: test-named-v8.0-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v8.0-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+  - name: test-named-v8.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-8.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+  - name: test-named-rapid-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-named-rapid-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-rapid-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.11
+      - standalone-noauth-nossl
   - name: test-named-rapid-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
@@ -8464,6 +10642,127 @@ tasks:
       - server-rapid
       - python-3.12
       - standalone-noauth-nossl
+  - name: test-named-rapid-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-rapid-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-rapid
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-rapid-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.9
+      - replica_set-noauth-ssl
+  - name: test-named-rapid-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-named-rapid-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-rapid-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.12
+      - replica_set-noauth-ssl
   - name: test-named-rapid-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8484,6 +10783,127 @@ tasks:
       - server-rapid
       - python-3.13
       - replica_set-noauth-ssl
+  - name: test-named-rapid-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-rapid
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-rapid-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-rapid-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.10
+      - sharded_cluster-auth-ssl
+  - name: test-named-rapid-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-named-rapid-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-rapid-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.13
+      - sharded_cluster-auth-ssl
   - name: test-named-rapid-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -8525,6 +10945,127 @@ tasks:
       - server-latest
       - python-3.9
       - standalone-noauth-nossl
+  - name: test-named-latest-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-latest-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.11
+      - standalone-noauth-nossl
+  - name: test-named-latest-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-named-latest-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-latest-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-latest
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-latest-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.9
+      - replica_set-noauth-ssl
   - name: test-named-latest-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8545,6 +11086,127 @@ tasks:
       - server-latest
       - python-3.10
       - replica_set-noauth-ssl
+  - name: test-named-latest-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-latest-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.12
+      - replica_set-noauth-ssl
+  - name: test-named-latest-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-latest-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-latest
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-latest-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-latest-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.10
+      - sharded_cluster-auth-ssl
   - name: test-named-latest-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -8565,3 +11227,64 @@ tasks:
       - server-latest
       - python-3.11
       - sharded_cluster-auth-ssl
+  - name: test-named-latest-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-latest-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.13
+      - sharded_cluster-auth-ssl
+  - name: test-named-latest-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-latest
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -328,6 +328,50 @@ tasks:
           PYTHON_VERSION: pypy3.10
     tags: [no-orchestration, python-pypy3.10]
 
+  # No toolchain tests
+  - name: test-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          TEST_NAME: default_sync
+    tags: [no-toolchain, standalone-noauth-nossl]
+  - name: test-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          TEST_NAME: default_async
+    tags: [no-toolchain, replica_set-noauth-ssl]
+  - name: test-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          TEST_NAME: default_sync
+    tags: [no-toolchain, sharded_cluster-auth-ssl]
+
   # Ocsp tests
   - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v4.4-python3.9
     commands:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -2505,50 +2505,6 @@ tasks:
           SUB_TEST_NAME: gke
     tags: [auth_oidc, auth_oidc_remote]
 
-  # Other hosts tests
-  - name: test-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          TEST_NAME: default_sync
-    tags: [other-hosts, standalone-noauth-nossl]
-  - name: test-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          TEST_NAME: default_async
-    tags: [other-hosts, replica_set-noauth-ssl]
-  - name: test-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          TEST_NAME: default_sync
-    tags: [other-hosts, sharded_cluster-auth-ssl]
-
   # Perf tests
   - name: perf-8.0-standalone-ssl
     commands:
@@ -7412,6 +7368,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
     tags: [server-version, python-3.9, sharded_cluster-auth-ssl]
   - name: test-python3.10-auth-ssl-sharded-cluster-cov
     commands:
@@ -7428,6 +7385,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
     tags: [server-version, python-3.10, sharded_cluster-auth-ssl]
   - name: test-python3.11-auth-ssl-sharded-cluster-cov
     commands:
@@ -7444,6 +7402,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
     tags: [server-version, python-3.11, sharded_cluster-auth-ssl]
   - name: test-python3.12-auth-ssl-sharded-cluster-cov
     commands:
@@ -7460,6 +7419,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
     tags: [server-version, python-3.12, sharded_cluster-auth-ssl]
   - name: test-python3.13-auth-ssl-sharded-cluster-cov
     commands:
@@ -7476,6 +7436,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
     tags: [server-version, python-3.13, sharded_cluster-auth-ssl]
   - name: test-pypy3.10-auth-ssl-sharded-cluster
     commands:
@@ -7490,6 +7451,7 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
     tags: [server-version, python-pypy3.10, sharded_cluster-auth-ssl]
   - name: test-python3.9-auth-ssl-standalone-cov
     commands:
@@ -7506,6 +7468,7 @@ tasks:
           TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
     tags: [server-version, python-3.9, standalone-auth-ssl]
   - name: test-python3.10-auth-nossl-standalone-cov
     commands:
@@ -7522,6 +7485,7 @@ tasks:
           TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
     tags: [server-version, python-3.10, standalone-auth-nossl]
   - name: test-python3.11-noauth-ssl-standalone-cov
     commands:
@@ -7538,6 +7502,7 @@ tasks:
           TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
     tags: [server-version, python-3.11, standalone-noauth-ssl]
   - name: test-python3.12-noauth-nossl-standalone-cov
     commands:
@@ -7554,6 +7519,7 @@ tasks:
           TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
     tags: [server-version, python-3.12, standalone-noauth-nossl]
   - name: test-python3.13-auth-ssl-replica-set-cov
     commands:
@@ -7570,6 +7536,7 @@ tasks:
           TOPOLOGY: replica_set
           COVERAGE: "1"
           PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
     tags: [server-version, python-3.13, replica_set-auth-ssl]
   - name: test-pypy3.10-auth-nossl-replica-set
     commands:
@@ -7584,6 +7551,7 @@ tasks:
           SSL: nossl
           TOPOLOGY: replica_set
           PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
     tags: [server-version, python-pypy3.10, replica_set-auth-nossl]
   - name: test-python3.9-noauth-ssl-replica-set-cov
     commands:
@@ -7600,6 +7568,7 @@ tasks:
           TOPOLOGY: replica_set
           COVERAGE: "1"
           PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
     tags: [server-version, python-3.9, replica_set-noauth-ssl]
   - name: test-python3.10-noauth-nossl-replica-set-cov
     commands:
@@ -7616,6 +7585,7 @@ tasks:
           TOPOLOGY: replica_set
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
     tags: [server-version, python-3.10, replica_set-noauth-nossl]
   - name: test-python3.12-auth-nossl-sharded-cluster-cov
     commands:
@@ -7632,6 +7602,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.12"
+          TEST_NAME: default_sync
     tags: [server-version, python-3.12, sharded_cluster-auth-nossl]
   - name: test-python3.13-noauth-ssl-sharded-cluster-cov
     commands:
@@ -7648,6 +7619,7 @@ tasks:
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.13"
+          TEST_NAME: default_async
     tags: [server-version, python-3.13, sharded_cluster-noauth-ssl]
   - name: test-pypy3.10-noauth-nossl-sharded-cluster
     commands:
@@ -7662,6 +7634,7 @@ tasks:
           SSL: nossl
           TOPOLOGY: sharded_cluster
           PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_sync
     tags: [server-version, python-pypy3.10, sharded_cluster-noauth-nossl]
 
   # Serverless tests
@@ -7674,549 +7647,7 @@ tasks:
           SSL: ssl
     tags: [serverless]
 
-  # Standard linux tests
-  - name: test-v4.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - standard-linux
-      - server-4.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-v4.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - standard-linux
-      - server-4.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-v4.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - standard-linux
-      - server-4.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-v4.2-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - standard-linux
-      - server-4.2
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-v4.2-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - standard-linux
-      - server-4.2
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-v4.2-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - standard-linux
-      - server-4.2
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-  - name: test-v4.4-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - standard-linux
-      - server-4.4
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-v4.4-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - standard-linux
-      - server-4.4
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-v4.4-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - standard-linux
-      - server-4.4
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-v5.0-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - standard-linux
-      - server-5.0
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-v5.0-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - standard-linux
-      - server-5.0
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-v5.0-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - standard-linux
-      - server-5.0
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-  - name: test-v6.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - standard-linux
-      - server-6.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-v6.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - standard-linux
-      - server-6.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-v6.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - standard-linux
-      - server-6.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-v7.0-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - standard-linux
-      - server-7.0
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-v7.0-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - standard-linux
-      - server-7.0
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-v7.0-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - standard-linux
-      - server-7.0
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-  - name: test-v8.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - standard-linux
-      - server-8.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-v8.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - standard-linux
-      - server-8.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-v8.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - standard-linux
-      - server-8.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-rapid-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.12"
-    tags:
-      - standard-linux
-      - server-rapid
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-rapid-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.13"
-    tags:
-      - standard-linux
-      - server-rapid
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-rapid-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - standard-linux
-      - server-rapid
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-  - name: test-latest-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.9"
-    tags:
-      - standard-linux
-      - server-latest
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-latest-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: "3.10"
-    tags:
-      - standard-linux
-      - server-latest
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-latest-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.11"
-    tags:
-      - standard-linux
-      - server-latest
-      - python-3.11
-      - sharded_cluster-auth-ssl
-
-  # Standard non linux tests
+  # Standard tests
   - name: test-v4.0-python3.9-sync-noauth-nossl-standalone
     commands:
       - func: run server
@@ -8234,7 +7665,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags:
-      - standard-non-linux
+      - standard
       - server-4.0
       - python-3.9
       - standalone-noauth-nossl
@@ -8256,7 +7687,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags:
-      - standard-non-linux
+      - standard
       - server-4.0
       - python-3.10
       - replica_set-noauth-ssl
@@ -8278,7 +7709,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_sync
     tags:
-      - standard-non-linux
+      - standard
       - server-4.0
       - python-3.11
       - sharded_cluster-auth-ssl
@@ -8300,7 +7731,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags:
-      - standard-non-linux
+      - standard
       - server-4.2
       - python-3.12
       - standalone-noauth-nossl
@@ -8322,12 +7753,12 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags:
-      - standard-non-linux
+      - standard
       - server-4.2
       - python-3.13
       - replica_set-noauth-ssl
       - sync
-  - name: test-v4.2-python3.9-async-auth-ssl-sharded-cluster
+  - name: test-v4.2-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8341,15 +7772,16 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: "4.2"
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
     tags:
-      - standard-non-linux
+      - standard
       - server-4.2
-      - python-3.9
+      - python-pypy3.10
       - sharded_cluster-auth-ssl
       - async
-  - name: test-v4.4-python3.10-sync-noauth-nossl-standalone
+      - pypy
+  - name: test-v4.4-python3.9-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8363,433 +7795,984 @@ tasks:
           SSL: nossl
           TOPOLOGY: standalone
           VERSION: "4.4"
-          PYTHON_VERSION: "3.10"
+          PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags:
-      - standard-non-linux
+      - standard
+      - server-4.4
+      - python-3.9
+      - standalone-noauth-nossl
+      - sync
+  - name: test-v4.4-python3.10-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
       - server-4.4
       - python-3.10
-      - standalone-noauth-nossl
-      - sync
-  - name: test-v4.4-python3.11-async-noauth-ssl-replica-set
+      - replica_set-noauth-ssl
+      - async
+  - name: test-v4.4-python3.11-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
-          AUTH: noauth
+          AUTH: auth
           SSL: ssl
-          TOPOLOGY: replica_set
+          TOPOLOGY: sharded_cluster
           VERSION: "4.4"
       - func: run tests
         vars:
-          AUTH: noauth
+          AUTH: auth
           SSL: ssl
-          TOPOLOGY: replica_set
+          TOPOLOGY: sharded_cluster
           VERSION: "4.4"
           PYTHON_VERSION: "3.11"
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
-      - standard-non-linux
+      - standard
       - server-4.4
       - python-3.11
-      - replica_set-noauth-ssl
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-v5.0-python3.12-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-5.0
+      - python-3.12
+      - standalone-noauth-nossl
       - async
-  - name: test-v4.4-python3.12-sync-auth-ssl-sharded-cluster
+  - name: test-v5.0-python3.13-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-5.0
+      - python-3.13
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-v5.0-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
+          VERSION: "5.0"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.12"
+          VERSION: "5.0"
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-5.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - async
+      - pypy
+  - name: test-v6.0-python3.9-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags:
-      - standard-non-linux
+      - standard
+      - server-6.0
+      - python-3.9
+      - standalone-noauth-nossl
+      - sync
+  - name: test-v6.0-python3.10-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-6.0
+      - python-3.10
+      - replica_set-noauth-ssl
+      - async
+  - name: test-v6.0-python3.11-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-6.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-v7.0-python3.12-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-7.0
+      - python-3.12
+      - standalone-noauth-nossl
+      - async
+  - name: test-v7.0-python3.13-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-7.0
+      - python-3.13
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-v7.0-pypy3.10-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-7.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - async
+      - pypy
+  - name: test-v8.0-python3.9-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-8.0
+      - python-3.9
+      - standalone-noauth-nossl
+      - sync
+  - name: test-v8.0-python3.10-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-8.0
+      - python-3.10
+      - replica_set-noauth-ssl
+      - async
+  - name: test-v8.0-python3.11-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-8.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-rapid-python3.12-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-rapid
+      - python-3.12
+      - standalone-noauth-nossl
+      - async
+  - name: test-rapid-python3.13-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-rapid
+      - python-3.13
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-rapid-pypy3.10-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-rapid
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - async
+      - pypy
+  - name: test-latest-python3.9-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-latest
+      - python-3.9
+      - standalone-noauth-nossl
+      - sync
+  - name: test-latest-python3.10-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-latest
+      - python-3.10
+      - replica_set-noauth-ssl
+      - async
+  - name: test-latest-python3.11-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-latest
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - sync
+
+  # Test name tests
+  - name: test-v4.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-name
+      - server-4.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-v4.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-name
+      - server-4.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-v4.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-name
+      - server-4.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-v4.2-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-name
+      - server-4.2
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-v4.2-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-name
+      - server-4.2
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-v4.2-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-name
+      - server-4.2
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+  - name: test-v4.4-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-name
       - server-4.4
-      - python-3.12
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-v5.0-python3.13-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.13"
-          TEST_NAME: default_async
-    tags:
-      - standard-non-linux
-      - server-5.0
-      - python-3.13
-      - standalone-noauth-nossl
-      - async
-  - name: test-v5.0-python3.9-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - standard-non-linux
-      - server-5.0
-      - python-3.9
-      - replica_set-noauth-ssl
-      - sync
-  - name: test-v5.0-python3.10-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - standard-non-linux
-      - server-5.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-      - async
-  - name: test-v6.0-python3.11-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags:
-      - standard-non-linux
-      - server-6.0
-      - python-3.11
-      - standalone-noauth-nossl
-      - sync
-  - name: test-v6.0-python3.12-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags:
-      - standard-non-linux
-      - server-6.0
-      - python-3.12
-      - replica_set-noauth-ssl
-      - async
-  - name: test-v6.0-python3.13-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - standard-non-linux
-      - server-6.0
-      - python-3.13
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-v7.0-python3.9-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
-    tags:
-      - standard-non-linux
-      - server-7.0
       - python-3.9
       - standalone-noauth-nossl
-      - async
-  - name: test-v7.0-python3.10-sync-noauth-ssl-replica-set
+  - name: test-v4.4-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: "7.0"
+          VERSION: "4.4"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: "7.0"
+          VERSION: "4.4"
           PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
     tags:
-      - standard-non-linux
-      - server-7.0
+      - test-name
+      - server-4.4
       - python-3.10
       - replica_set-noauth-ssl
-      - sync
-  - name: test-v7.0-python3.11-async-auth-ssl-sharded-cluster
+  - name: test-v4.4-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
+          VERSION: "4.4"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
+          VERSION: "4.4"
           PYTHON_VERSION: "3.11"
-          TEST_NAME: default_async
     tags:
-      - standard-non-linux
-      - server-7.0
+      - test-name
+      - server-4.4
       - python-3.11
       - sharded_cluster-auth-ssl
-      - async
-  - name: test-v8.0-python3.12-sync-noauth-nossl-standalone
+  - name: test-v5.0-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "8.0"
+          VERSION: "5.0"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "8.0"
+          VERSION: "5.0"
           PYTHON_VERSION: "3.12"
-          TEST_NAME: default_sync
     tags:
-      - standard-non-linux
-      - server-8.0
+      - test-name
+      - server-5.0
       - python-3.12
       - standalone-noauth-nossl
-      - sync
-  - name: test-v8.0-python3.13-async-noauth-ssl-replica-set
+  - name: test-v5.0-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: "8.0"
+          VERSION: "5.0"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: "8.0"
+          VERSION: "5.0"
           PYTHON_VERSION: "3.13"
-          TEST_NAME: default_async
     tags:
-      - standard-non-linux
-      - server-8.0
+      - test-name
+      - server-5.0
       - python-3.13
       - replica_set-noauth-ssl
-      - async
-  - name: test-v8.0-python3.9-sync-auth-ssl-sharded-cluster
+  - name: test-v5.0-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
+          VERSION: "5.0"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
+          VERSION: "5.0"
+          PYTHON_VERSION: pypy3.10
     tags:
-      - standard-non-linux
-      - server-8.0
-      - python-3.9
+      - test-name
+      - server-5.0
+      - python-pypy3.10
       - sharded_cluster-auth-ssl
-      - sync
-  - name: test-rapid-python3.10-async-noauth-nossl-standalone
+      - pypy
+  - name: test-v6.0-python3.9-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: rapid
+          VERSION: "6.0"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.9"
     tags:
-      - standard-non-linux
-      - server-rapid
-      - python-3.10
+      - test-name
+      - server-6.0
+      - python-3.9
       - standalone-noauth-nossl
-      - async
-  - name: test-rapid-python3.11-sync-noauth-ssl-replica-set
+  - name: test-v6.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: rapid
+          VERSION: "6.0"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: rapid
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-name
+      - server-6.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-v6.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
           PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
     tags:
-      - standard-non-linux
-      - server-rapid
+      - test-name
+      - server-6.0
       - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-v7.0-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-name
+      - server-7.0
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-v7.0-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-name
+      - server-7.0
+      - python-3.13
       - replica_set-noauth-ssl
-      - sync
-  - name: test-rapid-python3.12-async-auth-ssl-sharded-cluster
+  - name: test-v7.0-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: rapid
+          VERSION: "7.0"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-name
+      - server-7.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+  - name: test-v8.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-name
+      - server-8.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-v8.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-name
+      - server-8.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-v8.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-name
+      - server-8.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-rapid-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
           VERSION: rapid
           PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
     tags:
-      - standard-non-linux
+      - test-name
       - server-rapid
       - python-3.12
-      - sharded_cluster-auth-ssl
-      - async
-  - name: test-latest-python3.13-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - standard-non-linux
-      - server-latest
-      - python-3.13
       - standalone-noauth-nossl
-      - sync
-  - name: test-latest-python3.9-async-noauth-ssl-replica-set
+  - name: test-rapid-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: latest
+          VERSION: rapid
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-name
+      - server-rapid
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-rapid-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-name
+      - server-rapid
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+  - name: test-latest-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
           VERSION: latest
           PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
     tags:
-      - standard-non-linux
+      - test-name
       - server-latest
       - python-3.9
+      - standalone-noauth-nossl
+  - name: test-latest-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-name
+      - server-latest
+      - python-3.10
       - replica_set-noauth-ssl
-      - async
-  - name: test-latest-python3.10-sync-auth-ssl-sharded-cluster
+  - name: test-latest-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8803,11 +8786,9 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: latest
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
+          PYTHON_VERSION: "3.11"
     tags:
-      - standard-non-linux
+      - test-name
       - server-latest
-      - python-3.10
+      - python-3.11
       - sharded_cluster-auth-ssl
-      - sync

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -329,7 +329,7 @@ tasks:
     tags: [no-orchestration, python-pypy3.10]
 
   # No toolchain tests
-  - name: test-sync-noauth-nossl-standalone
+  - name: test-no-toolchain-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -343,7 +343,7 @@ tasks:
           TOPOLOGY: standalone
           TEST_NAME: default_sync
     tags: [no-toolchain, standalone-noauth-nossl]
-  - name: test-async-noauth-ssl-replica-set
+  - name: test-no-toolchain-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -357,7 +357,7 @@ tasks:
           TOPOLOGY: replica_set
           TEST_NAME: default_async
     tags: [no-toolchain, replica_set-noauth-ssl]
-  - name: test-sync-auth-ssl-sharded-cluster
+  - name: test-no-toolchain-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7170,7 +7170,7 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test-python3.9-sync-auth-ssl-sharded-cluster-cov
+  - name: test-server-version-python3.9-sync-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7187,7 +7187,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags: [server-version, python-3.9, sharded_cluster-auth-ssl]
-  - name: test-python3.10-async-auth-ssl-sharded-cluster-cov
+  - name: test-server-version-python3.10-async-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7204,7 +7204,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags: [server-version, python-3.10, sharded_cluster-auth-ssl]
-  - name: test-python3.11-sync-auth-ssl-sharded-cluster-cov
+  - name: test-server-version-python3.11-sync-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7221,7 +7221,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_sync
     tags: [server-version, python-3.11, sharded_cluster-auth-ssl]
-  - name: test-python3.12-async-auth-ssl-sharded-cluster-cov
+  - name: test-server-version-python3.12-async-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7238,7 +7238,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags: [server-version, python-3.12, sharded_cluster-auth-ssl]
-  - name: test-python3.13-sync-auth-ssl-sharded-cluster-cov
+  - name: test-server-version-python3.13-sync-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7255,7 +7255,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags: [server-version, python-3.13, sharded_cluster-auth-ssl]
-  - name: test-pypy3.10-async-auth-ssl-sharded-cluster
+  - name: test-server-version-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7270,7 +7270,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
     tags: [server-version, python-pypy3.10, sharded_cluster-auth-ssl]
-  - name: test-python3.9-sync-auth-ssl-standalone-cov
+  - name: test-server-version-python3.9-sync-auth-ssl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -7287,7 +7287,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags: [server-version, python-3.9, standalone-auth-ssl]
-  - name: test-python3.10-async-auth-nossl-standalone-cov
+  - name: test-server-version-python3.10-async-auth-nossl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -7304,7 +7304,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags: [server-version, python-3.10, standalone-auth-nossl]
-  - name: test-python3.11-sync-noauth-ssl-standalone-cov
+  - name: test-server-version-python3.11-sync-noauth-ssl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -7321,7 +7321,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_sync
     tags: [server-version, python-3.11, standalone-noauth-ssl]
-  - name: test-python3.12-async-noauth-nossl-standalone-cov
+  - name: test-server-version-python3.12-async-noauth-nossl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -7338,7 +7338,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags: [server-version, python-3.12, standalone-noauth-nossl]
-  - name: test-python3.13-sync-auth-ssl-replica-set-cov
+  - name: test-server-version-python3.13-sync-auth-ssl-replica-set-cov
     commands:
       - func: run server
         vars:
@@ -7355,7 +7355,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags: [server-version, python-3.13, replica_set-auth-ssl]
-  - name: test-pypy3.10-async-auth-nossl-replica-set
+  - name: test-server-version-pypy3.10-async-auth-nossl-replica-set
     commands:
       - func: run server
         vars:
@@ -7370,7 +7370,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
     tags: [server-version, python-pypy3.10, replica_set-auth-nossl]
-  - name: test-python3.9-sync-noauth-ssl-replica-set-cov
+  - name: test-server-version-python3.9-sync-noauth-ssl-replica-set-cov
     commands:
       - func: run server
         vars:
@@ -7387,7 +7387,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags: [server-version, python-3.9, replica_set-noauth-ssl]
-  - name: test-python3.10-async-noauth-nossl-replica-set-cov
+  - name: test-server-version-python3.10-async-noauth-nossl-replica-set-cov
     commands:
       - func: run server
         vars:
@@ -7404,7 +7404,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags: [server-version, python-3.10, replica_set-noauth-nossl]
-  - name: test-python3.12-sync-auth-nossl-sharded-cluster-cov
+  - name: test-server-version-python3.12-sync-auth-nossl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7421,7 +7421,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_sync
     tags: [server-version, python-3.12, sharded_cluster-auth-nossl]
-  - name: test-python3.13-async-noauth-ssl-sharded-cluster-cov
+  - name: test-server-version-python3.13-async-noauth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7438,7 +7438,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_async
     tags: [server-version, python-3.13, sharded_cluster-noauth-ssl]
-  - name: test-pypy3.10-sync-noauth-nossl-sharded-cluster
+  - name: test-server-version-pypy3.10-sync-noauth-nossl-sharded-cluster
     commands:
       - func: run server
         vars:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8041,86 +8041,526 @@ tasks:
       - server-4.0
       - python-3.9
       - standalone-noauth-nossl
-  - name: test-named-v4.0-python3.10-noauth-nossl-standalone
+  - name: test-named-v4.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
+          SSL: ssl
+          TOPOLOGY: replica_set
           VERSION: "4.0"
       - func: run tests
         vars:
           AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
+          SSL: ssl
+          TOPOLOGY: replica_set
           VERSION: "4.0"
           PYTHON_VERSION: "3.10"
     tags:
       - test-named
       - server-4.0
       - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-v4.0-python3.11-noauth-nossl-standalone
+      - replica_set-noauth-ssl
+  - name: test-named-v4.0-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
           VERSION: "4.0"
       - func: run tests
         vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
           VERSION: "4.0"
           PYTHON_VERSION: "3.11"
     tags:
       - test-named
       - server-4.0
       - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-v4.0-python3.12-noauth-nossl-standalone
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.2-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "4.0"
+          VERSION: "4.2"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "4.0"
+          VERSION: "4.2"
           PYTHON_VERSION: "3.12"
     tags:
       - test-named
-      - server-4.0
+      - server-4.2
       - python-3.12
       - standalone-noauth-nossl
-  - name: test-named-v4.0-python3.13-noauth-nossl-standalone
+  - name: test-named-v4.2-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-v4.2-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.4-python3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "4.0"
+          VERSION: "4.4"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "4.0"
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v4.4-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-v4.4-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v5.0-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
           PYTHON_VERSION: "3.13"
     tags:
       - test-named
-      - server-4.0
+      - server-5.0
       - python-3.13
       - standalone-noauth-nossl
+  - name: test-named-v5.0-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.9
+      - replica_set-noauth-ssl
+  - name: test-named-v5.0-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+  - name: test-named-v6.0-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.11
+      - standalone-noauth-nossl
+  - name: test-named-v6.0-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.12
+      - replica_set-noauth-ssl
+  - name: test-named-v6.0-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+  - name: test-named-v7.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-named-v7.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-named-v7.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-named-v8.0-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-named-v8.0-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-v8.0-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-rapid-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-rapid-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-rapid-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-latest-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-latest-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.9
+      - replica_set-noauth-ssl
+  - name: test-named-latest-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.10
+      - sharded_cluster-auth-ssl
   - name: test-named-v4.0-pypy3.10-noauth-nossl-standalone
     commands:
       - func: run server
@@ -8142,469 +8582,6 @@ tasks:
       - python-pypy3.10
       - standalone-noauth-nossl
       - pypy
-  - name: test-named-v4.0-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-v4.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v4.0-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-v4.0-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-v4.0-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-named-v4.0-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-4.0
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-v4.0-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.0-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.0-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.0-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.13
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.0-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-4.0
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - pypy
-  - name: test-named-v4.2-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-v4.2-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-v4.2-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-v4.2-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-v4.2-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.13
-      - standalone-noauth-nossl
-  - name: test-named-v4.2-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-4.2
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-v4.2-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-v4.2-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v4.2-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-v4.2-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-v4.2-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.13
-      - replica_set-noauth-ssl
   - name: test-named-v4.2-pypy3.10-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -8626,469 +8603,6 @@ tasks:
       - python-pypy3.10
       - replica_set-noauth-ssl
       - pypy
-  - name: test-named-v4.2-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.2-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.2-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.2-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.2-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.13
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.2-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-4.2
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - pypy
-  - name: test-named-v4.4-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-v4.4-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-v4.4-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-v4.4-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-v4.4-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.13
-      - standalone-noauth-nossl
-  - name: test-named-v4.4-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-4.4
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-v4.4-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-v4.4-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v4.4-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-v4.4-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-v4.4-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-named-v4.4-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-4.4
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-v4.4-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.4-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.4-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.4-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.4-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.13
-      - sharded_cluster-auth-ssl
   - name: test-named-v4.4-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -9110,106 +8624,6 @@ tasks:
       - python-pypy3.10
       - sharded_cluster-auth-ssl
       - pypy
-  - name: test-named-v5.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-v5.0-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-v5.0-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-v5.0-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-v5.0-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.13
-      - standalone-noauth-nossl
   - name: test-named-v5.0-pypy3.10-noauth-nossl-standalone
     commands:
       - func: run server
@@ -9231,469 +8645,6 @@ tasks:
       - python-pypy3.10
       - standalone-noauth-nossl
       - pypy
-  - name: test-named-v5.0-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-v5.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v5.0-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-v5.0-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-v5.0-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-named-v5.0-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-5.0
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-v5.0-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-v5.0-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v5.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v5.0-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-v5.0-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.13
-      - sharded_cluster-auth-ssl
-  - name: test-named-v5.0-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-5.0
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - pypy
-  - name: test-named-v6.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-v6.0-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-v6.0-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-v6.0-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-v6.0-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.13
-      - standalone-noauth-nossl
-  - name: test-named-v6.0-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-6.0
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-v6.0-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-v6.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v6.0-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-v6.0-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-v6.0-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.13
-      - replica_set-noauth-ssl
   - name: test-named-v6.0-pypy3.10-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -9715,469 +8666,6 @@ tasks:
       - python-pypy3.10
       - replica_set-noauth-ssl
       - pypy
-  - name: test-named-v6.0-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-v6.0-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v6.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v6.0-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-v6.0-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.13
-      - sharded_cluster-auth-ssl
-  - name: test-named-v6.0-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-6.0
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - pypy
-  - name: test-named-v7.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-v7.0-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-v7.0-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-v7.0-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-v7.0-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.13
-      - standalone-noauth-nossl
-  - name: test-named-v7.0-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-7.0
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-v7.0-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-v7.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v7.0-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-v7.0-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-v7.0-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-named-v7.0-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-7.0
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-v7.0-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-v7.0-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v7.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v7.0-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-v7.0-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.13
-      - sharded_cluster-auth-ssl
   - name: test-named-v7.0-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -10199,106 +8687,6 @@ tasks:
       - python-pypy3.10
       - sharded_cluster-auth-ssl
       - pypy
-  - name: test-named-v8.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-v8.0-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-v8.0-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-v8.0-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-v8.0-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.13
-      - standalone-noauth-nossl
   - name: test-named-v8.0-pypy3.10-noauth-nossl-standalone
     commands:
       - func: run server
@@ -10320,469 +8708,6 @@ tasks:
       - python-pypy3.10
       - standalone-noauth-nossl
       - pypy
-  - name: test-named-v8.0-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-v8.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v8.0-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-v8.0-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-v8.0-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-named-v8.0-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-8.0
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-v8.0-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-v8.0-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v8.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v8.0-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-v8.0-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.13
-      - sharded_cluster-auth-ssl
-  - name: test-named-v8.0-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-8.0
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - pypy
-  - name: test-named-rapid-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-rapid-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-rapid-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-rapid-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-rapid-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.13
-      - standalone-noauth-nossl
-  - name: test-named-rapid-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-rapid
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-rapid-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-rapid-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-rapid-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-rapid-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-rapid-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.13
-      - replica_set-noauth-ssl
   - name: test-named-rapid-pypy3.10-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -10804,469 +8729,6 @@ tasks:
       - python-pypy3.10
       - replica_set-noauth-ssl
       - pypy
-  - name: test-named-rapid-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-rapid-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-rapid-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-rapid-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-rapid-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.13
-      - sharded_cluster-auth-ssl
-  - name: test-named-rapid-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-rapid
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - pypy
-  - name: test-named-latest-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-latest-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-latest-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-latest-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-latest-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.13
-      - standalone-noauth-nossl
-  - name: test-named-latest-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-latest
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-latest-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-latest-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-latest-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-latest-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-latest-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-named-latest-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-latest
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-latest-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-latest-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-latest-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-latest-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-latest-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.13
-      - sharded_cluster-auth-ssl
   - name: test-named-latest-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -342,7 +342,7 @@ tasks:
           SSL: nossl
           TOPOLOGY: standalone
           TEST_NAME: default_sync
-    tags: [no-toolchain, standalone-noauth-nossl]
+    tags: [test-no-toolchain, standalone-noauth-nossl]
   - name: test-no-toolchain-async-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -356,7 +356,7 @@ tasks:
           SSL: ssl
           TOPOLOGY: replica_set
           TEST_NAME: default_async
-    tags: [no-toolchain, replica_set-noauth-ssl]
+    tags: [test-no-toolchain, replica_set-noauth-ssl]
   - name: test-no-toolchain-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -370,7 +370,7 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           TEST_NAME: default_sync
-    tags: [no-toolchain, sharded_cluster-auth-ssl]
+    tags: [test-no-toolchain, sharded_cluster-auth-ssl]
 
   # Ocsp tests
   - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v4.4-python3.9

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -7666,6 +7666,214 @@ tasks:
       - python-pypy3.10
       - sharded_cluster-noauth-nossl
       - async
+  - name: test-server-version-python3.9-sync-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.9
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-server-version-python3.9-async-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.9
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-server-version-python3.10-sync-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-server-version-python3.10-async-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-server-version-python3.11-sync-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-server-version-python3.11-async-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-server-version-python3.12-sync-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-server-version-python3.12-async-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-server-version-python3.13-async-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.13
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-server-version-pypy3.10-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - sync
 
   # Serverless tests
   - name: test-serverless

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -7531,7 +7531,7 @@ tasks:
       - python-3.13
       - replica_set-noauth-ssl
       - sync
-  - name: test-standard-v4.2-pypy3.10-async-auth-ssl-sharded-cluster
+  - name: test-standard-v4.2-python3.9-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7544,6 +7544,513 @@ tasks:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-4.2
+      - python-3.9
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-v4.4-python3.10-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-4.4
+      - python-3.10
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-v4.4-python3.11-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-4.4
+      - python-3.11
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-v4.4-python3.12-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-4.4
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-v5.0-python3.13-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-5.0
+      - python-3.13
+      - standalone-noauth-nossl
+      - async
+  - name: test-standard-v5.0-python3.9-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-5.0
+      - python-3.9
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-standard-v5.0-python3.10-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-5.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-v6.0-python3.11-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-6.0
+      - python-3.11
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-v6.0-python3.12-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-6.0
+      - python-3.12
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-v6.0-python3.13-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-6.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-v7.0-python3.9-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-7.0
+      - python-3.9
+      - standalone-noauth-nossl
+      - async
+  - name: test-standard-v7.0-python3.10-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-7.0
+      - python-3.10
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-standard-v7.0-python3.11-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-7.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-v8.0-python3.12-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-8.0
+      - python-3.12
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-v8.0-python3.13-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-8.0
+      - python-3.13
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-v8.0-python3.9-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-8.0
+      - python-3.9
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-rapid-python3.10-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-rapid
+      - python-3.10
+      - standalone-noauth-nossl
+      - async
+  - name: test-standard-rapid-python3.11-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-rapid
+      - python-3.11
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-standard-rapid-python3.12-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-rapid
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-latest-python3.13-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-latest
+      - python-3.13
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-latest-python3.9-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-latest
+      - python-3.9
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-latest-python3.10-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-latest
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-v4.0-pypy3.10-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-4.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - sync
+      - pypy
+  - name: test-standard-v4.2-pypy3.10-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
           VERSION: "4.2"
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
@@ -7551,54 +8058,10 @@ tasks:
       - standard
       - server-4.2
       - python-pypy3.10
-      - sharded_cluster-auth-ssl
+      - replica_set-noauth-ssl
       - async
       - pypy
-  - name: test-standard-v4.4-python3.9-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-4.4
-      - python-3.9
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-v4.4-python3.10-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-4.4
-      - python-3.10
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-v4.4-python3.11-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v4.4-pypy3.10-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7612,15 +8075,16 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: "4.4"
-          PYTHON_VERSION: "3.11"
+          PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
       - standard
       - server-4.4
-      - python-3.11
+      - python-pypy3.10
       - sharded_cluster-auth-ssl
       - sync
-  - name: test-standard-v5.0-python3.12-async-noauth-nossl-standalone
+      - pypy
+  - name: test-standard-v5.0-pypy3.10-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -7633,50 +8097,6 @@ tasks:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-5.0
-      - python-3.12
-      - standalone-noauth-nossl
-      - async
-  - name: test-standard-v5.0-python3.13-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-5.0
-      - python-3.13
-      - replica_set-noauth-ssl
-      - sync
-  - name: test-standard-v5.0-pypy3.10-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
           VERSION: "5.0"
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
@@ -7684,119 +8104,32 @@ tasks:
       - standard
       - server-5.0
       - python-pypy3.10
-      - sharded_cluster-auth-ssl
+      - standalone-noauth-nossl
       - async
       - pypy
-  - name: test-standard-v6.0-python3.9-sync-noauth-nossl-standalone
+  - name: test-standard-v6.0-pypy3.10-sync-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
+          SSL: ssl
+          TOPOLOGY: replica_set
           VERSION: "6.0"
       - func: run tests
         vars:
           AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
+          SSL: ssl
+          TOPOLOGY: replica_set
           VERSION: "6.0"
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
       - standard
       - server-6.0
-      - python-3.9
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-v6.0-python3.10-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-6.0
-      - python-3.10
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-v6.0-python3.11-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-6.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v7.0-python3.12-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-7.0
-      - python-3.12
-      - standalone-noauth-nossl
-      - async
-  - name: test-standard-v7.0-python3.13-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-7.0
-      - python-3.13
+      - python-pypy3.10
       - replica_set-noauth-ssl
       - sync
+      - pypy
   - name: test-standard-v7.0-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -7820,7 +8153,7 @@ tasks:
       - sharded_cluster-auth-ssl
       - async
       - pypy
-  - name: test-standard-v8.0-python3.9-sync-noauth-nossl-standalone
+  - name: test-standard-v8.0-pypy3.10-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -7834,81 +8167,16 @@ tasks:
           SSL: nossl
           TOPOLOGY: standalone
           VERSION: "8.0"
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
       - standard
       - server-8.0
-      - python-3.9
+      - python-pypy3.10
       - standalone-noauth-nossl
       - sync
-  - name: test-standard-v8.0-python3.10-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-8.0
-      - python-3.10
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-v8.0-python3.11-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-8.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-rapid-python3.12-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-rapid
-      - python-3.12
-      - standalone-noauth-nossl
-      - async
-  - name: test-standard-rapid-python3.13-sync-noauth-ssl-replica-set
+      - pypy
+  - name: test-standard-rapid-pypy3.10-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -7921,28 +8189,6 @@ tasks:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-rapid
-      - python-3.13
-      - replica_set-noauth-ssl
-      - sync
-  - name: test-standard-rapid-pypy3.10-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
           VERSION: rapid
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
@@ -7950,54 +8196,10 @@ tasks:
       - standard
       - server-rapid
       - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - async
-      - pypy
-  - name: test-standard-latest-python3.9-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-latest
-      - python-3.9
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-latest-python3.10-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-latest
-      - python-3.10
       - replica_set-noauth-ssl
       - async
-  - name: test-standard-latest-python3.11-sync-auth-ssl-sharded-cluster
+      - pypy
+  - name: test-standard-latest-pypy3.10-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8011,14 +8213,15 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: latest
-          PYTHON_VERSION: "3.11"
+          PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
       - standard
       - server-latest
-      - python-3.11
+      - python-pypy3.10
       - sharded_cluster-auth-ssl
       - sync
+      - pypy
 
   # Test named tests
   - name: test-named-v4.0-python3.9-noauth-nossl-standalone

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -305,6 +305,371 @@ tasks:
           PYTHON_VERSION: "3.13"
     tags: [mod_wsgi]
 
+  # Named test tests
+  - name: test-named-v4.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-named-v4.2-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.9
+      - replica_set-noauth-ssl
+  - name: test-named-v4.4-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v5.0-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v6.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-named-v7.0-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+  - name: test-named-v8.0-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.11
+      - standalone-noauth-nossl
+  - name: test-named-rapid-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-latest-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.0-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-named-v4.2-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.12
+      - replica_set-noauth-ssl
+  - name: test-named-v4.4-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v5.0-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-v6.0-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-v7.0-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+  - name: test-named-v8.0-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-8.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-rapid-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-rapid
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-latest-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-latest
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+
   # No orchestration tests
   - name: test-no-orchestration-python3.9
     commands:
@@ -7443,161 +7808,227 @@ tasks:
       - python-3.9
       - standalone-noauth-nossl
       - sync
-  - name: test-standard-v4.0-python3.10-async-noauth-ssl-replica-set
+  - name: test-standard-v4.2-python3.9-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: "4.0"
+          VERSION: "4.2"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: "4.0"
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-4.2
+      - python-3.9
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-v4.4-python3.9-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-4.4
+      - python-3.9
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-v5.0-python3.10-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
           PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-5.0
+      - python-3.10
+      - standalone-noauth-nossl
+      - async
+  - name: test-standard-v6.0-python3.10-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-6.0
+      - python-3.10
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-standard-v7.0-python3.10-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-7.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-v8.0-python3.11-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-8.0
+      - python-3.11
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-rapid-python3.11-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-rapid
+      - python-3.11
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-latest-python3.11-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-latest
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-v4.0-python3.12-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags:
       - standard
       - server-4.0
-      - python-3.10
-      - replica_set-noauth-ssl
+      - python-3.12
+      - standalone-noauth-nossl
       - async
-  - name: test-standard-v4.0-python3.11-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-4.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v4.2-python3.12-async-noauth-nossl-standalone
+  - name: test-standard-v4.2-python3.12-sync-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
+          SSL: ssl
+          TOPOLOGY: replica_set
           VERSION: "4.2"
       - func: run tests
         vars:
           AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
+          SSL: ssl
+          TOPOLOGY: replica_set
           VERSION: "4.2"
           PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
       - standard
       - server-4.2
       - python-3.12
-      - standalone-noauth-nossl
-      - async
-  - name: test-standard-v4.2-python3.13-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-4.2
-      - python-3.13
       - replica_set-noauth-ssl
       - sync
-  - name: test-standard-v4.2-python3.9-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-4.2
-      - python-3.9
-      - sharded_cluster-auth-ssl
-      - async
-  - name: test-standard-v4.4-python3.10-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-4.4
-      - python-3.10
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-v4.4-python3.11-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-4.4
-      - python-3.11
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-v4.4-python3.12-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v4.4-python3.12-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7612,14 +8043,14 @@ tasks:
           TOPOLOGY: sharded_cluster
           VERSION: "4.4"
           PYTHON_VERSION: "3.12"
-          TEST_NAME: default_sync
+          TEST_NAME: default_async
     tags:
       - standard
       - server-4.4
       - python-3.12
       - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v5.0-python3.13-async-noauth-nossl-standalone
+      - async
+  - name: test-standard-v5.0-python3.13-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -7634,80 +8065,14 @@ tasks:
           TOPOLOGY: standalone
           VERSION: "5.0"
           PYTHON_VERSION: "3.13"
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
       - standard
       - server-5.0
       - python-3.13
       - standalone-noauth-nossl
-      - async
-  - name: test-standard-v5.0-python3.9-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-5.0
-      - python-3.9
-      - replica_set-noauth-ssl
       - sync
-  - name: test-standard-v5.0-python3.10-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-5.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-      - async
-  - name: test-standard-v6.0-python3.11-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-6.0
-      - python-3.11
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-v6.0-python3.12-async-noauth-ssl-replica-set
+  - name: test-standard-v6.0-python3.13-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -7721,439 +8086,37 @@ tasks:
           SSL: ssl
           TOPOLOGY: replica_set
           VERSION: "6.0"
-          PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-6.0
-      - python-3.12
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-v6.0-python3.13-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-6.0
-      - python-3.13
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v7.0-python3.9-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-7.0
-      - python-3.9
-      - standalone-noauth-nossl
-      - async
-  - name: test-standard-v7.0-python3.10-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-7.0
-      - python-3.10
-      - replica_set-noauth-ssl
-      - sync
-  - name: test-standard-v7.0-python3.11-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-7.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-      - async
-  - name: test-standard-v8.0-python3.12-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.12"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-8.0
-      - python-3.12
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-v8.0-python3.13-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_async
     tags:
       - standard
-      - server-8.0
+      - server-6.0
       - python-3.13
       - replica_set-noauth-ssl
       - async
-  - name: test-standard-v8.0-python3.9-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v7.0-python3.13-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
+          VERSION: "7.0"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-8.0
-      - python-3.9
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-rapid-python3.10-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-rapid
-      - python-3.10
-      - standalone-noauth-nossl
-      - async
-  - name: test-standard-rapid-python3.11-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-rapid
-      - python-3.11
-      - replica_set-noauth-ssl
-      - sync
-  - name: test-standard-rapid-python3.12-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-rapid
-      - python-3.12
-      - sharded_cluster-auth-ssl
-      - async
-  - name: test-standard-latest-python3.13-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
+          VERSION: "7.0"
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags:
       - standard
-      - server-latest
-      - python-3.13
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-latest-python3.9-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-latest
-      - python-3.9
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-latest-python3.10-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-latest
-      - python-3.10
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v4.0-pypy3.10-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-          PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-4.0
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - sync
-      - pypy
-  - name: test-standard-v4.2-pypy3.10-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-4.2
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - async
-      - pypy
-  - name: test-standard-v4.4-pypy3.10-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-4.4
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - sync
-      - pypy
-  - name: test-standard-v5.0-pypy3.10-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-5.0
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - async
-      - pypy
-  - name: test-standard-v6.0-pypy3.10-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-6.0
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - sync
-      - pypy
-  - name: test-standard-v7.0-pypy3.10-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_async
-    tags:
-      - standard
       - server-7.0
-      - python-pypy3.10
+      - python-3.13
       - sharded_cluster-auth-ssl
-      - async
-      - pypy
-  - name: test-standard-v8.0-pypy3.10-sync-noauth-nossl-standalone
+      - sync
+  - name: test-standard-v8.0-pypy3.10-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8168,771 +8131,38 @@ tasks:
           TOPOLOGY: standalone
           VERSION: "8.0"
           PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_sync
+          TEST_NAME: default_async
     tags:
       - standard
       - server-8.0
       - python-pypy3.10
       - standalone-noauth-nossl
-      - sync
-      - pypy
-  - name: test-standard-rapid-pypy3.10-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-rapid
-      - python-pypy3.10
-      - replica_set-noauth-ssl
       - async
       - pypy
-  - name: test-standard-latest-pypy3.10-sync-auth-ssl-sharded-cluster
+  - name: test-standard-rapid-pypy3.10-sync-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
-          AUTH: auth
+          AUTH: noauth
           SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
+          TOPOLOGY: replica_set
+          VERSION: rapid
       - func: run tests
         vars:
-          AUTH: auth
+          AUTH: noauth
           SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
+          TOPOLOGY: replica_set
+          VERSION: rapid
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_sync
     tags:
       - standard
-      - server-latest
+      - server-rapid
       - python-pypy3.10
-      - sharded_cluster-auth-ssl
+      - replica_set-noauth-ssl
       - sync
       - pypy
-
-  # Test named tests
-  - name: test-named-v4.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-v4.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v4.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.2-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-v4.2-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-named-v4.2-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.4-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-v4.4-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-v4.4-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-v5.0-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.13
-      - standalone-noauth-nossl
-  - name: test-named-v5.0-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-v5.0-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v6.0-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-v6.0-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-v6.0-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.13
-      - sharded_cluster-auth-ssl
-  - name: test-named-v7.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-v7.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v7.0-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v8.0-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-v8.0-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-named-v8.0-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-rapid-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-rapid-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-rapid-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-latest-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.13
-      - standalone-noauth-nossl
-  - name: test-named-latest-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-latest-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.0-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-4.0
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-v4.2-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-4.2
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-v4.4-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-4.4
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - pypy
-  - name: test-named-v5.0-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-5.0
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-v6.0-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-6.0
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-v7.0-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-7.0
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - pypy
-  - name: test-named-v8.0-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-8.0
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-rapid-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-rapid
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-latest-pypy3.10-auth-ssl-sharded-cluster
+  - name: test-standard-latest-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8947,9 +8177,11 @@ tasks:
           TOPOLOGY: sharded_cluster
           VERSION: latest
           PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
     tags:
-      - test-named
+      - standard
       - server-latest
       - python-pypy3.10
       - sharded_cluster-auth-ssl
+      - async
       - pypy

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -7353,7 +7353,7 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test-python3.9-auth-ssl-sharded-cluster-cov
+  - name: test-python3.9-sync-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7370,7 +7370,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags: [server-version, python-3.9, sharded_cluster-auth-ssl]
-  - name: test-python3.10-auth-ssl-sharded-cluster-cov
+  - name: test-python3.10-async-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7387,7 +7387,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags: [server-version, python-3.10, sharded_cluster-auth-ssl]
-  - name: test-python3.11-auth-ssl-sharded-cluster-cov
+  - name: test-python3.11-sync-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7404,7 +7404,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_sync
     tags: [server-version, python-3.11, sharded_cluster-auth-ssl]
-  - name: test-python3.12-auth-ssl-sharded-cluster-cov
+  - name: test-python3.12-async-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7421,7 +7421,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags: [server-version, python-3.12, sharded_cluster-auth-ssl]
-  - name: test-python3.13-auth-ssl-sharded-cluster-cov
+  - name: test-python3.13-sync-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7438,7 +7438,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags: [server-version, python-3.13, sharded_cluster-auth-ssl]
-  - name: test-pypy3.10-auth-ssl-sharded-cluster
+  - name: test-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7453,7 +7453,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
     tags: [server-version, python-pypy3.10, sharded_cluster-auth-ssl]
-  - name: test-python3.9-auth-ssl-standalone-cov
+  - name: test-python3.9-sync-auth-ssl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -7470,7 +7470,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags: [server-version, python-3.9, standalone-auth-ssl]
-  - name: test-python3.10-auth-nossl-standalone-cov
+  - name: test-python3.10-async-auth-nossl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -7487,7 +7487,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags: [server-version, python-3.10, standalone-auth-nossl]
-  - name: test-python3.11-noauth-ssl-standalone-cov
+  - name: test-python3.11-sync-noauth-ssl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -7504,7 +7504,7 @@ tasks:
           PYTHON_VERSION: "3.11"
           TEST_NAME: default_sync
     tags: [server-version, python-3.11, standalone-noauth-ssl]
-  - name: test-python3.12-noauth-nossl-standalone-cov
+  - name: test-python3.12-async-noauth-nossl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -7521,7 +7521,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags: [server-version, python-3.12, standalone-noauth-nossl]
-  - name: test-python3.13-auth-ssl-replica-set-cov
+  - name: test-python3.13-sync-auth-ssl-replica-set-cov
     commands:
       - func: run server
         vars:
@@ -7538,7 +7538,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags: [server-version, python-3.13, replica_set-auth-ssl]
-  - name: test-pypy3.10-auth-nossl-replica-set
+  - name: test-pypy3.10-async-auth-nossl-replica-set
     commands:
       - func: run server
         vars:
@@ -7553,7 +7553,7 @@ tasks:
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
     tags: [server-version, python-pypy3.10, replica_set-auth-nossl]
-  - name: test-python3.9-noauth-ssl-replica-set-cov
+  - name: test-python3.9-sync-noauth-ssl-replica-set-cov
     commands:
       - func: run server
         vars:
@@ -7570,7 +7570,7 @@ tasks:
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags: [server-version, python-3.9, replica_set-noauth-ssl]
-  - name: test-python3.10-noauth-nossl-replica-set-cov
+  - name: test-python3.10-async-noauth-nossl-replica-set-cov
     commands:
       - func: run server
         vars:
@@ -7587,7 +7587,7 @@ tasks:
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags: [server-version, python-3.10, replica_set-noauth-nossl]
-  - name: test-python3.12-auth-nossl-sharded-cluster-cov
+  - name: test-python3.12-sync-auth-nossl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7604,7 +7604,7 @@ tasks:
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_sync
     tags: [server-version, python-3.12, sharded_cluster-auth-nossl]
-  - name: test-python3.13-noauth-ssl-sharded-cluster-cov
+  - name: test-python3.13-async-noauth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -7621,7 +7621,7 @@ tasks:
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_async
     tags: [server-version, python-3.13, sharded_cluster-noauth-ssl]
-  - name: test-pypy3.10-noauth-nossl-sharded-cluster
+  - name: test-pypy3.10-sync-noauth-nossl-sharded-cluster
     commands:
       - func: run server
         vars:

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -305,371 +305,6 @@ tasks:
           PYTHON_VERSION: "3.13"
     tags: [mod_wsgi]
 
-  # Named test tests
-  - name: test-named-v4.0-python3.9-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.9
-      - standalone-noauth-nossl
-  - name: test-named-v4.2-python3.9-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.9
-      - replica_set-noauth-ssl
-  - name: test-named-v4.4-python3.9-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.9
-      - sharded_cluster-auth-ssl
-  - name: test-named-v5.0-python3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.10
-      - standalone-noauth-nossl
-  - name: test-named-v6.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.10
-      - replica_set-noauth-ssl
-  - name: test-named-v7.0-python3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.10"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-  - name: test-named-v8.0-python3.11-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-8.0
-      - python-3.11
-      - standalone-noauth-nossl
-  - name: test-named-rapid-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-rapid
-      - python-3.11
-      - replica_set-noauth-ssl
-  - name: test-named-latest-python3.11-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.11"
-    tags:
-      - test-named
-      - server-latest
-      - python-3.11
-      - sharded_cluster-auth-ssl
-  - name: test-named-v4.0-python3.12-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.0"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.0
-      - python-3.12
-      - standalone-noauth-nossl
-  - name: test-named-v4.2-python3.12-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.2
-      - python-3.12
-      - replica_set-noauth-ssl
-  - name: test-named-v4.4-python3.12-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.12"
-    tags:
-      - test-named
-      - server-4.4
-      - python-3.12
-      - sharded_cluster-auth-ssl
-  - name: test-named-v5.0-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-5.0
-      - python-3.13
-      - standalone-noauth-nossl
-  - name: test-named-v6.0-python3.13-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-6.0
-      - python-3.13
-      - replica_set-noauth-ssl
-  - name: test-named-v7.0-python3.13-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.13"
-    tags:
-      - test-named
-      - server-7.0
-      - python-3.13
-      - sharded_cluster-auth-ssl
-  - name: test-named-v8.0-pypy3.10-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-8.0
-      - python-pypy3.10
-      - standalone-noauth-nossl
-      - pypy
-  - name: test-named-rapid-pypy3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-rapid
-      - python-pypy3.10
-      - replica_set-noauth-ssl
-      - pypy
-  - name: test-named-latest-pypy3.10-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: pypy3.10
-    tags:
-      - test-named
-      - server-latest
-      - python-pypy3.10
-      - sharded_cluster-auth-ssl
-      - pypy
-
   # No orchestration tests
   - name: test-no-orchestration-python3.9
     commands:
@@ -7808,227 +7443,161 @@ tasks:
       - python-3.9
       - standalone-noauth-nossl
       - sync
-  - name: test-standard-v4.2-python3.9-async-noauth-ssl-replica-set
+  - name: test-standard-v4.0-python3.10-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-4.2
-      - python-3.9
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-v4.4-python3.9-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-4.4
-      - python-3.9
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v5.0-python3.10-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-5.0
-      - python-3.10
-      - standalone-noauth-nossl
-      - async
-  - name: test-standard-v6.0-python3.10-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-6.0
-      - python-3.10
-      - replica_set-noauth-ssl
-      - sync
-  - name: test-standard-v7.0-python3.10-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-7.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-      - async
-  - name: test-standard-v8.0-python3.11-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-8.0
-      - python-3.11
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-rapid-python3.11-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_async
-    tags:
-      - standard
-      - server-rapid
-      - python-3.11
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-latest-python3.11-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags:
-      - standard
-      - server-latest
-      - python-3.11
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v4.0-python3.12-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
           VERSION: "4.0"
       - func: run tests
         vars:
           AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
+          SSL: ssl
+          TOPOLOGY: replica_set
           VERSION: "4.0"
-          PYTHON_VERSION: "3.12"
+          PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags:
       - standard
       - server-4.0
-      - python-3.12
-      - standalone-noauth-nossl
+      - python-3.10
+      - replica_set-noauth-ssl
       - async
-  - name: test-standard-v4.2-python3.12-sync-noauth-ssl-replica-set
+  - name: test-standard-v4.0-python3.11-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-4.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-v4.2-python3.12-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
           AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
+          SSL: nossl
+          TOPOLOGY: standalone
           VERSION: "4.2"
       - func: run tests
         vars:
           AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
+          SSL: nossl
+          TOPOLOGY: standalone
           VERSION: "4.2"
           PYTHON_VERSION: "3.12"
-          TEST_NAME: default_sync
+          TEST_NAME: default_async
     tags:
       - standard
       - server-4.2
       - python-3.12
+      - standalone-noauth-nossl
+      - async
+  - name: test-standard-v4.2-python3.13-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-4.2
+      - python-3.13
       - replica_set-noauth-ssl
       - sync
-  - name: test-standard-v4.4-python3.12-async-auth-ssl-sharded-cluster
+  - name: test-standard-v4.2-python3.9-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-4.2
+      - python-3.9
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-v4.4-python3.10-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-4.4
+      - python-3.10
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-v4.4-python3.11-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-4.4
+      - python-3.11
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-v4.4-python3.12-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8043,14 +7612,14 @@ tasks:
           TOPOLOGY: sharded_cluster
           VERSION: "4.4"
           PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
       - standard
       - server-4.4
       - python-3.12
       - sharded_cluster-auth-ssl
-      - async
-  - name: test-standard-v5.0-python3.13-sync-noauth-nossl-standalone
+      - sync
+  - name: test-standard-v5.0-python3.13-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8065,14 +7634,80 @@ tasks:
           TOPOLOGY: standalone
           VERSION: "5.0"
           PYTHON_VERSION: "3.13"
-          TEST_NAME: default_sync
+          TEST_NAME: default_async
     tags:
       - standard
       - server-5.0
       - python-3.13
       - standalone-noauth-nossl
+      - async
+  - name: test-standard-v5.0-python3.9-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-5.0
+      - python-3.9
+      - replica_set-noauth-ssl
       - sync
-  - name: test-standard-v6.0-python3.13-async-noauth-ssl-replica-set
+  - name: test-standard-v5.0-python3.10-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-5.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-v6.0-python3.11-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-6.0
+      - python-3.11
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-v6.0-python3.12-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8086,15 +7721,81 @@ tasks:
           SSL: ssl
           TOPOLOGY: replica_set
           VERSION: "6.0"
-          PYTHON_VERSION: "3.13"
+          PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
     tags:
       - standard
       - server-6.0
-      - python-3.13
+      - python-3.12
       - replica_set-noauth-ssl
       - async
-  - name: test-standard-v7.0-python3.13-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v6.0-python3.13-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-6.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-v7.0-python3.9-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-7.0
+      - python-3.9
+      - standalone-noauth-nossl
+      - async
+  - name: test-standard-v7.0-python3.10-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-7.0
+      - python-3.10
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-standard-v7.0-python3.11-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8108,15 +7809,351 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: "7.0"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-7.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-v8.0-python3.12-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-8.0
+      - python-3.12
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-v8.0-python3.13-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-8.0
+      - python-3.13
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-v8.0-python3.9-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-8.0
+      - python-3.9
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-rapid-python3.10-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-rapid
+      - python-3.10
+      - standalone-noauth-nossl
+      - async
+  - name: test-standard-rapid-python3.11-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-rapid
+      - python-3.11
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-standard-rapid-python3.12-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-rapid
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-latest-python3.13-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
     tags:
       - standard
-      - server-7.0
+      - server-latest
       - python-3.13
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-latest-python3.9-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-latest
+      - python-3.9
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-latest-python3.10-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-latest
+      - python-3.10
       - sharded_cluster-auth-ssl
       - sync
-  - name: test-standard-v8.0-pypy3.10-async-noauth-nossl-standalone
+  - name: test-standard-v4.0-pypy3.10-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-4.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - sync
+      - pypy
+  - name: test-standard-v4.2-pypy3.10-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-4.2
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - async
+      - pypy
+  - name: test-standard-v4.4-pypy3.10-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-4.4
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - sync
+      - pypy
+  - name: test-standard-v5.0-pypy3.10-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-5.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - async
+      - pypy
+  - name: test-standard-v6.0-pypy3.10-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_sync
+    tags:
+      - standard
+      - server-6.0
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - sync
+      - pypy
+  - name: test-standard-v7.0-pypy3.10-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
+    tags:
+      - standard
+      - server-7.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - async
+      - pypy
+  - name: test-standard-v8.0-pypy3.10-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8131,15 +8168,15 @@ tasks:
           TOPOLOGY: standalone
           VERSION: "8.0"
           PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
       - standard
       - server-8.0
       - python-pypy3.10
       - standalone-noauth-nossl
-      - async
+      - sync
       - pypy
-  - name: test-standard-rapid-pypy3.10-sync-noauth-ssl-replica-set
+  - name: test-standard-rapid-pypy3.10-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8154,15 +8191,15 @@ tasks:
           TOPOLOGY: replica_set
           VERSION: rapid
           PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_sync
+          TEST_NAME: default_async
     tags:
       - standard
       - server-rapid
       - python-pypy3.10
       - replica_set-noauth-ssl
-      - sync
+      - async
       - pypy
-  - name: test-standard-latest-pypy3.10-async-auth-ssl-sharded-cluster
+  - name: test-standard-latest-pypy3.10-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8177,11 +8214,742 @@ tasks:
           TOPOLOGY: sharded_cluster
           VERSION: latest
           PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
       - standard
       - server-latest
       - python-pypy3.10
       - sharded_cluster-auth-ssl
-      - async
+      - sync
+      - pypy
+
+  # Test named tests
+  - name: test-named-v4.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-named-v4.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-named-v4.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.2-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-named-v4.2-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-v4.2-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-4.2
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.4-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-v4.4-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-v4.4-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-4.4
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-v5.0-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-v5.0-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.9
+      - replica_set-noauth-ssl
+  - name: test-named-v5.0-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-5.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+  - name: test-named-v6.0-python3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.11
+      - standalone-noauth-nossl
+  - name: test-named-v6.0-python3.12-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.12
+      - replica_set-noauth-ssl
+  - name: test-named-v6.0-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-6.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+  - name: test-named-v7.0-python3.9-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.9
+      - standalone-noauth-nossl
+  - name: test-named-v7.0-python3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.10
+      - replica_set-noauth-ssl
+  - name: test-named-v7.0-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-7.0
+      - python-3.11
+      - sharded_cluster-auth-ssl
+  - name: test-named-v8.0-python3.12-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.12
+      - standalone-noauth-nossl
+  - name: test-named-v8.0-python3.13-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.13
+      - replica_set-noauth-ssl
+  - name: test-named-v8.0-python3.9-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-8.0
+      - python-3.9
+      - sharded_cluster-auth-ssl
+  - name: test-named-rapid-python3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.10
+      - standalone-noauth-nossl
+  - name: test-named-rapid-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.11
+      - replica_set-noauth-ssl
+  - name: test-named-rapid-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-named
+      - server-rapid
+      - python-3.12
+      - sharded_cluster-auth-ssl
+  - name: test-named-latest-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.13
+      - standalone-noauth-nossl
+  - name: test-named-latest-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.9
+      - replica_set-noauth-ssl
+  - name: test-named-latest-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-named
+      - server-latest
+      - python-3.10
+      - sharded_cluster-auth-ssl
+  - name: test-named-v4.0-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-v4.2-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.2
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-v4.4-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-4.4
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+  - name: test-named-v5.0-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "5.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-5.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-v6.0-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-6.0
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-v7.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-7.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - pypy
+  - name: test-named-v8.0-pypy3.10-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "8.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-8.0
+      - python-pypy3.10
+      - standalone-noauth-nossl
+      - pypy
+  - name: test-named-rapid-pypy3.10-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-rapid
+      - python-pypy3.10
+      - replica_set-noauth-ssl
+      - pypy
+  - name: test-named-latest-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-named
+      - server-latest
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
       - pypy

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -243,233 +243,6 @@ tasks:
           TEST_NAME: kms
           SUB_TEST_NAME: azure-fail
 
-  # Load balancer tests
-  - name: test-load-balancer-auth-ssl-v6.0
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, auth, ssl]
-  - name: test-load-balancer-auth-ssl-v7.0
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, auth, ssl]
-  - name: test-load-balancer-auth-ssl-v8.0
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, auth, ssl]
-  - name: test-load-balancer-auth-ssl-rapid
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, auth, ssl]
-  - name: test-load-balancer-auth-ssl-latest
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, auth, ssl]
-  - name: test-load-balancer-noauth-ssl-v6.0
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, ssl]
-  - name: test-load-balancer-noauth-ssl-v7.0
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, ssl]
-  - name: test-load-balancer-noauth-ssl-v8.0
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, ssl]
-  - name: test-load-balancer-noauth-ssl-rapid
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, ssl]
-  - name: test-load-balancer-noauth-ssl-latest
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, ssl]
-  - name: test-load-balancer-noauth-nossl-v6.0
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, nossl]
-  - name: test-load-balancer-noauth-nossl-v7.0
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, nossl]
-  - name: test-load-balancer-noauth-nossl-v8.0
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, nossl]
-  - name: test-load-balancer-noauth-nossl-rapid
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, nossl]
-  - name: test-load-balancer-noauth-nossl-latest
-    commands:
-      - func: run server
-        vars:
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TEST_NAME: load_balancer
-    tags: [load-balancer, noauth, nossl]
-
   # Mod wsgi tests
   - name: mod-wsgi-replica-set-python3.9
     commands:
@@ -7648,7 +7421,7 @@ tasks:
     tags: [serverless]
 
   # Standard tests
-  - name: test-v4.0-python3.9-sync-noauth-nossl-standalone
+  - name: test-standard-v4.0-python3.9-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -7670,7 +7443,7 @@ tasks:
       - python-3.9
       - standalone-noauth-nossl
       - sync
-  - name: test-v4.0-python3.10-async-noauth-ssl-replica-set
+  - name: test-standard-v4.0-python3.10-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -7692,7 +7465,7 @@ tasks:
       - python-3.10
       - replica_set-noauth-ssl
       - async
-  - name: test-v4.0-python3.11-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v4.0-python3.11-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7714,7 +7487,7 @@ tasks:
       - python-3.11
       - sharded_cluster-auth-ssl
       - sync
-  - name: test-v4.2-python3.12-async-noauth-nossl-standalone
+  - name: test-standard-v4.2-python3.12-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -7736,7 +7509,7 @@ tasks:
       - python-3.12
       - standalone-noauth-nossl
       - async
-  - name: test-v4.2-python3.13-sync-noauth-ssl-replica-set
+  - name: test-standard-v4.2-python3.13-sync-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -7758,7 +7531,7 @@ tasks:
       - python-3.13
       - replica_set-noauth-ssl
       - sync
-  - name: test-v4.2-pypy3.10-async-auth-ssl-sharded-cluster
+  - name: test-standard-v4.2-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7781,7 +7554,7 @@ tasks:
       - sharded_cluster-auth-ssl
       - async
       - pypy
-  - name: test-v4.4-python3.9-sync-noauth-nossl-standalone
+  - name: test-standard-v4.4-python3.9-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -7803,7 +7576,7 @@ tasks:
       - python-3.9
       - standalone-noauth-nossl
       - sync
-  - name: test-v4.4-python3.10-async-noauth-ssl-replica-set
+  - name: test-standard-v4.4-python3.10-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -7825,7 +7598,7 @@ tasks:
       - python-3.10
       - replica_set-noauth-ssl
       - async
-  - name: test-v4.4-python3.11-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v4.4-python3.11-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7847,7 +7620,7 @@ tasks:
       - python-3.11
       - sharded_cluster-auth-ssl
       - sync
-  - name: test-v5.0-python3.12-async-noauth-nossl-standalone
+  - name: test-standard-v5.0-python3.12-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -7869,7 +7642,7 @@ tasks:
       - python-3.12
       - standalone-noauth-nossl
       - async
-  - name: test-v5.0-python3.13-sync-noauth-ssl-replica-set
+  - name: test-standard-v5.0-python3.13-sync-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -7891,7 +7664,7 @@ tasks:
       - python-3.13
       - replica_set-noauth-ssl
       - sync
-  - name: test-v5.0-pypy3.10-async-auth-ssl-sharded-cluster
+  - name: test-standard-v5.0-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7914,7 +7687,7 @@ tasks:
       - sharded_cluster-auth-ssl
       - async
       - pypy
-  - name: test-v6.0-python3.9-sync-noauth-nossl-standalone
+  - name: test-standard-v6.0-python3.9-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -7936,7 +7709,7 @@ tasks:
       - python-3.9
       - standalone-noauth-nossl
       - sync
-  - name: test-v6.0-python3.10-async-noauth-ssl-replica-set
+  - name: test-standard-v6.0-python3.10-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -7958,7 +7731,7 @@ tasks:
       - python-3.10
       - replica_set-noauth-ssl
       - async
-  - name: test-v6.0-python3.11-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v6.0-python3.11-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7980,7 +7753,7 @@ tasks:
       - python-3.11
       - sharded_cluster-auth-ssl
       - sync
-  - name: test-v7.0-python3.12-async-noauth-nossl-standalone
+  - name: test-standard-v7.0-python3.12-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8002,7 +7775,7 @@ tasks:
       - python-3.12
       - standalone-noauth-nossl
       - async
-  - name: test-v7.0-python3.13-sync-noauth-ssl-replica-set
+  - name: test-standard-v7.0-python3.13-sync-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8024,7 +7797,7 @@ tasks:
       - python-3.13
       - replica_set-noauth-ssl
       - sync
-  - name: test-v7.0-pypy3.10-async-auth-ssl-sharded-cluster
+  - name: test-standard-v7.0-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8047,7 +7820,7 @@ tasks:
       - sharded_cluster-auth-ssl
       - async
       - pypy
-  - name: test-v8.0-python3.9-sync-noauth-nossl-standalone
+  - name: test-standard-v8.0-python3.9-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8069,7 +7842,7 @@ tasks:
       - python-3.9
       - standalone-noauth-nossl
       - sync
-  - name: test-v8.0-python3.10-async-noauth-ssl-replica-set
+  - name: test-standard-v8.0-python3.10-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8091,7 +7864,7 @@ tasks:
       - python-3.10
       - replica_set-noauth-ssl
       - async
-  - name: test-v8.0-python3.11-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v8.0-python3.11-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8113,7 +7886,7 @@ tasks:
       - python-3.11
       - sharded_cluster-auth-ssl
       - sync
-  - name: test-rapid-python3.12-async-noauth-nossl-standalone
+  - name: test-standard-rapid-python3.12-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8135,7 +7908,7 @@ tasks:
       - python-3.12
       - standalone-noauth-nossl
       - async
-  - name: test-rapid-python3.13-sync-noauth-ssl-replica-set
+  - name: test-standard-rapid-python3.13-sync-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8157,7 +7930,7 @@ tasks:
       - python-3.13
       - replica_set-noauth-ssl
       - sync
-  - name: test-rapid-pypy3.10-async-auth-ssl-sharded-cluster
+  - name: test-standard-rapid-pypy3.10-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8180,7 +7953,7 @@ tasks:
       - sharded_cluster-auth-ssl
       - async
       - pypy
-  - name: test-latest-python3.9-sync-noauth-nossl-standalone
+  - name: test-standard-latest-python3.9-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8202,7 +7975,7 @@ tasks:
       - python-3.9
       - standalone-noauth-nossl
       - sync
-  - name: test-latest-python3.10-async-noauth-ssl-replica-set
+  - name: test-standard-latest-python3.10-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8224,7 +7997,7 @@ tasks:
       - python-3.10
       - replica_set-noauth-ssl
       - async
-  - name: test-latest-python3.11-sync-auth-ssl-sharded-cluster
+  - name: test-standard-latest-python3.11-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8247,8 +8020,8 @@ tasks:
       - sharded_cluster-auth-ssl
       - sync
 
-  # Test name tests
-  - name: test-v4.0-python3.9-noauth-nossl-standalone
+  # Test named tests
+  - name: test-named-v4.0-python3.9-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8264,11 +8037,11 @@ tasks:
           VERSION: "4.0"
           PYTHON_VERSION: "3.9"
     tags:
-      - test-name
+      - test-named
       - server-4.0
       - python-3.9
       - standalone-noauth-nossl
-  - name: test-v4.0-python3.10-noauth-ssl-replica-set
+  - name: test-named-v4.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8284,11 +8057,11 @@ tasks:
           VERSION: "4.0"
           PYTHON_VERSION: "3.10"
     tags:
-      - test-name
+      - test-named
       - server-4.0
       - python-3.10
       - replica_set-noauth-ssl
-  - name: test-v4.0-python3.11-auth-ssl-sharded-cluster
+  - name: test-named-v4.0-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8304,11 +8077,11 @@ tasks:
           VERSION: "4.0"
           PYTHON_VERSION: "3.11"
     tags:
-      - test-name
+      - test-named
       - server-4.0
       - python-3.11
       - sharded_cluster-auth-ssl
-  - name: test-v4.2-python3.12-noauth-nossl-standalone
+  - name: test-named-v4.2-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8324,11 +8097,11 @@ tasks:
           VERSION: "4.2"
           PYTHON_VERSION: "3.12"
     tags:
-      - test-name
+      - test-named
       - server-4.2
       - python-3.12
       - standalone-noauth-nossl
-  - name: test-v4.2-python3.13-noauth-ssl-replica-set
+  - name: test-named-v4.2-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8344,11 +8117,11 @@ tasks:
           VERSION: "4.2"
           PYTHON_VERSION: "3.13"
     tags:
-      - test-name
+      - test-named
       - server-4.2
       - python-3.13
       - replica_set-noauth-ssl
-  - name: test-v4.2-pypy3.10-auth-ssl-sharded-cluster
+  - name: test-named-v4.2-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8364,12 +8137,12 @@ tasks:
           VERSION: "4.2"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-name
+      - test-named
       - server-4.2
       - python-pypy3.10
       - sharded_cluster-auth-ssl
       - pypy
-  - name: test-v4.4-python3.9-noauth-nossl-standalone
+  - name: test-named-v4.4-python3.9-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8385,11 +8158,11 @@ tasks:
           VERSION: "4.4"
           PYTHON_VERSION: "3.9"
     tags:
-      - test-name
+      - test-named
       - server-4.4
       - python-3.9
       - standalone-noauth-nossl
-  - name: test-v4.4-python3.10-noauth-ssl-replica-set
+  - name: test-named-v4.4-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8405,11 +8178,11 @@ tasks:
           VERSION: "4.4"
           PYTHON_VERSION: "3.10"
     tags:
-      - test-name
+      - test-named
       - server-4.4
       - python-3.10
       - replica_set-noauth-ssl
-  - name: test-v4.4-python3.11-auth-ssl-sharded-cluster
+  - name: test-named-v4.4-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8425,11 +8198,11 @@ tasks:
           VERSION: "4.4"
           PYTHON_VERSION: "3.11"
     tags:
-      - test-name
+      - test-named
       - server-4.4
       - python-3.11
       - sharded_cluster-auth-ssl
-  - name: test-v5.0-python3.12-noauth-nossl-standalone
+  - name: test-named-v5.0-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8445,11 +8218,11 @@ tasks:
           VERSION: "5.0"
           PYTHON_VERSION: "3.12"
     tags:
-      - test-name
+      - test-named
       - server-5.0
       - python-3.12
       - standalone-noauth-nossl
-  - name: test-v5.0-python3.13-noauth-ssl-replica-set
+  - name: test-named-v5.0-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8465,11 +8238,11 @@ tasks:
           VERSION: "5.0"
           PYTHON_VERSION: "3.13"
     tags:
-      - test-name
+      - test-named
       - server-5.0
       - python-3.13
       - replica_set-noauth-ssl
-  - name: test-v5.0-pypy3.10-auth-ssl-sharded-cluster
+  - name: test-named-v5.0-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8485,12 +8258,12 @@ tasks:
           VERSION: "5.0"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-name
+      - test-named
       - server-5.0
       - python-pypy3.10
       - sharded_cluster-auth-ssl
       - pypy
-  - name: test-v6.0-python3.9-noauth-nossl-standalone
+  - name: test-named-v6.0-python3.9-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8506,11 +8279,11 @@ tasks:
           VERSION: "6.0"
           PYTHON_VERSION: "3.9"
     tags:
-      - test-name
+      - test-named
       - server-6.0
       - python-3.9
       - standalone-noauth-nossl
-  - name: test-v6.0-python3.10-noauth-ssl-replica-set
+  - name: test-named-v6.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8526,11 +8299,11 @@ tasks:
           VERSION: "6.0"
           PYTHON_VERSION: "3.10"
     tags:
-      - test-name
+      - test-named
       - server-6.0
       - python-3.10
       - replica_set-noauth-ssl
-  - name: test-v6.0-python3.11-auth-ssl-sharded-cluster
+  - name: test-named-v6.0-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8546,11 +8319,11 @@ tasks:
           VERSION: "6.0"
           PYTHON_VERSION: "3.11"
     tags:
-      - test-name
+      - test-named
       - server-6.0
       - python-3.11
       - sharded_cluster-auth-ssl
-  - name: test-v7.0-python3.12-noauth-nossl-standalone
+  - name: test-named-v7.0-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8566,11 +8339,11 @@ tasks:
           VERSION: "7.0"
           PYTHON_VERSION: "3.12"
     tags:
-      - test-name
+      - test-named
       - server-7.0
       - python-3.12
       - standalone-noauth-nossl
-  - name: test-v7.0-python3.13-noauth-ssl-replica-set
+  - name: test-named-v7.0-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8586,11 +8359,11 @@ tasks:
           VERSION: "7.0"
           PYTHON_VERSION: "3.13"
     tags:
-      - test-name
+      - test-named
       - server-7.0
       - python-3.13
       - replica_set-noauth-ssl
-  - name: test-v7.0-pypy3.10-auth-ssl-sharded-cluster
+  - name: test-named-v7.0-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8606,12 +8379,12 @@ tasks:
           VERSION: "7.0"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-name
+      - test-named
       - server-7.0
       - python-pypy3.10
       - sharded_cluster-auth-ssl
       - pypy
-  - name: test-v8.0-python3.9-noauth-nossl-standalone
+  - name: test-named-v8.0-python3.9-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8627,11 +8400,11 @@ tasks:
           VERSION: "8.0"
           PYTHON_VERSION: "3.9"
     tags:
-      - test-name
+      - test-named
       - server-8.0
       - python-3.9
       - standalone-noauth-nossl
-  - name: test-v8.0-python3.10-noauth-ssl-replica-set
+  - name: test-named-v8.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8647,11 +8420,11 @@ tasks:
           VERSION: "8.0"
           PYTHON_VERSION: "3.10"
     tags:
-      - test-name
+      - test-named
       - server-8.0
       - python-3.10
       - replica_set-noauth-ssl
-  - name: test-v8.0-python3.11-auth-ssl-sharded-cluster
+  - name: test-named-v8.0-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8667,11 +8440,11 @@ tasks:
           VERSION: "8.0"
           PYTHON_VERSION: "3.11"
     tags:
-      - test-name
+      - test-named
       - server-8.0
       - python-3.11
       - sharded_cluster-auth-ssl
-  - name: test-rapid-python3.12-noauth-nossl-standalone
+  - name: test-named-rapid-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8687,11 +8460,11 @@ tasks:
           VERSION: rapid
           PYTHON_VERSION: "3.12"
     tags:
-      - test-name
+      - test-named
       - server-rapid
       - python-3.12
       - standalone-noauth-nossl
-  - name: test-rapid-python3.13-noauth-ssl-replica-set
+  - name: test-named-rapid-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8707,11 +8480,11 @@ tasks:
           VERSION: rapid
           PYTHON_VERSION: "3.13"
     tags:
-      - test-name
+      - test-named
       - server-rapid
       - python-3.13
       - replica_set-noauth-ssl
-  - name: test-rapid-pypy3.10-auth-ssl-sharded-cluster
+  - name: test-named-rapid-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8727,12 +8500,12 @@ tasks:
           VERSION: rapid
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-name
+      - test-named
       - server-rapid
       - python-pypy3.10
       - sharded_cluster-auth-ssl
       - pypy
-  - name: test-latest-python3.9-noauth-nossl-standalone
+  - name: test-named-latest-python3.9-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8748,11 +8521,11 @@ tasks:
           VERSION: latest
           PYTHON_VERSION: "3.9"
     tags:
-      - test-name
+      - test-named
       - server-latest
       - python-3.9
       - standalone-noauth-nossl
-  - name: test-latest-python3.10-noauth-ssl-replica-set
+  - name: test-named-latest-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8768,11 +8541,11 @@ tasks:
           VERSION: latest
           PYTHON_VERSION: "3.10"
     tags:
-      - test-name
+      - test-named
       - server-latest
       - python-3.10
       - replica_set-noauth-ssl
-  - name: test-latest-python3.11-auth-ssl-sharded-cluster
+  - name: test-named-latest-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8788,7 +8561,7 @@ tasks:
           VERSION: latest
           PYTHON_VERSION: "3.11"
     tags:
-      - test-name
+      - test-named
       - server-latest
       - python-3.11
       - sharded_cluster-auth-ssl

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -7170,106 +7170,6 @@ tasks:
       - sync_async
 
   # Server version tests
-  - name: test-server-version-python3.9-sync-auth-ssl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags: [server-version, python-3.9, sharded_cluster-auth-ssl]
-  - name: test-server-version-python3.10-async-auth-ssl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags: [server-version, python-3.10, sharded_cluster-auth-ssl]
-  - name: test-server-version-python3.11-sync-auth-ssl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags: [server-version, python-3.11, sharded_cluster-auth-ssl]
-  - name: test-server-version-python3.12-async-auth-ssl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags: [server-version, python-3.12, sharded_cluster-auth-ssl]
-  - name: test-server-version-python3.13-sync-auth-ssl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags: [server-version, python-3.13, sharded_cluster-auth-ssl]
-  - name: test-server-version-pypy3.10-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_async
-    tags: [server-version, python-pypy3.10, sharded_cluster-auth-ssl]
   - name: test-server-version-python3.9-sync-auth-ssl-standalone-cov
     commands:
       - func: run server
@@ -7286,59 +7186,157 @@ tasks:
           COVERAGE: "1"
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
-    tags: [server-version, python-3.9, standalone-auth-ssl]
-  - name: test-server-version-python3.10-async-auth-nossl-standalone-cov
+    tags:
+      - server-version
+      - python-3.9
+      - standalone-auth-ssl
+      - sync
+  - name: test-server-version-python3.10-async-auth-ssl-standalone-cov
     commands:
       - func: run server
         vars:
           AUTH: auth
-          SSL: nossl
+          SSL: ssl
           TOPOLOGY: standalone
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: auth
-          SSL: nossl
+          SSL: ssl
           TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
-    tags: [server-version, python-3.10, standalone-auth-nossl]
-  - name: test-server-version-python3.11-sync-noauth-ssl-standalone-cov
+    tags:
+      - server-version
+      - python-3.10
+      - standalone-auth-ssl
+      - async
+  - name: test-server-version-python3.11-sync-auth-nossl-standalone-cov
     commands:
       - func: run server
         vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: standalone
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: standalone
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags: [server-version, python-3.11, standalone-noauth-ssl]
-  - name: test-server-version-python3.12-async-noauth-nossl-standalone-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
+          AUTH: auth
           SSL: nossl
           TOPOLOGY: standalone
           COVERAGE: "1"
       - func: run tests
         vars:
-          AUTH: noauth
+          AUTH: auth
+          SSL: nossl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.11
+      - standalone-auth-nossl
+      - sync
+  - name: test-server-version-python3.12-async-auth-nossl-standalone-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: nossl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
           SSL: nossl
           TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.12"
           TEST_NAME: default_async
-    tags: [server-version, python-3.12, standalone-noauth-nossl]
-  - name: test-server-version-python3.13-sync-auth-ssl-replica-set-cov
+    tags:
+      - server-version
+      - python-3.12
+      - standalone-auth-nossl
+      - async
+  - name: test-server-version-python3.13-sync-noauth-ssl-standalone-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.13
+      - standalone-noauth-ssl
+      - sync
+  - name: test-server-version-pypy3.10-async-noauth-ssl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: standalone
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: standalone
+          PYTHON_VERSION: pypy3.10
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-pypy3.10
+      - standalone-noauth-ssl
+      - async
+  - name: test-server-version-python3.9-sync-noauth-nossl-standalone-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.9
+      - standalone-noauth-nossl
+      - sync
+  - name: test-server-version-python3.10-async-noauth-nossl-standalone-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.10
+      - standalone-noauth-nossl
+      - async
+  - name: test-server-version-python3.11-sync-auth-ssl-replica-set-cov
     commands:
       - func: run server
         vars:
@@ -7352,9 +7350,55 @@ tasks:
           SSL: ssl
           TOPOLOGY: replica_set
           COVERAGE: "1"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.11
+      - replica_set-auth-ssl
+      - sync
+  - name: test-server-version-python3.12-async-auth-ssl-replica-set-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.12
+      - replica_set-auth-ssl
+      - async
+  - name: test-server-version-python3.13-sync-auth-nossl-replica-set-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: nossl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: nossl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
           PYTHON_VERSION: "3.13"
           TEST_NAME: default_sync
-    tags: [server-version, python-3.13, replica_set-auth-ssl]
+    tags:
+      - server-version
+      - python-3.13
+      - replica_set-auth-nossl
+      - sync
   - name: test-server-version-pypy3.10-async-auth-nossl-replica-set
     commands:
       - func: run server
@@ -7369,7 +7413,11 @@ tasks:
           TOPOLOGY: replica_set
           PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
-    tags: [server-version, python-pypy3.10, replica_set-auth-nossl]
+    tags:
+      - server-version
+      - python-pypy3.10
+      - replica_set-auth-nossl
+      - async
   - name: test-server-version-python3.9-sync-noauth-ssl-replica-set-cov
     commands:
       - func: run server
@@ -7386,59 +7434,220 @@ tasks:
           COVERAGE: "1"
           PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
-    tags: [server-version, python-3.9, replica_set-noauth-ssl]
-  - name: test-server-version-python3.10-async-noauth-nossl-replica-set-cov
+    tags:
+      - server-version
+      - python-3.9
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-server-version-python3.10-async-noauth-ssl-replica-set-cov
     commands:
       - func: run server
         vars:
           AUTH: noauth
-          SSL: nossl
+          SSL: ssl
           TOPOLOGY: replica_set
           COVERAGE: "1"
       - func: run tests
         vars:
           AUTH: noauth
-          SSL: nossl
+          SSL: ssl
           TOPOLOGY: replica_set
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
-    tags: [server-version, python-3.10, replica_set-noauth-nossl]
-  - name: test-server-version-python3.12-sync-auth-nossl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: nossl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: nossl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.12"
-          TEST_NAME: default_sync
-    tags: [server-version, python-3.12, sharded_cluster-auth-nossl]
-  - name: test-server-version-python3.13-async-noauth-ssl-sharded-cluster-cov
+    tags:
+      - server-version
+      - python-3.10
+      - replica_set-noauth-ssl
+      - async
+  - name: test-server-version-python3.11-sync-noauth-nossl-replica-set-cov
     commands:
       - func: run server
         vars:
           AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.11
+      - replica_set-noauth-nossl
+      - sync
+  - name: test-server-version-python3.12-async-noauth-nossl-replica-set-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.12
+      - replica_set-noauth-nossl
+      - async
+  - name: test-server-version-python3.13-sync-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
       - func: run tests
         vars:
-          AUTH: noauth
+          AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.13
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-server-version-pypy3.10-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          PYTHON_VERSION: pypy3.10
           TEST_NAME: default_async
-    tags: [server-version, python-3.13, sharded_cluster-noauth-ssl]
-  - name: test-server-version-pypy3.10-sync-noauth-nossl-sharded-cluster
+    tags:
+      - server-version
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-server-version-python3.9-sync-auth-nossl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: nossl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: nossl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.9
+      - sharded_cluster-auth-nossl
+      - sync
+  - name: test-server-version-python3.10-async-auth-nossl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: nossl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: nossl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.10
+      - sharded_cluster-auth-nossl
+      - async
+  - name: test-server-version-python3.11-sync-noauth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.11
+      - sharded_cluster-noauth-ssl
+      - sync
+  - name: test-server-version-python3.12-async-noauth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.12
+      - sharded_cluster-noauth-ssl
+      - async
+  - name: test-server-version-python3.13-sync-noauth-nossl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.13"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.13
+      - sharded_cluster-noauth-nossl
+      - sync
+  - name: test-server-version-pypy3.10-async-noauth-nossl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -7451,8 +7660,12 @@ tasks:
           SSL: nossl
           TOPOLOGY: sharded_cluster
           PYTHON_VERSION: pypy3.10
-          TEST_NAME: default_sync
-    tags: [server-version, python-pypy3.10, sharded_cluster-noauth-nossl]
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-pypy3.10
+      - sharded_cluster-noauth-nossl
+      - async
 
   # Serverless tests
   - name: test-serverless

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -8267,8 +8267,8 @@ tasks:
       - sync
       - pypy
 
-  # Test named tests
-  - name: test-named-v4.0-python3.9-noauth-nossl-standalone
+  # Test non standard tests
+  - name: test-non-standard-v4.0-python3.9-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8284,11 +8284,11 @@ tasks:
           VERSION: "4.0"
           PYTHON_VERSION: "3.9"
     tags:
-      - test-named
+      - test-non-standard
       - server-4.0
       - python-3.9
       - standalone-noauth-nossl
-  - name: test-named-v4.0-python3.10-noauth-ssl-replica-set
+  - name: test-non-standard-v4.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8304,11 +8304,11 @@ tasks:
           VERSION: "4.0"
           PYTHON_VERSION: "3.10"
     tags:
-      - test-named
+      - test-non-standard
       - server-4.0
       - python-3.10
       - replica_set-noauth-ssl
-  - name: test-named-v4.0-python3.11-auth-ssl-sharded-cluster
+  - name: test-non-standard-v4.0-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8324,11 +8324,11 @@ tasks:
           VERSION: "4.0"
           PYTHON_VERSION: "3.11"
     tags:
-      - test-named
+      - test-non-standard
       - server-4.0
       - python-3.11
       - sharded_cluster-auth-ssl
-  - name: test-named-v4.2-python3.12-noauth-nossl-standalone
+  - name: test-non-standard-v4.2-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8344,11 +8344,11 @@ tasks:
           VERSION: "4.2"
           PYTHON_VERSION: "3.12"
     tags:
-      - test-named
+      - test-non-standard
       - server-4.2
       - python-3.12
       - standalone-noauth-nossl
-  - name: test-named-v4.2-python3.13-noauth-ssl-replica-set
+  - name: test-non-standard-v4.2-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8364,11 +8364,11 @@ tasks:
           VERSION: "4.2"
           PYTHON_VERSION: "3.13"
     tags:
-      - test-named
+      - test-non-standard
       - server-4.2
       - python-3.13
       - replica_set-noauth-ssl
-  - name: test-named-v4.2-python3.9-auth-ssl-sharded-cluster
+  - name: test-non-standard-v4.2-python3.9-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8384,11 +8384,11 @@ tasks:
           VERSION: "4.2"
           PYTHON_VERSION: "3.9"
     tags:
-      - test-named
+      - test-non-standard
       - server-4.2
       - python-3.9
       - sharded_cluster-auth-ssl
-  - name: test-named-v4.4-python3.10-noauth-nossl-standalone
+  - name: test-non-standard-v4.4-python3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8404,11 +8404,11 @@ tasks:
           VERSION: "4.4"
           PYTHON_VERSION: "3.10"
     tags:
-      - test-named
+      - test-non-standard
       - server-4.4
       - python-3.10
       - standalone-noauth-nossl
-  - name: test-named-v4.4-python3.11-noauth-ssl-replica-set
+  - name: test-non-standard-v4.4-python3.11-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8424,11 +8424,11 @@ tasks:
           VERSION: "4.4"
           PYTHON_VERSION: "3.11"
     tags:
-      - test-named
+      - test-non-standard
       - server-4.4
       - python-3.11
       - replica_set-noauth-ssl
-  - name: test-named-v4.4-python3.12-auth-ssl-sharded-cluster
+  - name: test-non-standard-v4.4-python3.12-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8444,11 +8444,11 @@ tasks:
           VERSION: "4.4"
           PYTHON_VERSION: "3.12"
     tags:
-      - test-named
+      - test-non-standard
       - server-4.4
       - python-3.12
       - sharded_cluster-auth-ssl
-  - name: test-named-v5.0-python3.13-noauth-nossl-standalone
+  - name: test-non-standard-v5.0-python3.13-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8464,11 +8464,11 @@ tasks:
           VERSION: "5.0"
           PYTHON_VERSION: "3.13"
     tags:
-      - test-named
+      - test-non-standard
       - server-5.0
       - python-3.13
       - standalone-noauth-nossl
-  - name: test-named-v5.0-python3.9-noauth-ssl-replica-set
+  - name: test-non-standard-v5.0-python3.9-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8484,11 +8484,11 @@ tasks:
           VERSION: "5.0"
           PYTHON_VERSION: "3.9"
     tags:
-      - test-named
+      - test-non-standard
       - server-5.0
       - python-3.9
       - replica_set-noauth-ssl
-  - name: test-named-v5.0-python3.10-auth-ssl-sharded-cluster
+  - name: test-non-standard-v5.0-python3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8504,11 +8504,11 @@ tasks:
           VERSION: "5.0"
           PYTHON_VERSION: "3.10"
     tags:
-      - test-named
+      - test-non-standard
       - server-5.0
       - python-3.10
       - sharded_cluster-auth-ssl
-  - name: test-named-v6.0-python3.11-noauth-nossl-standalone
+  - name: test-non-standard-v6.0-python3.11-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8524,11 +8524,11 @@ tasks:
           VERSION: "6.0"
           PYTHON_VERSION: "3.11"
     tags:
-      - test-named
+      - test-non-standard
       - server-6.0
       - python-3.11
       - standalone-noauth-nossl
-  - name: test-named-v6.0-python3.12-noauth-ssl-replica-set
+  - name: test-non-standard-v6.0-python3.12-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8544,11 +8544,11 @@ tasks:
           VERSION: "6.0"
           PYTHON_VERSION: "3.12"
     tags:
-      - test-named
+      - test-non-standard
       - server-6.0
       - python-3.12
       - replica_set-noauth-ssl
-  - name: test-named-v6.0-python3.13-auth-ssl-sharded-cluster
+  - name: test-non-standard-v6.0-python3.13-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8564,11 +8564,11 @@ tasks:
           VERSION: "6.0"
           PYTHON_VERSION: "3.13"
     tags:
-      - test-named
+      - test-non-standard
       - server-6.0
       - python-3.13
       - sharded_cluster-auth-ssl
-  - name: test-named-v7.0-python3.9-noauth-nossl-standalone
+  - name: test-non-standard-v7.0-python3.9-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8584,11 +8584,11 @@ tasks:
           VERSION: "7.0"
           PYTHON_VERSION: "3.9"
     tags:
-      - test-named
+      - test-non-standard
       - server-7.0
       - python-3.9
       - standalone-noauth-nossl
-  - name: test-named-v7.0-python3.10-noauth-ssl-replica-set
+  - name: test-non-standard-v7.0-python3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8604,11 +8604,11 @@ tasks:
           VERSION: "7.0"
           PYTHON_VERSION: "3.10"
     tags:
-      - test-named
+      - test-non-standard
       - server-7.0
       - python-3.10
       - replica_set-noauth-ssl
-  - name: test-named-v7.0-python3.11-auth-ssl-sharded-cluster
+  - name: test-non-standard-v7.0-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8624,11 +8624,11 @@ tasks:
           VERSION: "7.0"
           PYTHON_VERSION: "3.11"
     tags:
-      - test-named
+      - test-non-standard
       - server-7.0
       - python-3.11
       - sharded_cluster-auth-ssl
-  - name: test-named-v8.0-python3.12-noauth-nossl-standalone
+  - name: test-non-standard-v8.0-python3.12-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8644,11 +8644,11 @@ tasks:
           VERSION: "8.0"
           PYTHON_VERSION: "3.12"
     tags:
-      - test-named
+      - test-non-standard
       - server-8.0
       - python-3.12
       - standalone-noauth-nossl
-  - name: test-named-v8.0-python3.13-noauth-ssl-replica-set
+  - name: test-non-standard-v8.0-python3.13-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8664,11 +8664,11 @@ tasks:
           VERSION: "8.0"
           PYTHON_VERSION: "3.13"
     tags:
-      - test-named
+      - test-non-standard
       - server-8.0
       - python-3.13
       - replica_set-noauth-ssl
-  - name: test-named-v8.0-python3.9-auth-ssl-sharded-cluster
+  - name: test-non-standard-v8.0-python3.9-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8684,11 +8684,11 @@ tasks:
           VERSION: "8.0"
           PYTHON_VERSION: "3.9"
     tags:
-      - test-named
+      - test-non-standard
       - server-8.0
       - python-3.9
       - sharded_cluster-auth-ssl
-  - name: test-named-rapid-python3.10-noauth-nossl-standalone
+  - name: test-non-standard-rapid-python3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8704,11 +8704,11 @@ tasks:
           VERSION: rapid
           PYTHON_VERSION: "3.10"
     tags:
-      - test-named
+      - test-non-standard
       - server-rapid
       - python-3.10
       - standalone-noauth-nossl
-  - name: test-named-rapid-python3.11-noauth-ssl-replica-set
+  - name: test-non-standard-rapid-python3.11-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8724,11 +8724,11 @@ tasks:
           VERSION: rapid
           PYTHON_VERSION: "3.11"
     tags:
-      - test-named
+      - test-non-standard
       - server-rapid
       - python-3.11
       - replica_set-noauth-ssl
-  - name: test-named-rapid-python3.12-auth-ssl-sharded-cluster
+  - name: test-non-standard-rapid-python3.12-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8744,11 +8744,11 @@ tasks:
           VERSION: rapid
           PYTHON_VERSION: "3.12"
     tags:
-      - test-named
+      - test-non-standard
       - server-rapid
       - python-3.12
       - sharded_cluster-auth-ssl
-  - name: test-named-latest-python3.13-noauth-nossl-standalone
+  - name: test-non-standard-latest-python3.13-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8764,11 +8764,11 @@ tasks:
           VERSION: latest
           PYTHON_VERSION: "3.13"
     tags:
-      - test-named
+      - test-non-standard
       - server-latest
       - python-3.13
       - standalone-noauth-nossl
-  - name: test-named-latest-python3.9-noauth-ssl-replica-set
+  - name: test-non-standard-latest-python3.9-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8784,11 +8784,11 @@ tasks:
           VERSION: latest
           PYTHON_VERSION: "3.9"
     tags:
-      - test-named
+      - test-non-standard
       - server-latest
       - python-3.9
       - replica_set-noauth-ssl
-  - name: test-named-latest-python3.10-auth-ssl-sharded-cluster
+  - name: test-non-standard-latest-python3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8804,11 +8804,11 @@ tasks:
           VERSION: latest
           PYTHON_VERSION: "3.10"
     tags:
-      - test-named
+      - test-non-standard
       - server-latest
       - python-3.10
       - sharded_cluster-auth-ssl
-  - name: test-named-v4.0-pypy3.10-noauth-nossl-standalone
+  - name: test-non-standard-v4.0-pypy3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8824,12 +8824,12 @@ tasks:
           VERSION: "4.0"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-named
+      - test-non-standard
       - server-4.0
       - python-pypy3.10
       - standalone-noauth-nossl
       - pypy
-  - name: test-named-v4.2-pypy3.10-noauth-ssl-replica-set
+  - name: test-non-standard-v4.2-pypy3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8845,12 +8845,12 @@ tasks:
           VERSION: "4.2"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-named
+      - test-non-standard
       - server-4.2
       - python-pypy3.10
       - replica_set-noauth-ssl
       - pypy
-  - name: test-named-v4.4-pypy3.10-auth-ssl-sharded-cluster
+  - name: test-non-standard-v4.4-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8866,12 +8866,12 @@ tasks:
           VERSION: "4.4"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-named
+      - test-non-standard
       - server-4.4
       - python-pypy3.10
       - sharded_cluster-auth-ssl
       - pypy
-  - name: test-named-v5.0-pypy3.10-noauth-nossl-standalone
+  - name: test-non-standard-v5.0-pypy3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8887,12 +8887,12 @@ tasks:
           VERSION: "5.0"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-named
+      - test-non-standard
       - server-5.0
       - python-pypy3.10
       - standalone-noauth-nossl
       - pypy
-  - name: test-named-v6.0-pypy3.10-noauth-ssl-replica-set
+  - name: test-non-standard-v6.0-pypy3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8908,12 +8908,12 @@ tasks:
           VERSION: "6.0"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-named
+      - test-non-standard
       - server-6.0
       - python-pypy3.10
       - replica_set-noauth-ssl
       - pypy
-  - name: test-named-v7.0-pypy3.10-auth-ssl-sharded-cluster
+  - name: test-non-standard-v7.0-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8929,12 +8929,12 @@ tasks:
           VERSION: "7.0"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-named
+      - test-non-standard
       - server-7.0
       - python-pypy3.10
       - sharded_cluster-auth-ssl
       - pypy
-  - name: test-named-v8.0-pypy3.10-noauth-nossl-standalone
+  - name: test-non-standard-v8.0-pypy3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -8950,12 +8950,12 @@ tasks:
           VERSION: "8.0"
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-named
+      - test-non-standard
       - server-8.0
       - python-pypy3.10
       - standalone-noauth-nossl
       - pypy
-  - name: test-named-rapid-pypy3.10-noauth-ssl-replica-set
+  - name: test-non-standard-rapid-pypy3.10-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -8971,12 +8971,12 @@ tasks:
           VERSION: rapid
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-named
+      - test-non-standard
       - server-rapid
       - python-pypy3.10
       - replica_set-noauth-ssl
       - pypy
-  - name: test-named-latest-pypy3.10-auth-ssl-sharded-cluster
+  - name: test-non-standard-latest-pypy3.10-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -8992,7 +8992,7 @@ tasks:
           VERSION: latest
           PYTHON_VERSION: pypy3.10
     tags:
-      - test-named
+      - test-non-standard
       - server-latest
       - python-pypy3.10
       - sharded_cluster-auth-ssl

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -74,7 +74,7 @@ buildvariants:
   # Atlas data lake tests
   - name: atlas-data-lake-ubuntu-22
     tasks:
-      - name: .no-orchestration
+      - name: .test-no-orchestration
     display_name: Atlas Data Lake Ubuntu-22
     run_on:
       - ubuntu2204-small
@@ -120,7 +120,7 @@ buildvariants:
   # Compression tests
   - name: compression-snappy-rhel8
     tasks:
-      - name: .standard
+      - name: .test-standard
     display_name: Compression snappy RHEL8
     run_on:
       - rhel87-small
@@ -128,7 +128,7 @@ buildvariants:
       COMPRESSOR: snappy
   - name: compression-zlib-rhel8
     tasks:
-      - name: .standard
+      - name: .test-standard
     display_name: Compression zlib RHEL8
     run_on:
       - rhel87-small
@@ -136,7 +136,7 @@ buildvariants:
       COMPRESSOR: zlib
   - name: compression-zstd-rhel8
     tasks:
-      - name: .standard !.server-4.0
+      - name: .test-standard !.server-4.0
     display_name: Compression zstd RHEL8
     run_on:
       - rhel87-small
@@ -468,7 +468,7 @@ buildvariants:
   # Green framework tests
   - name: green-eventlet-rhel8
     tasks:
-      - name: .standard .standalone-noauth-nossl .python-3.9
+      - name: .test-standard .standalone-noauth-nossl .python-3.9
     display_name: Green Eventlet RHEL8
     run_on:
       - rhel87-small
@@ -478,7 +478,7 @@ buildvariants:
       SSL: ssl
   - name: green-gevent-rhel8
     tasks:
-      - name: .standard .standalone-noauth-nossl
+      - name: .test-standard .standalone-noauth-nossl
     display_name: Green Gevent RHEL8
     run_on:
       - rhel87-small
@@ -526,7 +526,7 @@ buildvariants:
   # Mockupdb tests
   - name: mockupdb-rhel8
     tasks:
-      - name: .no-orchestration
+      - name: .test-no-orchestration
     display_name: MockupDB RHEL8
     run_on:
       - rhel87-small
@@ -546,7 +546,7 @@ buildvariants:
   # No c ext tests
   - name: no-c-ext-rhel8
     tasks:
-      - name: .standard
+      - name: .test-standard
     display_name: No C Ext RHEL8
     run_on:
       - rhel87-small
@@ -788,12 +788,12 @@ buildvariants:
   # Stable api tests
   - name: stable-api-require-v1-rhel8-auth
     tasks:
-      - name: .standard !.replica_set-noauth-ssl .server-5.0
-      - name: .standard !.replica_set-noauth-ssl .server-6.0
-      - name: .standard !.replica_set-noauth-ssl .server-7.0
-      - name: .standard !.replica_set-noauth-ssl .server-8.0
-      - name: .standard !.replica_set-noauth-ssl .server-rapid
-      - name: .standard !.replica_set-noauth-ssl .server-latest
+      - name: .test-standard !.replica_set-noauth-ssl .server-5.0
+      - name: .test-standard !.replica_set-noauth-ssl .server-6.0
+      - name: .test-standard !.replica_set-noauth-ssl .server-7.0
+      - name: .test-standard !.replica_set-noauth-ssl .server-8.0
+      - name: .test-standard !.replica_set-noauth-ssl .server-rapid
+      - name: .test-standard !.replica_set-noauth-ssl .server-latest
     display_name: Stable API require v1 RHEL8 Auth
     run_on:
       - rhel87-small
@@ -804,12 +804,12 @@ buildvariants:
     tags: [versionedApi_tag]
   - name: stable-api-accept-v2-rhel8-auth
     tasks:
-      - name: .standard .server-5.0 .standalone-noauth-nossl
-      - name: .standard .server-6.0 .standalone-noauth-nossl
-      - name: .standard .server-7.0 .standalone-noauth-nossl
-      - name: .standard .server-8.0 .standalone-noauth-nossl
-      - name: .standard .server-rapid .standalone-noauth-nossl
-      - name: .standard .server-latest .standalone-noauth-nossl
+      - name: .test-standard .server-5.0 .standalone-noauth-nossl
+      - name: .test-standard .server-6.0 .standalone-noauth-nossl
+      - name: .test-standard .server-7.0 .standalone-noauth-nossl
+      - name: .test-standard .server-8.0 .standalone-noauth-nossl
+      - name: .test-standard .server-rapid .standalone-noauth-nossl
+      - name: .test-standard .server-latest .standalone-noauth-nossl
     display_name: Stable API accept v2 RHEL8 Auth
     run_on:
       - rhel87-small
@@ -821,32 +821,32 @@ buildvariants:
   # Standard nonlinux tests
   - name: test-macos
     tasks:
-      - name: .standard !.pypy
+      - name: .test-standard !.pypy
     display_name: "* Test macOS"
     run_on:
       - macos-14
     tags: [standard-non-linux]
   - name: test-macos-arm64
     tasks:
-      - name: .standard !.pypy .server-6.0
-      - name: .standard !.pypy .server-7.0
-      - name: .standard !.pypy .server-8.0
-      - name: .standard !.pypy .server-rapid
-      - name: .standard !.pypy .server-latest
+      - name: .test-standard !.pypy .server-6.0
+      - name: .test-standard !.pypy .server-7.0
+      - name: .test-standard !.pypy .server-8.0
+      - name: .test-standard !.pypy .server-rapid
+      - name: .test-standard !.pypy .server-latest
     display_name: "* Test macOS Arm64"
     run_on:
       - macos-14-arm64
     tags: [standard-non-linux]
   - name: test-win64
     tasks:
-      - name: .standard !.pypy
+      - name: .test-standard !.pypy
     display_name: "* Test Win64"
     run_on:
       - windows-64-vsMulti-small
     tags: [standard-non-linux]
   - name: test-win32
     tasks:
-      - name: .standard !.pypy
+      - name: .test-standard !.pypy
     display_name: "* Test Win32"
     run_on:
       - windows-64-vsMulti-small
@@ -857,7 +857,7 @@ buildvariants:
   # Storage engine tests
   - name: storage-inmemory-rhel8
     tasks:
-      - name: .standard .standalone-noauth-nossl
+      - name: .test-standard .standalone-noauth-nossl
     display_name: Storage InMemory RHEL8
     run_on:
       - rhel87-small
@@ -865,7 +865,7 @@ buildvariants:
       STORAGE_ENGINE: inmemory
   - name: storage-mmapv1-rhel8
     tasks:
-      - name: .standard !.sharded_cluster-auth-ssl .server-4.0
+      - name: .test-standard !.sharded_cluster-auth-ssl .server-4.0
     display_name: Storage MMAPv1 RHEL8
     run_on:
       - rhel87-small

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1,66 +1,59 @@
 buildvariants:
   # Alternative hosts tests
-  - name: openssl-1.0.2-rhel7-v5.0-python3.9
+  - name: openssl-1.0.2-rhel7
     tasks:
-      - name: .other-hosts
-    display_name: OpenSSL 1.0.2 RHEL7 v5.0 Python3.9
+      - name: .standard .server-5.0
+    display_name: OpenSSL 1.0.2 RHEL7
     run_on:
       - rhel79-small
     batchtime: 10080
     expansions:
-      VERSION: "5.0"
-      PYTHON_VERSION: "3.9"
       PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: other-hosts-rhel9-fips-latest
+  - name: other-hosts-rhel9-fips
     tasks:
-      - name: .other-hosts
-    display_name: Other hosts RHEL9-FIPS latest
+      - name: .standard .server-latest
+    display_name: Other hosts RHEL9-FIPS
     run_on:
       - rhel92-fips
     batchtime: 10080
     expansions:
-      VERSION: latest
       NO_EXT: "1"
       REQUIRE_FIPS: "1"
-  - name: other-hosts-rhel8-zseries-latest
+  - name: other-hosts-rhel8-zseries
     tasks:
-      - name: .other-hosts
-    display_name: Other hosts RHEL8-zseries latest
+      - name: .standard .server-latest
+    display_name: Other hosts RHEL8-zseries
     run_on:
       - rhel8-zseries-small
     batchtime: 10080
     expansions:
-      VERSION: latest
       NO_EXT: "1"
-  - name: other-hosts-rhel8-power8-latest
+  - name: other-hosts-rhel8-power8
     tasks:
-      - name: .other-hosts
-    display_name: Other hosts RHEL8-POWER8 latest
+      - name: .standard .server-latest
+    display_name: Other hosts RHEL8-POWER8
     run_on:
       - rhel8-power-small
     batchtime: 10080
     expansions:
-      VERSION: latest
       NO_EXT: "1"
-  - name: other-hosts-rhel8-arm64-latest
+  - name: other-hosts-rhel8-arm64
     tasks:
-      - name: .other-hosts
-    display_name: Other hosts RHEL8-arm64 latest
+      - name: .standard .server-latest
+    display_name: Other hosts RHEL8-arm64
     run_on:
       - rhel82-arm64-small
     batchtime: 10080
     expansions:
-      VERSION: latest
       NO_EXT: "1"
-  - name: other-hosts-amazon2023-latest
+  - name: other-hosts-amazon2023
     tasks:
-      - name: .other-hosts
-    display_name: Other hosts Amazon2023 latest
+      - name: .standard .server-latest
+    display_name: Other hosts Amazon2023
     run_on:
       - amazon2023-arm64-latest-large-m8g
     batchtime: 10080
     expansions:
-      VERSION: latest
       NO_EXT: "1"
 
   # Atlas connect tests
@@ -120,7 +113,7 @@ buildvariants:
   # Compression tests
   - name: compression-snappy-rhel8
     tasks:
-      - name: .standard-linux
+      - name: .standard
     display_name: Compression snappy RHEL8
     run_on:
       - rhel87-small
@@ -128,7 +121,7 @@ buildvariants:
       COMPRESSOR: snappy
   - name: compression-zlib-rhel8
     tasks:
-      - name: .standard-linux
+      - name: .standard
     display_name: Compression zlib RHEL8
     run_on:
       - rhel87-small
@@ -136,7 +129,7 @@ buildvariants:
       COMPRESSOR: zlib
   - name: compression-zstd-rhel8
     tasks:
-      - name: .standard-linux !.server-4.0
+      - name: .standard !.server-4.0
     display_name: Compression zstd RHEL8
     run_on:
       - rhel87-small
@@ -167,7 +160,7 @@ buildvariants:
   # Doctests tests
   - name: doctests-rhel8
     tasks:
-      - name: .standard-linux .standalone-noauth-nossl
+      - name: .test-name .standalone-noauth-nossl
     display_name: Doctests RHEL8
     run_on:
       - rhel87-small
@@ -468,7 +461,7 @@ buildvariants:
   # Green framework tests
   - name: green-eventlet-rhel8
     tasks:
-      - name: .standard-linux .standalone-noauth-nossl .python-3.9
+      - name: .standard .standalone-noauth-nossl .python-3.9
     display_name: Green Eventlet RHEL8
     run_on:
       - rhel87-small
@@ -478,7 +471,7 @@ buildvariants:
       SSL: ssl
   - name: green-gevent-rhel8
     tasks:
-      - name: .standard-linux .standalone-noauth-nossl
+      - name: .standard .standalone-noauth-nossl
     display_name: Green Gevent RHEL8
     run_on:
       - rhel87-small
@@ -540,7 +533,7 @@ buildvariants:
   # No c ext tests
   - name: no-c-ext-rhel8
     tasks:
-      - name: .standard-linux
+      - name: .standard
     display_name: No C Ext RHEL8
     run_on:
       - rhel87-small
@@ -776,12 +769,12 @@ buildvariants:
   # Stable api tests
   - name: stable-api-require-v1-rhel8-auth
     tasks:
-      - name: .standard-linux !.replica_set-noauth-ssl .server-5.0
-      - name: .standard-linux !.replica_set-noauth-ssl .server-6.0
-      - name: .standard-linux !.replica_set-noauth-ssl .server-7.0
-      - name: .standard-linux !.replica_set-noauth-ssl .server-8.0
-      - name: .standard-linux !.replica_set-noauth-ssl .server-rapid
-      - name: .standard-linux !.replica_set-noauth-ssl .server-latest
+      - name: .standard !.replica_set-noauth-ssl .server-5.0
+      - name: .standard !.replica_set-noauth-ssl .server-6.0
+      - name: .standard !.replica_set-noauth-ssl .server-7.0
+      - name: .standard !.replica_set-noauth-ssl .server-8.0
+      - name: .standard !.replica_set-noauth-ssl .server-rapid
+      - name: .standard !.replica_set-noauth-ssl .server-latest
     display_name: Stable API require v1 RHEL8 Auth
     run_on:
       - rhel87-small
@@ -792,12 +785,12 @@ buildvariants:
     tags: [versionedApi_tag]
   - name: stable-api-accept-v2-rhel8-auth
     tasks:
-      - name: .standard-linux .server-5.0 .standalone-noauth-nossl
-      - name: .standard-linux .server-6.0 .standalone-noauth-nossl
-      - name: .standard-linux .server-7.0 .standalone-noauth-nossl
-      - name: .standard-linux .server-8.0 .standalone-noauth-nossl
-      - name: .standard-linux .server-rapid .standalone-noauth-nossl
-      - name: .standard-linux .server-latest .standalone-noauth-nossl
+      - name: .standard .server-5.0 .standalone-noauth-nossl
+      - name: .standard .server-6.0 .standalone-noauth-nossl
+      - name: .standard .server-7.0 .standalone-noauth-nossl
+      - name: .standard .server-8.0 .standalone-noauth-nossl
+      - name: .standard .server-rapid .standalone-noauth-nossl
+      - name: .standard .server-latest .standalone-noauth-nossl
     display_name: Stable API accept v2 RHEL8 Auth
     run_on:
       - rhel87-small
@@ -809,32 +802,32 @@ buildvariants:
   # Standard nonlinux tests
   - name: test-macos
     tasks:
-      - name: .standard-non-linux
+      - name: .standard !.pypy
     display_name: "* Test macOS"
     run_on:
       - macos-14
     tags: [standard-non-linux]
   - name: test-macos-arm64
     tasks:
-      - name: .standard-non-linux .server-6.0
-      - name: .standard-non-linux .server-7.0
-      - name: .standard-non-linux .server-8.0
-      - name: .standard-non-linux .server-rapid
-      - name: .standard-non-linux .server-latest
+      - name: .standard .server-6.0
+      - name: .standard .server-7.0
+      - name: .standard .server-8.0
+      - name: .standard .server-rapid
+      - name: .standard .server-latest
     display_name: "* Test macOS Arm64"
     run_on:
       - macos-14-arm64
     tags: [standard-non-linux]
   - name: test-win64
     tasks:
-      - name: .standard-non-linux
+      - name: .standard !.pypy
     display_name: "* Test Win64"
     run_on:
       - windows-64-vsMulti-small
     tags: [standard-non-linux]
   - name: test-win32
     tasks:
-      - name: .standard-non-linux
+      - name: .standard !.pypy
     display_name: "* Test Win32"
     run_on:
       - windows-64-vsMulti-small
@@ -845,7 +838,7 @@ buildvariants:
   # Storage engine tests
   - name: storage-inmemory-rhel8
     tasks:
-      - name: .standard-linux .standalone-noauth-nossl
+      - name: .standard .standalone-noauth-nossl
     display_name: Storage InMemory RHEL8
     run_on:
       - rhel87-small
@@ -853,7 +846,7 @@ buildvariants:
       STORAGE_ENGINE: inmemory
   - name: storage-mmapv1-rhel8
     tasks:
-      - name: .standard-linux !.sharded_cluster-auth-ssl .server-4.0
+      - name: .standard !.sharded_cluster-auth-ssl .server-4.0
     display_name: Storage MMAPv1 RHEL8
     run_on:
       - rhel87-small

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -167,7 +167,7 @@ buildvariants:
   # Doctests tests
   - name: doctests-rhel8
     tasks:
-      - name: .test-named .standalone-noauth-nossl
+      - name: .test-non-standard .standalone-noauth-nossl
     display_name: Doctests RHEL8
     run_on:
       - rhel87-small
@@ -511,11 +511,11 @@ buildvariants:
   # Load balancer tests
   - name: load-balancer
     tasks:
-      - name: .test-named .server-6.0 .sharded_cluster-auth-ssl
-      - name: .test-named .server-7.0 .sharded_cluster-auth-ssl
-      - name: .test-named .server-8.0 .sharded_cluster-auth-ssl
-      - name: .test-named .server-rapid .sharded_cluster-auth-ssl
-      - name: .test-named .server-latest .sharded_cluster-auth-ssl
+      - name: .test-non-standard .server-6.0 .sharded_cluster-auth-ssl
+      - name: .test-non-standard .server-7.0 .sharded_cluster-auth-ssl
+      - name: .test-non-standard .server-8.0 .sharded_cluster-auth-ssl
+      - name: .test-non-standard .server-rapid .sharded_cluster-auth-ssl
+      - name: .test-non-standard .server-latest .sharded_cluster-auth-ssl
     display_name: Load Balancer
     run_on:
       - rhel87-small
@@ -828,11 +828,11 @@ buildvariants:
     tags: [standard-non-linux]
   - name: test-macos-arm64
     tasks:
-      - name: .standard .server-6.0
-      - name: .standard .server-7.0
-      - name: .standard .server-8.0
-      - name: .standard .server-rapid
-      - name: .standard .server-latest
+      - name: .standard !.pypy .server-6.0
+      - name: .standard !.pypy .server-7.0
+      - name: .standard !.pypy .server-8.0
+      - name: .standard !.pypy .server-rapid
+      - name: .standard !.pypy .server-latest
     display_name: "* Test macOS Arm64"
     run_on:
       - macos-14-arm64

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -2,7 +2,7 @@ buildvariants:
   # Alternative hosts tests
   - name: openssl-1.0.2-rhel7-v5.0-python3.9
     tasks:
-      - name: .no-toolchain
+      - name: .test-no-toolchain
     display_name: OpenSSL 1.0.2 RHEL7 v5.0 Python3.9
     run_on:
       - rhel79-small
@@ -13,7 +13,7 @@ buildvariants:
       PYTHON_BINARY: /opt/python/3.9/bin/python3
   - name: other-hosts-rhel9-fips-latest
     tasks:
-      - name: .no-toolchain
+      - name: .test-no-toolchain
     display_name: Other hosts RHEL9-FIPS latest
     run_on:
       - rhel92-fips
@@ -24,7 +24,7 @@ buildvariants:
       REQUIRE_FIPS: "1"
   - name: other-hosts-rhel8-zseries-latest
     tasks:
-      - name: .no-toolchain
+      - name: .test-no-toolchain
     display_name: Other hosts RHEL8-zseries latest
     run_on:
       - rhel8-zseries-small
@@ -34,7 +34,7 @@ buildvariants:
       NO_EXT: "1"
   - name: other-hosts-rhel8-power8-latest
     tasks:
-      - name: .no-toolchain
+      - name: .test-no-toolchain
     display_name: Other hosts RHEL8-POWER8 latest
     run_on:
       - rhel8-power-small
@@ -44,7 +44,7 @@ buildvariants:
       NO_EXT: "1"
   - name: other-hosts-rhel8-arm64-latest
     tasks:
-      - name: .no-toolchain
+      - name: .test-no-toolchain
     display_name: Other hosts RHEL8-arm64 latest
     run_on:
       - rhel82-arm64-small
@@ -54,7 +54,7 @@ buildvariants:
       NO_EXT: "1"
   - name: other-hosts-amazon2023-latest
     tasks:
-      - name: .no-toolchain
+      - name: .test-no-toolchain
     display_name: Other hosts Amazon2023 latest
     run_on:
       - amazon2023-arm64-latest-large-m8g
@@ -554,7 +554,7 @@ buildvariants:
   # No server tests
   - name: no-server-rhel8
     tasks:
-      - name: .no-orchestration
+      - name: .test-no-orchestration
     display_name: No server RHEL8
     run_on:
       - rhel87-small

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -504,11 +504,11 @@ buildvariants:
   # Load balancer tests
   - name: load-balancer
     tasks:
-      - name: .test-named .server-6.0 .sharded-auth-ssl
-      - name: .test-named .server-7.0 .sharded-auth-ssl
-      - name: .test-named .server-8.0 .sharded-auth-ssl
-      - name: .test-named .server-rapid .sharded-auth-ssl
-      - name: .test-named .server-latest .sharded-auth-ssl
+      - name: .test-named .server-6.0 .sharded_cluster-auth-ssl
+      - name: .test-named .server-7.0 .sharded_cluster-auth-ssl
+      - name: .test-named .server-8.0 .sharded_cluster-auth-ssl
+      - name: .test-named .server-rapid .sharded_cluster-auth-ssl
+      - name: .test-named .server-latest .sharded_cluster-auth-ssl
     display_name: Load Balancer
     run_on:
       - rhel87-small

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -66,7 +66,7 @@ buildvariants:
   # Atlas connect tests
   - name: atlas-connect-rhel8
     tasks:
-      - name: .no-orchestration
+      - name: .test-no-orchestration
     display_name: Atlas connect RHEL8
     run_on:
       - rhel87-small

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -160,7 +160,7 @@ buildvariants:
   # Doctests tests
   - name: doctests-rhel8
     tasks:
-      - name: .test-name .standalone-noauth-nossl
+      - name: .test-named .standalone-noauth-nossl
     display_name: Doctests RHEL8
     run_on:
       - rhel87-small
@@ -504,11 +504,17 @@ buildvariants:
   # Load balancer tests
   - name: load-balancer
     tasks:
-      - name: .load-balancer
+      - name: .test-named .server-6.0 .sharded-auth-ssl
+      - name: .test-named .server-7.0 .sharded-auth-ssl
+      - name: .test-named .server-8.0 .sharded-auth-ssl
+      - name: .test-named .server-rapid .sharded-auth-ssl
+      - name: .test-named .server-latest .sharded-auth-ssl
     display_name: Load Balancer
     run_on:
       - rhel87-small
     batchtime: 10080
+    expansions:
+      TEST_NAME: load_balancer
 
   # Mockupdb tests
   - name: mockupdb-rhel8

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -1,59 +1,66 @@
 buildvariants:
   # Alternative hosts tests
-  - name: openssl-1.0.2-rhel7
+  - name: openssl-1.0.2-rhel7-v5.0-python3.9
     tasks:
-      - name: .standard .server-5.0
-    display_name: OpenSSL 1.0.2 RHEL7
+      - name: .no-toolchain
+    display_name: OpenSSL 1.0.2 RHEL7 v5.0 Python3.9
     run_on:
       - rhel79-small
     batchtime: 10080
     expansions:
+      VERSION: "5.0"
+      PYTHON_VERSION: "3.9"
       PYTHON_BINARY: /opt/python/3.9/bin/python3
-  - name: other-hosts-rhel9-fips
+  - name: other-hosts-rhel9-fips-latest
     tasks:
-      - name: .standard .server-latest
-    display_name: Other hosts RHEL9-FIPS
+      - name: .no-toolchain
+    display_name: Other hosts RHEL9-FIPS latest
     run_on:
       - rhel92-fips
     batchtime: 10080
     expansions:
+      VERSION: latest
       NO_EXT: "1"
       REQUIRE_FIPS: "1"
-  - name: other-hosts-rhel8-zseries
+  - name: other-hosts-rhel8-zseries-latest
     tasks:
-      - name: .standard .server-latest
-    display_name: Other hosts RHEL8-zseries
+      - name: .no-toolchain
+    display_name: Other hosts RHEL8-zseries latest
     run_on:
       - rhel8-zseries-small
     batchtime: 10080
     expansions:
+      VERSION: latest
       NO_EXT: "1"
-  - name: other-hosts-rhel8-power8
+  - name: other-hosts-rhel8-power8-latest
     tasks:
-      - name: .standard .server-latest
-    display_name: Other hosts RHEL8-POWER8
+      - name: .no-toolchain
+    display_name: Other hosts RHEL8-POWER8 latest
     run_on:
       - rhel8-power-small
     batchtime: 10080
     expansions:
+      VERSION: latest
       NO_EXT: "1"
-  - name: other-hosts-rhel8-arm64
+  - name: other-hosts-rhel8-arm64-latest
     tasks:
-      - name: .standard .server-latest
-    display_name: Other hosts RHEL8-arm64
+      - name: .no-toolchain
+    display_name: Other hosts RHEL8-arm64 latest
     run_on:
       - rhel82-arm64-small
     batchtime: 10080
     expansions:
+      VERSION: latest
       NO_EXT: "1"
-  - name: other-hosts-amazon2023
+  - name: other-hosts-amazon2023-latest
     tasks:
-      - name: .standard .server-latest
-    display_name: Other hosts Amazon2023
+      - name: .no-toolchain
+    display_name: Other hosts Amazon2023 latest
     run_on:
       - amazon2023-arm64-latest-large-m8g
     batchtime: 10080
     expansions:
+      VERSION: latest
       NO_EXT: "1"
 
   # Atlas connect tests

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -504,11 +504,11 @@ buildvariants:
   # Load balancer tests
   - name: load-balancer
     tasks:
-      - name: .test-named .server-6.0 .sharded_cluster-auth-ssl
-      - name: .test-named .server-7.0 .sharded_cluster-auth-ssl
-      - name: .test-named .server-8.0 .sharded_cluster-auth-ssl
-      - name: .test-named .server-rapid .sharded_cluster-auth-ssl
-      - name: .test-named .server-latest .sharded_cluster-auth-ssl
+      - name: .test-named .server-6.0 .sharded-auth-ssl
+      - name: .test-named .server-7.0 .sharded-auth-ssl
+      - name: .test-named .server-8.0 .sharded-auth-ssl
+      - name: .test-named .server-rapid .sharded-auth-ssl
+      - name: .test-named .server-latest .sharded-auth-ssl
     display_name: Load Balancer
     run_on:
       - rhel87-small

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -201,7 +201,7 @@ def create_encryption_variants() -> list[BuildVariant]:
 
 
 def create_load_balancer_variants():
-    tasks = [f".test-named .server-{v} .sharded_cluster-auth-ssl" for v in get_versions_from("6.0")]
+    tasks = [f".test-named .server-{v} .sharded-auth-ssl" for v in get_versions_from("6.0")]
     expansions = dict(TEST_NAME="load_balancer")
     return [
         create_variant(
@@ -598,8 +598,12 @@ def create_server_version_tasks():
 def create_test_named_tasks():
     """For variants that set a TEST_NAME."""
     tasks = []
-
-    for version, topology, python in product(ALL_VERSIONS, TOPOLOGIES, ALL_PYTHONS):
+    task_combos = []
+    for (version, topology), python in zip_cycle(list(product(ALL_VERSIONS, TOPOLOGIES)), CPYTHONS):
+        task_combos.append((version, topology, python))
+    for (python, topology), version in zip_cycle(list(product(PYPYS, TOPOLOGIES)), ALL_VERSIONS):
+        task_combos.append((version, topology, python))
+    for version, topology, python in task_combos:
         auth, ssl = get_standard_auth_ssl(topology)
         tags = [
             "test-named",

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -591,18 +591,11 @@ def create_aws_lambda_variants():
 
 def create_server_version_tasks():
     tasks = []
-    # Test all pythons with sharded_cluster, auth, and ssl.
-    task_types = [(p, "sharded_cluster", "auth", "ssl") for p in ALL_PYTHONS]
-    # Test all combinations of topology, auth, and ssl, with rotating pythons.
-    for (topology, auth, ssl), python in zip_cycle(
-        list(product(TOPOLOGIES, ["auth", "noauth"], ["ssl", "nossl"])), ALL_PYTHONS
+    # Test all combinations of topology, auth, ssl, and sync, with rotating pythons.
+    for (topology, auth, ssl, sync), python in zip_cycle(
+        list(product(TOPOLOGIES, ["auth", "noauth"], ["ssl", "nossl"], SYNCS)), ALL_PYTHONS
     ):
-        # Skip the ones we already have.
-        if topology == "sharded_cluster" and auth == "auth" and ssl == "ssl":
-            continue
-        task_types.append((python, topology, auth, ssl))
-    for (python, topology, auth, ssl), sync in zip_cycle(task_types, SYNCS):
-        tags = ["server-version", f"python-{python}", f"{topology}-{auth}-{ssl}"]
+        tags = ["server-version", f"python-{python}", f"{topology}-{auth}-{ssl}", sync]
         expansions = dict(AUTH=auth, SSL=ssl, TOPOLOGY=topology)
         if python not in PYPYS:
             expansions["COVERAGE"] = "1"

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -580,7 +580,7 @@ def create_server_version_tasks():
         expansions = dict(AUTH=auth, SSL=ssl, TOPOLOGY=topology)
         if python not in PYPYS:
             expansions["COVERAGE"] = "1"
-        name = get_task_name("test", python=python, **expansions)
+        name = get_task_name("test", python=python, sync=sync, **expansions)
         server_func = FunctionCall(func="run server", vars=expansions)
         test_vars = expansions.copy()
         test_vars["PYTHON_VERSION"] = python

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -201,7 +201,7 @@ def create_encryption_variants() -> list[BuildVariant]:
 
 
 def create_load_balancer_variants():
-    tasks = [f".test-named .server-{v} .sharded-auth-ssl" for v in get_versions_from("6.0")]
+    tasks = [f".test-named .server-{v} .sharded_cluster-auth-ssl" for v in get_versions_from("6.0")]
     expansions = dict(TEST_NAME="load_balancer")
     return [
         create_variant(

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -599,9 +599,7 @@ def create_test_named_tasks():
     """For variants that set a TEST_NAME."""
     tasks = []
 
-    for (version, topology), python in zip_cycle(
-        list(product(ALL_VERSIONS, TOPOLOGIES)), ALL_PYTHONS
-    ):
+    for version, topology, python in product(ALL_VERSIONS, TOPOLOGIES, ALL_PYTHONS):
         auth, ssl = get_standard_auth_ssl(topology)
         tags = [
             "test-named",

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -595,13 +595,17 @@ def create_server_version_tasks():
     return tasks
 
 
-def create_named_test_tasks():
+def create_test_named_tasks():
     """For variants that set a TEST_NAME."""
     tasks = []
-    # For each Python and Topology, rotate through the versions.
-    for (python, topology), version in zip_cycle(
-        list(product(ALL_PYTHONS, TOPOLOGIES)), ALL_VERSIONS
-    ):
+    task_combos = []
+    # For each version and topology, rotate through the CPythons.
+    for (version, topology), python in zip_cycle(list(product(ALL_VERSIONS, TOPOLOGIES)), CPYTHONS):
+        task_combos.append((version, topology, python))
+    # For each PyPy and topology, rotate through the the versions.
+    for (python, topology), version in zip_cycle(list(product(PYPYS, TOPOLOGIES)), ALL_VERSIONS):
+        task_combos.append((version, topology, python))
+    for version, topology, python in task_combos:
         auth, ssl = get_standard_auth_ssl(topology)
         tags = [
             "test-named",
@@ -624,10 +628,19 @@ def create_named_test_tasks():
 def create_standard_tasks():
     """For variants that do not set a TEST_NAME."""
     tasks = []
-    # For each Python and Topology, rotate through the versions and sync/async.
-    for (python, topology), version, sync in zip_cycle(
-        list(product(ALL_PYTHONS, TOPOLOGIES)), ALL_VERSIONS, SYNCS
+    task_combos = []
+    # For each version and topology, rotate through the CPythons and sync/async.
+    for (version, topology), python, sync in zip_cycle(
+        list(product(ALL_VERSIONS, TOPOLOGIES)), CPYTHONS, SYNCS
     ):
+        task_combos.append((version, topology, python, sync))
+    # For each PyPy and topology, rotate through the the versions and sync/async.
+    for (python, topology), version, sync in zip_cycle(
+        list(product(PYPYS, TOPOLOGIES)), ALL_VERSIONS, SYNCS
+    ):
+        task_combos.append((version, topology, python, sync))
+
+    for version, topology, python, sync in task_combos:
         auth, ssl = get_standard_auth_ssl(topology)
         tags = [
             "standard",

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -540,7 +540,7 @@ def create_aws_auth_variants():
 def create_no_server_variants():
     host = HOSTS["rhel8"]
     name = get_variant_name("No server", host=host)
-    return [create_variant([".no-orchestration"], name, host=host)]
+    return [create_variant([".test-no-orchestration"], name, host=host)]
 
 
 def create_alternative_hosts_variants():
@@ -551,7 +551,7 @@ def create_alternative_hosts_variants():
     version = "5.0"
     variants.append(
         create_variant(
-            [".no-toolchain"],
+            [".test-no-toolchain"],
             get_variant_name("OpenSSL 1.0.2", host, python=CPYTHONS[0], version=version),
             host=host,
             python=CPYTHONS[0],
@@ -569,7 +569,7 @@ def create_alternative_hosts_variants():
             expansions["REQUIRE_FIPS"] = "1"
         variants.append(
             create_variant(
-                [".no-toolchain"],
+                [".test-no-toolchain"],
                 display_name=get_variant_name("Other hosts", host, version=version),
                 batchtime=batchtime,
                 host=host,
@@ -622,7 +622,7 @@ def create_no_toolchain_tasks():
     for topology, sync in zip_cycle(TOPOLOGIES, SYNCS):
         auth, ssl = get_standard_auth_ssl(topology)
         tags = [
-            "no-toolchain",
+            "test-no-toolchain",
             f"{topology}-{auth}-{ssl}",
         ]
         expansions = dict(AUTH=auth, SSL=ssl, TOPOLOGY=topology)

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -598,7 +598,7 @@ def create_server_version_tasks():
     ):
         task_inputs.append((topology, auth, ssl, sync, python))
 
-    # Every python should be tested with sharded cluster auth ssl, sync and async.
+    # Every python should be tested with sharded cluster, auth, ssl, with sync and async.
     for python, sync in product(ALL_PYTHONS, SYNCS):
         task_input = ("sharded_cluster", "auth", "ssl", sync, python)
         if task_input not in task_inputs:

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -588,7 +588,7 @@ def create_server_version_tasks():
         expansions = dict(AUTH=auth, SSL=ssl, TOPOLOGY=topology)
         if python not in PYPYS:
             expansions["COVERAGE"] = "1"
-        name = get_task_name("test", python=python, sync=sync, **expansions)
+        name = get_task_name("test-server-version", python=python, sync=sync, **expansions)
         server_func = FunctionCall(func="run server", vars=expansions)
         test_vars = expansions.copy()
         test_vars["PYTHON_VERSION"] = python
@@ -608,7 +608,7 @@ def create_no_toolchain_tasks():
             f"{topology}-{auth}-{ssl}",
         ]
         expansions = dict(AUTH=auth, SSL=ssl, TOPOLOGY=topology)
-        name = get_task_name("test", sync=sync, **expansions)
+        name = get_task_name("test-no-toolchain", sync=sync, **expansions)
         server_func = FunctionCall(func="run server", vars=expansions)
         test_vars = expansions.copy()
         test_vars["TEST_NAME"] = f"default_{sync}"

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -481,7 +481,7 @@ def create_atlas_connect_variants():
     host = DEFAULT_HOST
     return [
         create_variant(
-            [".no-orchestration"],
+            [".test-no-orchestration"],
             get_variant_name("Atlas connect", host),
             host=DEFAULT_HOST,
         )

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -626,10 +626,17 @@ def create_test_named_tasks():
 def create_standard_tasks():
     """For variants that do not set a TEST_NAME."""
     tasks = []
-
+    task_combos = []
     for (version, topology), python, sync in zip_cycle(
-        list(product(ALL_VERSIONS, TOPOLOGIES)), ALL_PYTHONS, SYNCS
+        list(product(ALL_VERSIONS, TOPOLOGIES)), CPYTHONS, SYNCS
     ):
+        task_combos.append((version, topology, python, sync))
+    for (python, topology), version, sync in zip_cycle(
+        list(product(PYPYS, TOPOLOGIES)), ALL_VERSIONS, SYNCS
+    ):
+        task_combos.append((version, topology, python, sync))
+
+    for version, topology, python, sync in task_combos:
         auth, ssl = get_standard_auth_ssl(topology)
         tags = [
             "standard",

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -595,15 +595,13 @@ def create_server_version_tasks():
     return tasks
 
 
-def create_test_named_tasks():
+def create_named_test_tasks():
     """For variants that set a TEST_NAME."""
     tasks = []
-    task_combos = []
-    for (version, topology), python in zip_cycle(list(product(ALL_VERSIONS, TOPOLOGIES)), CPYTHONS):
-        task_combos.append((version, topology, python))
-    for (python, topology), version in zip_cycle(list(product(PYPYS, TOPOLOGIES)), ALL_VERSIONS):
-        task_combos.append((version, topology, python))
-    for version, topology, python in task_combos:
+    # For each Python and Topology, rotate through the versions.
+    for (python, topology), version in zip_cycle(
+        list(product(ALL_PYTHONS, TOPOLOGIES)), ALL_VERSIONS
+    ):
         auth, ssl = get_standard_auth_ssl(topology)
         tags = [
             "test-named",
@@ -626,17 +624,10 @@ def create_test_named_tasks():
 def create_standard_tasks():
     """For variants that do not set a TEST_NAME."""
     tasks = []
-    task_combos = []
-    for (version, topology), python, sync in zip_cycle(
-        list(product(ALL_VERSIONS, TOPOLOGIES)), CPYTHONS, SYNCS
-    ):
-        task_combos.append((version, topology, python, sync))
+    # For each Python and Topology, rotate through the versions and sync/async.
     for (python, topology), version, sync in zip_cycle(
-        list(product(PYPYS, TOPOLOGIES)), ALL_VERSIONS, SYNCS
+        list(product(ALL_PYTHONS, TOPOLOGIES)), ALL_VERSIONS, SYNCS
     ):
-        task_combos.append((version, topology, python, sync))
-
-    for version, topology, python, sync in task_combos:
         auth, ssl = get_standard_auth_ssl(topology)
         tags = [
             "standard",

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -93,7 +93,7 @@ def create_standard_nonlinux_variants() -> list[BuildVariant]:
         tasks = [".standard !.pypy"]
         # MacOS arm64 only works on server versions 6.0+
         if host_name == "macos-arm64":
-            tasks = [f".standard .server-{version}" for version in get_versions_from("6.0")]
+            tasks = [f".standard !.pypy .server-{version}" for version in get_versions_from("6.0")]
         host = HOSTS[host_name]
         tags = ["standard-non-linux"]
         expansions = dict()
@@ -201,7 +201,10 @@ def create_encryption_variants() -> list[BuildVariant]:
 
 
 def create_load_balancer_variants():
-    tasks = [f".test-named .server-{v} .sharded_cluster-auth-ssl" for v in get_versions_from("6.0")]
+    tasks = [
+        f".test-non-standard .server-{v} .sharded_cluster-auth-ssl"
+        for v in get_versions_from("6.0")
+    ]
     expansions = dict(TEST_NAME="load_balancer")
     return [
         create_variant(
@@ -462,7 +465,7 @@ def create_doctests_variants():
     expansions = dict(TEST_NAME="doctest")
     return [
         create_variant(
-            [".test-named .standalone-noauth-nossl"],
+            [".test-non-standard .standalone-noauth-nossl"],
             get_variant_name("Doctests", host),
             host=host,
             expansions=expansions,
@@ -628,7 +631,7 @@ def create_no_toolchain_tasks():
     return tasks
 
 
-def create_test_named_tasks():
+def create_test_non_standard_tasks():
     """For variants that set a TEST_NAME."""
     tasks = []
     task_combos = []
@@ -641,7 +644,7 @@ def create_test_named_tasks():
     for version, topology, python in task_combos:
         auth, ssl = get_standard_auth_ssl(topology)
         tags = [
-            "test-named",
+            "test-non-standard",
             f"server-{version}",
             f"python-{python}",
             f"{topology}-{auth}-{ssl}",
@@ -649,7 +652,7 @@ def create_test_named_tasks():
         if python in PYPYS:
             tags.append("pypy")
         expansions = dict(AUTH=auth, SSL=ssl, TOPOLOGY=topology, VERSION=version)
-        name = get_task_name("test-named", python=python, **expansions)
+        name = get_task_name("test-non-standard", python=python, **expansions)
         server_func = FunctionCall(func="run server", vars=expansions)
         test_vars = expansions.copy()
         test_vars["PYTHON_VERSION"] = python


### PR DESCRIPTION
See the [ticket](https://jira.mongodb.org/browse/PYTHON-5345) for more background on the reasoning.

Patch build: https://spruce.mongodb.com/version/680b9b831d659e0007140dda/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Doctests:

<img width="992" alt="image" src="https://github.com/user-attachments/assets/f21c33f1-ec2f-49fd-ab4e-ce8e5daee52d" />

Load Balancer:

<img width="967" alt="image" src="https://github.com/user-attachments/assets/75ca69d6-39c3-483d-b3c8-b55abd21c96c" />

No C Ext (partial list shown):

<img width="336" alt="image" src="https://github.com/user-attachments/assets/3f175b42-d6b2-49f2-b786-2dec163b7c47" />

MongoDB 4.4:

<img width="950" alt="image" src="https://github.com/user-attachments/assets/b24f9f46-24c1-43de-8a62-70fe86471986" />
