### PR TITLE
PYTHON-5362 WriteConcern repr should be eval-able

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+Changes in Version 4.13.0 (2025/05/29)
+--------------------------------------
+
+PyMongo 4.13 brings a number of changes including:
+
+- Fixed a bug where :class:`pymongo.write_concern.WriteConcern` repr was not eval-able
+  when using ``w="majority"``.
+
+Issues Resolved
+...............
+
+See the `PyMongo 4.13 release notes in JIRA`_ for the list of resolved issues
+in this release.
+
+.. _PyMongo 4.13 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=42509
 
 Changes in Version 4.12.1 (2025/04/29)
 --------------------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Changes in Version 4.13.0 (2025/05/29)
+Changes in Version 4.13.0 (2025/05/14)
 --------------------------------------
 
 PyMongo 4.13 brings a number of changes including:

--- a/pymongo/write_concern.py
+++ b/pymongo/write_concern.py
@@ -127,7 +127,7 @@ class WriteConcern:
 
     def __repr__(self) -> str:
         return "WriteConcern({})".format(
-            ", ".join("{}={}".format(*kvt) for kvt in self.__document.items())
+            ", ".join(f"{k}={v!r}" for k, v in self.__document.items())
         )
 
     def __eq__(self, other: Any) -> bool:

--- a/test/test_write_concern.py
+++ b/test/test_write_concern.py
@@ -67,6 +67,19 @@ class TestWriteConcern(unittest.TestCase):
         _fake_type = collections.namedtuple("NotAWriteConcern", ["document"])  # type: ignore
         self.assertNotEqual(WriteConcern(j=True), _fake_type({"j": True}))
 
+    def assertRepr(self, obj):
+        new_obj = eval(repr(obj))
+        self.assertEqual(type(new_obj), type(obj))
+        self.assertEqual(repr(new_obj), repr(obj))
+
+    def test_repr(self):
+        concern = WriteConcern(j=True, wtimeout=3000, w="majority", fsync=False)
+        self.assertRepr(concern)
+        self.assertEqual(
+            repr(concern),
+            "WriteConcern(wtimeout=3000, j=True, fsync=False, w='majority')",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
https://jira.mongodb.org/browse/PYTHON-5362