### PR TITLE
PYTHON-5423 Always use subprocess.run instead of subprocess.check_call or subprocess.call

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -19,7 +19,7 @@ class CustomHook(BuildHookInterface):
         here = Path(__file__).parent.resolve()
         sys.path.insert(0, str(here))
 
-        subprocess.check_call([sys.executable, "_setup.py", "build_ext", "-i"])
+        subprocess.run([sys.executable, "_setup.py", "build_ext", "-i"], check=True)
 
         # Ensure wheel is marked as binary and contains the binary files.
         build_data["infer_tag"] = True

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -369,7 +369,7 @@ class ClientContext:
         if self._fips_enabled is not None:
             return self._fips_enabled
         try:
-            subprocess.check_call(["fips-mode-setup", "--is-enabled"])
+            subprocess.run(["fips-mode-setup", "--is-enabled"], check=True)
             self._fips_enabled = True
         except (subprocess.SubprocessError, FileNotFoundError):
             self._fips_enabled = False

--- a/test/asynchronous/__init__.py
+++ b/test/asynchronous/__init__.py
@@ -369,7 +369,7 @@ class AsyncClientContext:
         if self._fips_enabled is not None:
             return self._fips_enabled
         try:
-            subprocess.check_call(["fips-mode-setup", "--is-enabled"])
+            subprocess.run(["fips-mode-setup", "--is-enabled"], check=True)
             self._fips_enabled = True
         except (subprocess.SubprocessError, FileNotFoundError):
             self._fips_enabled = False


### PR DESCRIPTION
Didn't find any instances of `subprocess.call` and all (three) instances of `subprocess.check_call(...)` are now `subprocess.run(..., check=True)`