### PR TITLE
PYTHON-4780 Implement fast path for server selection with Primary

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,16 +17,5 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1
-      - name: Get zizmor
-        run: cargo install zizmor
       - name: Run zizmor 🌈
-        run: zizmor --format sarif . > results.sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@39edc492dbe16b1465b0cafca41432d857bdb31a # v3
-        with:
-          sarif_file: results.sarif
-          category: zizmor
+        uses: zizmorcore/zizmor-action@1cc8f934e6fad1414fbfc420bd02b0c325d9daab # v1.11.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@1cc8f934e6fad1414fbfc420bd02b0c325d9daab # v1.11.0
+        uses: zizmorcore/zizmor-action@1c7106082dbc1753372e3924b7da1b9417011a21

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ a native Python driver for MongoDB, offering both synchronous and asynchronous A
 [gridfs](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.md/)
 implementation on top of `pymongo`.
 
-PyMongo supports MongoDB 4.0, 4.2, 4.4, 5.0, 6.0, 7.0, and 8.0. PyMongo follows [semantic versioning](https://semver.org/spec/v2.0.0.html) for its releases. 
+PyMongo supports MongoDB 4.0, 4.2, 4.4, 5.0, 6.0, 7.0, and 8.0. PyMongo follows [semantic versioning](https://semver.org/spec/v2.0.0.html) for its releases.
 
 ## Support / Feedback
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,7 @@ PyMongo 4.14 brings a number of changes including:
 - Added :meth:`pymongo.asynchronous.mongo_client.AsyncMongoClient.append_metadata` and
   :meth:`pymongo.mongo_client.MongoClient.append_metadata` to allow instantiated MongoClients to send client metadata
   on-demand
+- Improved performance of selecting a server with the Primary selector.
 
 - Introduces a minor breaking change. When encoding :class:`bson.binary.BinaryVector`, a ``ValueError`` will be raised
   if the 'padding' metadata field is < 0 or > 7, or non-zero for any type other than PACKED_BIT.

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -325,9 +325,7 @@ class TopologyDescription:
             return [description] if description else []
 
         # Primary selection fast path.
-        if self.topology_type == TOPOLOGY_TYPE.ReplicaSetWithPrimary and isinstance(
-            selector, Primary
-        ):
+        if self.topology_type == TOPOLOGY_TYPE.ReplicaSetWithPrimary and type(selector) is Primary:
             for sd in self._server_descriptions.values():
                 if sd.server_type == SERVER_TYPE.RSPrimary:
                     return [sd]

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -324,6 +324,14 @@ class TopologyDescription:
             description = self.server_descriptions().get(address)
             return [description] if description else []
 
+        # Primary selection fast path.
+        if self.topology_type == TOPOLOGY_TYPE.ReplicaSetWithPrimary and isinstance(
+            selector, TOPOLOGY_TYPE.Primary
+        ):
+            for sd in self._server_descriptions.values():
+                if sd.server_type == SERVER_TYPE.RSPrimary:
+                    return [sd]
+
         selection = Selection.from_topology_description(self)
         # Ignore read preference for sharded clusters.
         if self.topology_type != TOPOLOGY_TYPE.Sharded:

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -34,7 +34,7 @@ from bson.min_key import MinKey
 from bson.objectid import ObjectId
 from pymongo import common
 from pymongo.errors import ConfigurationError, PyMongoError
-from pymongo.read_preferences import ReadPreference, _AggWritePref, _ServerMode
+from pymongo.read_preferences import Primary, ReadPreference, _AggWritePref, _ServerMode
 from pymongo.server_description import ServerDescription
 from pymongo.server_selectors import Selection
 from pymongo.server_type import SERVER_TYPE
@@ -326,7 +326,7 @@ class TopologyDescription:
 
         # Primary selection fast path.
         if self.topology_type == TOPOLOGY_TYPE.ReplicaSetWithPrimary and isinstance(
-            selector, TOPOLOGY_TYPE.Primary
+            selector, Primary
         ):
             for sd in self._server_descriptions.values():
                 if sd.server_type == SERVER_TYPE.RSPrimary:

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -325,11 +325,7 @@ class TopologyDescription:
             return [description] if description else []
 
         # Primary selection fast path.
-        if (
-            custom_selector is None
-            and self.topology_type == TOPOLOGY_TYPE.ReplicaSetWithPrimary
-            and type(selector) is Primary
-        ):
+        if self.topology_type == TOPOLOGY_TYPE.ReplicaSetWithPrimary and type(selector) is Primary:
             for sd in self._server_descriptions.values():
                 if sd.server_type == SERVER_TYPE.RSPrimary:
                     sds = [sd]

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -325,10 +325,17 @@ class TopologyDescription:
             return [description] if description else []
 
         # Primary selection fast path.
-        if self.topology_type == TOPOLOGY_TYPE.ReplicaSetWithPrimary and type(selector) is Primary:
+        if (
+            custom_selector is None
+            and self.topology_type == TOPOLOGY_TYPE.ReplicaSetWithPrimary
+            and type(selector) is Primary
+        ):
             for sd in self._server_descriptions.values():
                 if sd.server_type == SERVER_TYPE.RSPrimary:
-                    return [sd]
+                    sds = [sd]
+                    if custom_selector:
+                        sds = custom_selector(sds)
+                    return sds
             # No primary found, return an empty list.
             return []
 

--- a/test/asynchronous/test_server_selection.py
+++ b/test/asynchronous/test_server_selection.py
@@ -130,12 +130,12 @@ class TestCustomServerSelectorFunction(AsyncIntegrationTest):
         test_collection = mongo_client.testdb.test_collection
         self.addAsyncCleanup(mongo_client.drop_database, "testdb")
 
-        # Do N operations and test selector is called at least N times.
+        # Do N operations and test selector is called at least N-1 times due to fast path.
         await test_collection.insert_one({"age": 20, "name": "John"})
         await test_collection.insert_one({"age": 31, "name": "Jane"})
         await test_collection.update_one({"name": "Jane"}, {"$set": {"age": 21}})
         await test_collection.find_one({"name": "Roe"})
-        self.assertGreaterEqual(selector.call_count, 4)
+        self.assertGreaterEqual(selector.call_count, 3)
 
     @async_client_context.require_replica_set
     async def test_latency_threshold_application(self):

--- a/test/test_server_selection.py
+++ b/test/test_server_selection.py
@@ -130,12 +130,12 @@ class TestCustomServerSelectorFunction(IntegrationTest):
         test_collection = mongo_client.testdb.test_collection
         self.addCleanup(mongo_client.drop_database, "testdb")
 
-        # Do N operations and test selector is called at least N times.
+        # Do N operations and test selector is called at least N-1 times due to fast path.
         test_collection.insert_one({"age": 20, "name": "John"})
         test_collection.insert_one({"age": 31, "name": "Jane"})
         test_collection.update_one({"name": "Jane"}, {"$set": {"age": 21}})
         test_collection.find_one({"name": "Roe"})
-        self.assertGreaterEqual(selector.call_count, 4)
+        self.assertGreaterEqual(selector.call_count, 3)
 
     @client_context.require_replica_set
     def test_latency_threshold_application(self):

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -30,7 +30,7 @@ from bson.objectid import ObjectId
 from pymongo import common
 from pymongo.errors import AutoReconnect, ConfigurationError, ConnectionFailure
 from pymongo.hello import Hello, HelloCompat
-from pymongo.read_preferences import ReadPreference, Secondary
+from pymongo.read_preferences import Primary, ReadPreference, Secondary
 from pymongo.server_description import ServerDescription
 from pymongo.server_selectors import any_server_selector, writable_server_selector
 from pymongo.server_type import SERVER_TYPE
@@ -51,7 +51,10 @@ address = ("a", 27017)
 
 
 def create_mock_topology(
-    seeds=None, replica_set_name=None, monitor_class=DummyMonitor, direct_connection=False
+    seeds=None,
+    replica_set_name=None,
+    monitor_class=DummyMonitor,
+    direct_connection=False,
 ):
     partitioned_seeds = list(map(common.partition_node, seeds or ["a"]))
     topology_settings = TopologySettings(
@@ -122,6 +125,25 @@ class TestTopologyConfiguration(TopologyTest):
 
         # The monitor, not its pool, is responsible for calling hello.
         self.assertTrue(monitor._pool.is_sdam)
+
+    def test_selector_fast_path(self):
+        topology = create_mock_topology(seeds=["a", "b:27018"], replica_set_name="foo")
+        description = topology.description
+        description._topology_type = TOPOLOGY_TYPE.ReplicaSetWithPrimary
+
+        # There is no primary yet, so it should give an empty list.
+        self.assertEqual(description.apply_selector(Primary()), [])
+
+        # If we set a primary server, we should get it back.
+        sd = list(description._server_descriptions.values())[0]
+        sd._server_type = SERVER_TYPE.RSPrimary
+        self.assertEqual(description.apply_selector(Primary()), [sd])
+
+        # If there is a custom selector, it should be applied.
+        def custom_selector(servers):
+            return []
+
+        self.assertEqual(description.apply_selector(Primary(), custom_selector=custom_selector), [])
 
 
 class TestSingleServerTopology(TopologyTest):


### PR DESCRIPTION
Tested with the following script:

```python
from pymongo import MongoClient
from pymongo.read_preferences import ReadPreference
from concurrent.futures import ThreadPoolExecutor, wait

client = MongoClient()
session = client.start_session()
read_preference = ReadPreference.PRIMARY


def test():
    for i in range(100):
        client._select_server(read_preference, session, "testOperation")



def test2_target():
    client._select_server(read_preference, session, "testOperation")


def test2():
    futures = []
    with ThreadPoolExecutor(max_workers=100) as pool:
        for i in range(100):
            futures.append(pool.submit(test2_target))
        wait(futures)
    

if __name__ == '__main__':
    import timeit
    print(timeit.timeit("test()", setup="from __main__ import test, client, read_preference, session", number=1000))
    print(timeit.timeit("test2()", setup="from __main__ import test2, client, read_preference, session", number=1000))
```


On `master`:
0.4806627919897437
1.5110677920019953

With this change:
0.17988054199668113
1.233099208009662
