### PR TITLE
PYTHON-5414 Add test for hostname verification error message regression

### DIFF
--- a/test/asynchronous/test_ssl.py
+++ b/test/asynchronous/test_ssl.py
@@ -323,7 +323,7 @@ class TestSSL(AsyncIntegrationTest):
 
         response = await self.client.admin.command(HelloCompat.LEGACY_CMD)
 
-        with self.assertRaises(ConnectionFailure):
+        with self.assertRaises(ConnectionFailure) as cm:
             await connected(
                 self.simple_client(
                     "server",
@@ -335,6 +335,8 @@ class TestSSL(AsyncIntegrationTest):
                     **self.credentials,  # type: ignore[arg-type]
                 )
             )
+        # PYTHON-5414 Check for "module service_identity has no attribute SICertificateError"
+        self.assertNotIn("has no attribute", str(cm.exception))
 
         await connected(
             self.simple_client(

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -323,7 +323,7 @@ class TestSSL(IntegrationTest):
 
         response = self.client.admin.command(HelloCompat.LEGACY_CMD)
 
-        with self.assertRaises(ConnectionFailure):
+        with self.assertRaises(ConnectionFailure) as cm:
             connected(
                 self.simple_client(
                     "server",
@@ -335,6 +335,8 @@ class TestSSL(IntegrationTest):
                     **self.credentials,  # type: ignore[arg-type]
                 )
             )
+        # PYTHON-5414 Check for "module service_identity has no attribute SICertificateError"
+        self.assertNotIn("has no attribute", str(cm.exception))
 
         connected(
             self.simple_client(


### PR DESCRIPTION
PYTHON-5414 Add test for hostname verification error message regression

Note that this test won't run in CI for now due to https://jira.mongodb.org/browse/PYTHON-5415 but I tested it locally and the assertion passed.