### PR TITLE
[v4.13] PYTHON-5400 Migrate away from Windows Server 2019 runner image on Github Actions

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -39,8 +39,8 @@ jobs:
         - [ubuntu-latest, "manylinux_ppc64le", "cp3*-manylinux_ppc64le"]
         - [ubuntu-latest, "manylinux_s390x", "cp3*-manylinux_s390x"]
         - [ubuntu-latest, "manylinux_i686", "cp3*-manylinux_i686"]
-        - [windows-2019, "win_amd6", "cp3*-win_amd64"]
-        - [windows-2019, "win32", "cp3*-win32"]
+        - [windows-2022, "win_amd6", "cp3*-win_amd64"]
+        - [windows-2022, "win32", "cp3*-win32"]
         - [macos-14, "macos", "cp*-macosx_*"]
 
     steps:


### PR DESCRIPTION
(cherry picked from commit 958b3d1)