### PR TITLE
PYTHON-5429 Server command is case sensitive

### DIFF
--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -2311,7 +2311,7 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
         return cast(
             dict,
             await self.admin.command(
-                "buildinfo", read_preference=ReadPreference.PRIMARY, session=session
+                "buildInfo", read_preference=ReadPreference.PRIMARY, session=session
             ),
         )
 

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -2303,7 +2303,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
         return cast(
             dict,
             self.admin.command(
-                "buildinfo", read_preference=ReadPreference.PRIMARY, session=session
+                "buildInfo", read_preference=ReadPreference.PRIMARY, session=session
             ),
         )
 


### PR DESCRIPTION
Via Erwin Pe, "libmongocrypt does case sensitive comparison of command names against the list of eligible commands."