### PR TITLE
DRIVERS-3915 Add a prose test for OIDC reauthentication when a session is involved

### DIFF
--- a/test/auth_oidc/test_auth_oidc.py
+++ b/test/auth_oidc/test_auth_oidc.py
@@ -1089,7 +1089,7 @@ class TestAuthOIDCMachine(OIDCTestBase):
             # Start a new session.
             with client.start_session() as session:
                 # In the started session perform a `find` operation that succeeds.
-                client.test.test.find({}, session=session)
+                client.test.test.find_one({}, session=session)
 
         # Assert that the callback was called 2 times (once during the connection handshake, and again during reauthentication).
         self.assertEqual(self.request_called, 2)

--- a/test/auth_oidc/test_auth_oidc.py
+++ b/test/auth_oidc/test_auth_oidc.py
@@ -1075,6 +1075,25 @@ class TestAuthOIDCMachine(OIDCTestBase):
         # Assert there were `SaslStart` commands executed.
         assert any(event.command_name.lower() == "saslstart" for event in listener.started_events)
 
+    def test_4_5_reauthentication_succeeds_when_a_session_is_involved(self):
+        # Create an OIDC configured client.
+        client = self.create_client()
+
+        # Set a fail point for `find` commands of the form:
+        with self.fail_point(
+            {
+                "mode": {"times": 1},
+                "data": {"failCommands": ["find"], "errorCode": 391},
+            }
+        ):
+            # Start a new session.
+            with client.start_session() as session:
+                # In the started session perform a `find` operation that succeeds.
+                client.test.test.find({}, session=session)
+
+        # Assert that the callback was called 2 times (once during the connection handshake, and again during reauthentication).
+        self.assertEqual(self.request_called, 2)
+
     def test_5_1_azure_with_no_username(self):
         if ENVIRON != "azure":
             raise unittest.SkipTest("Test is only supported on Azure")


### PR DESCRIPTION
Passing build: https://spruce.mongodb.com/version/68371af70106690007c1da04/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Depends on https://github.com/mongodb/specifications/pull/1805