### PR TITLE
PYTHON-5356 - Init unified test client SDAM for all unified tests

### DIFF
--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -256,7 +256,7 @@ class EntityMapUtil:
                 current[key] = self._handle_placeholders(spec, value, subpath)
         return current
 
-    def _create_entity(self, entity_spec, uri=None):
+    def _create_entity(self, entity_spec, uri=None, init_client=False):
         if len(entity_spec) != 1:
             self.test.fail(f"Entity spec {entity_spec} did not contain exactly one top-level key")
 
@@ -302,6 +302,8 @@ class EntityMapUtil:
             if uri:
                 kwargs["h"] = uri
             client = self.test.rs_or_single_client(**kwargs)
+            if init_client:
+                client._connect()
             self[spec["id"]] = client
             return
         elif entity_type == "database":
@@ -389,9 +391,9 @@ class EntityMapUtil:
 
         self.test.fail(f"Unable to create entity of unknown type {entity_type}")
 
-    def create_entities_from_spec(self, entity_spec, uri=None):
+    def create_entities_from_spec(self, entity_spec, uri=None, init_client=False):
         for spec in entity_spec:
-            self._create_entity(spec, uri=uri)
+            self._create_entity(spec, uri=uri, init_client=init_client)
 
     def get_listener_for_client(self, client_name: str) -> EventListenerUtil:
         client = self[client_name]
@@ -1393,7 +1395,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             attempts = 3
             for i in range(attempts):
                 try:
-                    return self._run_scenario(spec, uri)
+                    return self._run_scenario(spec, uri, init_client=True)
                 except (AssertionError, OperationFailure) as exc:
                     if isinstance(exc, OperationFailure) and (
                         _IS_SYNC or "failpoint" not in exc._message
@@ -1413,7 +1415,7 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
             self._run_scenario(spec, uri)
             return None
 
-    def _run_scenario(self, spec, uri=None):
+    def _run_scenario(self, spec, uri=None, init_client=False):
         # maybe skip test manually
         self.maybe_skip_test(spec)
 
@@ -1430,7 +1432,9 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
         # process createEntities
         self._uri = uri
         self.entity_map = EntityMapUtil(self)
-        self.entity_map.create_entities_from_spec(self.TEST_SPEC.get("createEntities", []), uri=uri)
+        self.entity_map.create_entities_from_spec(
+            self.TEST_SPEC.get("createEntities", []), uri=uri, init_client=init_client
+        )
         self._cluster_time = None
         # process initialData
         if "initialData" in self.TEST_SPEC:


### PR DESCRIPTION
Explicitly connect clients for unified CSOT tests before the test begins to minimize flakiness caused by SDAM creation and startup.

Patch build with everything run: https://spruce.mongodb.com/version/6812632b5456710007edc380/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC