### PR TITLE
PYTHON-5421 continued - update changelog, update docstring, and add testing

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ PyMongo 4.14 brings a number of changes including:
 
 - Introduces a minor breaking change. When encoding :class:`bson.binary.BinaryVector`, a ``ValueError`` will be raised
   if the 'padding' metadata field is < 0 or > 7, or non-zero for any type other than PACKED_BIT.
+- Changed :meth:`~pymongo.uri_parser.parse_uri`'s 'options' to be type ``dict`` instead of ``_CaseInsensitiveDictionary``.
 
 Changes in Version 4.13.2 (2025/06/17)
 --------------------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,7 +13,7 @@ PyMongo 4.14 brings a number of changes including:
 
 - Introduces a minor breaking change. When encoding :class:`bson.binary.BinaryVector`, a ``ValueError`` will be raised
   if the 'padding' metadata field is < 0 or > 7, or non-zero for any type other than PACKED_BIT.
-- Changed :meth:`~pymongo.uri_parser.parse_uri`'s 'options' to be type ``dict`` instead of ``_CaseInsensitiveDictionary``.
+- Changed :meth:`~pymongo.uri_parser.parse_uri`'s ``options`` parameter to be type ``dict`` instead of ``_CaseInsensitiveDictionary``.
 
 Changes in Version 4.13.2 (2025/06/17)
 --------------------------------------

--- a/pymongo/asynchronous/uri_parser.py
+++ b/pymongo/asynchronous/uri_parser.py
@@ -81,7 +81,7 @@ async def parse_uri(
     :param srv_service_name: A custom SRV service name
 
     .. versionchanged:: 4.14
-       'options' is now type ``dict`` as opposed to a ``_CaseInsensitiveDictionary``.
+       ``options`` is now type ``dict`` as opposed to a ``_CaseInsensitiveDictionary``.
 
     .. versionchanged:: 4.6
        The delimiting slash (``/``) between hosts and connection options is now optional.

--- a/pymongo/asynchronous/uri_parser.py
+++ b/pymongo/asynchronous/uri_parser.py
@@ -80,6 +80,9 @@ async def parse_uri(
           wait for a response from the DNS server.
     :param srv_service_name: A custom SRV service name
 
+    .. versionchanged:: 4.14
+       'options' is now type ``dict`` as opposed to a ``_CaseInsensitiveDictionary``.
+
     .. versionchanged:: 4.6
        The delimiting slash (``/``) between hosts and connection options is now optional.
        For example, "mongodb://example.com?tls=true" is now a valid URI.

--- a/pymongo/synchronous/uri_parser.py
+++ b/pymongo/synchronous/uri_parser.py
@@ -81,7 +81,7 @@ def parse_uri(
     :param srv_service_name: A custom SRV service name
 
     .. versionchanged:: 4.14
-       'options' is now type ``dict`` as opposed to a ``_CaseInsensitiveDictionary``.
+       ``options`` is now type ``dict`` as opposed to a ``_CaseInsensitiveDictionary``.
 
     .. versionchanged:: 4.6
        The delimiting slash (``/``) between hosts and connection options is now optional.

--- a/pymongo/synchronous/uri_parser.py
+++ b/pymongo/synchronous/uri_parser.py
@@ -80,6 +80,9 @@ def parse_uri(
           wait for a response from the DNS server.
     :param srv_service_name: A custom SRV service name
 
+    .. versionchanged:: 4.14
+       'options' is now type ``dict`` as opposed to a ``_CaseInsensitiveDictionary``.
+
     .. versionchanged:: 4.6
        The delimiting slash (``/``) between hosts and connection options is now optional.
        For example, "mongodb://example.com?tls=true" is now a valid URI.

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -555,6 +555,10 @@ class TestURI(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"Port contains whitespace character: '\\n'"):
             parse_uri("mongodb://localhost:27\n017")
 
+    def test_parse_uri_options_type(self):
+        opts = parse_uri("mongodb://localhost:27017")["options"]
+        self.assertIsInstance(opts, dict)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
follow up PR to https://github.com/mongodb/mongo-python-driver/pull/2413

