### PR TITLE
PYTHON-5414 Fix "module service_identity has no attribute SICertificateError" when using pyopenssl

### DIFF
--- a/pymongo/pyopenssl_context.py
+++ b/pymongo/pyopenssl_context.py
@@ -420,9 +420,9 @@ class SSLContext:
                         pyopenssl.verify_ip_address(ssl_conn, server_hostname)
                     else:
                         pyopenssl.verify_hostname(ssl_conn, server_hostname)
-                except (  # type:ignore[misc]
-                    service_identity.SICertificateError,
-                    service_identity.SIVerificationError,
+                except (
+                    service_identity.CertificateError,
+                    service_identity.VerificationError,
                 ) as exc:
                     raise _CertificateError(str(exc)) from None
         return ssl_conn


### PR DESCRIPTION
When there is a mistake in the certificates configuration, PyMongo would give the following error:
```
pymongo.errors.ServerSelectionTimeoutError: module service_identity has no attribute SICertificateError, Timeout: 30s, Topology Description: <…>
```
Because the `except` block expected non-existing errors, the error gets transformed to "module … has no attribute …". The errors in the `service_identity` have never had the `SI` prefix:
https://github.com/pyca/service-identity/blob/18.1.0/src/service_identity/exceptions.py
It looks like the errors were imported with an alias before, but this aliasing was (only partially) removed when rewriting to lazy imports in this commit:
https://github.com/mongodb/mongo-python-driver/commit/42a08c4a34c1bd58296de1ffa2368396fdb12f8f#diff-b277a2f4cfbb5decab333d0b90a08a4ad64b91fb1691ed8412b15949d1aaceee
The lazy imports were removed again in this commit, but the error remained:
https://github.com/mongodb/mongo-python-driver/commit/49987e6a8a5217de19a425838e16d5c9674a8841#diff-b277a2f4cfbb5decab333d0b90a08a4ad64b91fb1691ed8412b15949d1aaceee
After changing the expected errors manually in my virtual environment, the error I received earlier turned into this, so I could continue debugging my certificates configuration:
```
pymongo.errors.ServerSelectionTimeoutError: […]: ("VerificationError(errors=[IPAddressMismatch(…)])",) (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms), Timeout: 30s, Topology Description: <…>
```
Most likely, the `# type: ignore[misc]` comment can now also be removed (but I have not set up this repository for development on my machine, so I'll let the automated checks be the judge of that).