### PR TITLE
PYTHON-4779 Use slots for Selection and TopologyDescription

### DIFF
--- a/pymongo/server_selectors.py
+++ b/pymongo/server_selectors.py
@@ -32,6 +32,8 @@ TagSets = Sequence[TagSet]
 class Selection:
     """Input or output of a server selector function."""
 
+    __slots__ = ("totopology_description", "server_descriptions", "primary", "common_wire_version")
+
     @classmethod
     def from_topology_description(cls, topology_description: TopologyDescription) -> Selection:
         known_servers = topology_description.known_servers

--- a/pymongo/server_selectors.py
+++ b/pymongo/server_selectors.py
@@ -32,7 +32,7 @@ TagSets = Sequence[TagSet]
 class Selection:
     """Input or output of a server selector function."""
 
-    __slots__ = ("totopology_description", "server_descriptions", "primary", "common_wire_version")
+    __slots__ = ("topology_description", "server_descriptions", "primary", "common_wire_version")
 
     @classmethod
     def from_topology_description(cls, topology_description: TopologyDescription) -> Selection:

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -61,6 +61,16 @@ _ServerSelector = Callable[[List[ServerDescription]], List[ServerDescription]]
 
 
 class TopologyDescription:
+    __slots__ = (
+        "_topology_type",
+        "_replica_set_name",
+        "_server_descriptions",
+        "_max_set_version",
+        "_max_election_id",
+        "_incompatible_err",
+        "_ls_timeout_minutes",
+    )
+
     def __init__(
         self,
         topology_type: int,

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -63,6 +63,7 @@ _ServerSelector = Callable[[List[ServerDescription]], List[ServerDescription]]
 class TopologyDescription:
     __slots__ = (
         "_topology_type",
+        "_topology_settings",
         "_replica_set_name",
         "_server_descriptions",
         "_max_set_version",


### PR DESCRIPTION
I ran a perf build: https://spruce.mongodb.com/task/mongo_python_driver_performance_benchmarks_perf_8.0_standalone_patch_578c6c2ad2559c4c939c682151eeeaf3b847ab3e_68643055c8c88400072d3e1b_25_07_01_19_00_56/trend-charts?execution=0

I did not see an appreciable change in FindOneByID8Threads or SmallDocInsertOne, unfortunately.