### PR TITLE
PYTHON-5421 Make parse_uri() return "options" as a dict rather than _CaseInsensitiveDictionary

### DIFF
--- a/pymongo/asynchronous/uri_parser.py
+++ b/pymongo/asynchronous/uri_parser.py
@@ -184,5 +184,5 @@ async def _parse_srv(
 
     return {
         "nodelist": nodes,
-        "options": options,
+        "options": options.as_dict(),
     }

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -1083,6 +1083,9 @@ class _CaseInsensitiveDictionary(MutableMapping[str, Any]):
     def cased_key(self, key: str) -> Any:
         return self.__casedkeys[key.lower()]
 
+    def as_dict(self) -> dict[str, Any]:
+        return {self.__casedkeys[k]: self.__data[k] for k in self}
+
 
 def has_c() -> bool:
     """Is the C extension installed?"""

--- a/pymongo/synchronous/uri_parser.py
+++ b/pymongo/synchronous/uri_parser.py
@@ -184,5 +184,5 @@ def _parse_srv(
 
     return {
         "nodelist": nodes,
-        "options": options,
+        "options": options.as_dict(),
     }

--- a/pymongo/uri_parser_shared.py
+++ b/pymongo/uri_parser_shared.py
@@ -547,6 +547,6 @@ def _validate_uri(
         "password": passwd,
         "database": dbase,
         "collection": collection,
-        "options": options,
+        "options": options.as_dict(),
         "fqdn": fqdn,
     }


### PR DESCRIPTION
- Added a method to _CaseInsensitiveDictionary to return itself as a plain dict
- parse_uri now returns "options" as a plain dict: 
```
>>> from pymongo.uri_parser import parse_uri
>>> type(parse_uri("mongodb://cluster0.example.mongodb.net/myDatabase?retryWrit\
es=true&retryReads=true").get("options"))
<class 'dict'>
```