### PR TITLE
PYTHON-5126 - Implemented new test cases for Binary Vector

### DIFF
--- a/bson/binary.py
+++ b/bson/binary.py
@@ -490,6 +490,11 @@ class Binary(bytes):
         dtype = BinaryVectorDtype(dtype)
         n_values = len(self) - position
 
+        if padding and dtype != BinaryVectorDtype.PACKED_BIT:
+            raise ValueError(
+                f"Corrupt data. Padding ({padding}) must be 0 for all but PACKED_BIT dtypes. ({dtype=})"
+            )
+
         if dtype == BinaryVectorDtype.INT8:
             dtype_format = "b"
             format_string = f"<{n_values}{dtype_format}"
@@ -510,6 +515,10 @@ class Binary(bytes):
 
         elif dtype == BinaryVectorDtype.PACKED_BIT:
             # data packed as uint8
+            if padding and not n_values:
+                raise ValueError("Corrupt data. Vector has a padding P, but no data.")
+            if padding > 7 or padding < 0:
+                raise ValueError(f"Corrupt data. Padding ({padding}) must be between 0 and 7.")
             dtype_format = "B"
             format_string = f"<{n_values}{dtype_format}"
             unpacked_uint8s = list(struct.unpack_from(format_string, self, position))

--- a/test/bson_binary_vector/packed_bit.json
+++ b/test/bson_binary_vector/packed_bit.json
@@ -21,6 +21,15 @@
       "canonical_bson": "1600000005766563746F7200040000000910007F0700"
     },
     {
+      "description": "PACKED_BIT with padding",
+      "valid": true,
+      "vector": [127, 8],
+      "dtype_hex": "0x10",
+      "dtype_alias": "PACKED_BIT",
+      "padding": 3,
+      "canonical_bson": "1600000005766563746F7200040000000910037F0800"
+    },
+    {
       "description": "Empty Vector PACKED_BIT",
       "valid": true,
       "vector": [],
@@ -28,15 +37,6 @@
       "dtype_alias": "PACKED_BIT",
       "padding": 0,
       "canonical_bson": "1400000005766563746F72000200000009100000"
-    },
-    {
-      "description": "PACKED_BIT with padding",
-      "valid": true,
-      "vector": [127, 7],
-      "dtype_hex": "0x10",
-      "dtype_alias": "PACKED_BIT",
-      "padding": 3,
-      "canonical_bson": "1600000005766563746F7200040000000910037F0700"
     },
     {
       "description": "Overflow Vector PACKED_BIT",


### PR DESCRIPTION
This PR simply adds new invalid cases that @qingyang-hu had added. This had been done long ago, but we're splitting the python changes out from those specifically related to ignored bit in packed_bit dtype.