### PR TITLE
[v4.13] PYTHON-5414 Fix "module service_identity has no attribute SICertificateError" when using pyopenssl

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+Changes in Version 4.13.2 (2025/06/17)
+--------------------------------------
+
+Version 4.13.1 is a bug fix release.
+
+- Fixed a bug that resulted in confusing error messages after hostname verification errors when using PyOpenSSL.
+
+Issues Resolved
+...............
+
+See the `PyMongo 4.13.2 release notes in JIRA`_ for the list of resolved issues
+in this release.
+
+.. _PyMongo 4.13.2 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=43937
+
 Changes in Version 4.13.1 (2025/06/10)
 --------------------------------------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 Changes in Version 4.13.2 (2025/06/17)
 --------------------------------------
 
-Version 4.13.1 is a bug fix release.
+Version 4.13.2 is a bug fix release.
 
 - Fixed a bug that resulted in confusing error messages after hostname verification errors when using PyOpenSSL.
 

--- a/pymongo/pyopenssl_context.py
+++ b/pymongo/pyopenssl_context.py
@@ -420,9 +420,9 @@ class SSLContext:
                         pyopenssl.verify_ip_address(ssl_conn, server_hostname)
                     else:
                         pyopenssl.verify_hostname(ssl_conn, server_hostname)
-                except (  # type:ignore[misc]
-                    service_identity.SICertificateError,
-                    service_identity.SIVerificationError,
+                except (
+                    service_identity.CertificateError,
+                    service_identity.VerificationError,
                 ) as exc:
                     raise _CertificateError(str(exc)) from None
         return ssl_conn

--- a/test/asynchronous/test_ssl.py
+++ b/test/asynchronous/test_ssl.py
@@ -323,7 +323,7 @@ class TestSSL(AsyncIntegrationTest):
 
         response = await self.client.admin.command(HelloCompat.LEGACY_CMD)
 
-        with self.assertRaises(ConnectionFailure):
+        with self.assertRaises(ConnectionFailure) as cm:
             await connected(
                 self.simple_client(
                     "server",
@@ -335,6 +335,8 @@ class TestSSL(AsyncIntegrationTest):
                     **self.credentials,  # type: ignore[arg-type]
                 )
             )
+        # PYTHON-5414 Check for "module service_identity has no attribute SICertificateError"
+        self.assertNotIn("has no attribute", str(cm.exception))
 
         await connected(
             self.simple_client(

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -323,7 +323,7 @@ class TestSSL(IntegrationTest):
 
         response = self.client.admin.command(HelloCompat.LEGACY_CMD)
 
-        with self.assertRaises(ConnectionFailure):
+        with self.assertRaises(ConnectionFailure) as cm:
             connected(
                 self.simple_client(
                     "server",
@@ -335,6 +335,8 @@ class TestSSL(IntegrationTest):
                     **self.credentials,  # type: ignore[arg-type]
                 )
             )
+        # PYTHON-5414 Check for "module service_identity has no attribute SICertificateError"
+        self.assertNotIn("has no attribute", str(cm.exception))
 
         connected(
             self.simple_client(


### PR DESCRIPTION
Backports:  https://github.com/mongodb/mongo-python-driver/commit/c2aefc2edab2c34d10e34d69793431b0d6800d24 and https://github.com/mongodb/mongo-python-driver/commit/c16ef0a13e97dd04d1f4234f21ecda0627aaee8c for PYTHON-5414.