### PR TITLE
PYTHON-5343 Clean up contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ the pages will re-render and the browser will automatically refresh.
     version of Python, remove the `.venv` folder and set `PYTHON_BINARY` before running `just install`.
 -   Ensure you have started the appropriate Mongo Server(s).  You can run `just run-server` with optional args
     to set up the server.  All given options will be passed to
-    `run-orchestration.sh` in `$DRIVERS_TOOLS`.  See `$DRIVERS_TOOLS/evergreen/run-orchestration.sh -h`
+    [`run-orchestration.sh`](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/run-orchestration.sh).  Run `$DRIVERS_TOOLS/evergreen/run-orchestration.sh -h`
     for a full list of options.
 -   Run `just test` or `pytest` to run all of the tests.
 -   Append `test/<mod_name>.py::<class_name>::<test_name>` to run
@@ -229,9 +229,10 @@ the pages will re-render and the browser will automatically refresh.
 
 - Run `just run-server --ssl` to start the server with TLS enabled.
 - Run `just setup-tests --ssl`.
-- Run `just run-tests`
+- Run `just run-tests`.
 
-Note: for general testing purposes with an TLS-enabled server, you can use the following:
+Note: for general testing purposes with an TLS-enabled server, you can use the following (this should ONLY be used
+for local testing):
 
 ```python
 from pymongo import MongoClient


### PR DESCRIPTION
- Moves the SSL considerations from the Team Practices document to the contributing guide
- Cleans up the instructions for starting a server
- Specifies that secrets are only required for certain tests