### PR TITLE
PYTHON-5409 Fix test_implicit_sessions_checkout again

### DIFF
--- a/test/asynchronous/test_session.py
+++ b/test/asynchronous/test_session.py
@@ -235,7 +235,6 @@ class TestSession(AsyncIntegrationTest):
             for t in tasks:
                 await t.join()
                 self.assertIsNone(t.exc)
-            await client.close()
             lsid_set.clear()
             for i in listener.started_events:
                 if i.command.get("lsid"):

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -235,7 +235,6 @@ class TestSession(IntegrationTest):
             for t in tasks:
                 t.join()
                 self.assertIsNone(t.exc)
-            client.close()
             lsid_set.clear()
             for i in listener.started_events:
                 if i.command.get("lsid"):


### PR DESCRIPTION
Fixes the failure seen here: https://github.com/mongodb/mongo-python-driver/actions/runs/15606502724/job/43991538564?pr=2382
```
FAILED test/test_session.py::TestSession::test_implicit_sessions_checkout - AssertionError: InvalidOperation('Cannot use MongoClient after close') is not None
```
