### PR TITLE
PYTHON-5373 test client auth on cloud-dev

### DIFF
--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -75,6 +75,8 @@ buildvariants:
     display_name: Atlas connect RHEL8
     run_on:
       - rhel87-small
+    expansions:
+      TEST_NAME: atlas_connect
     tags: [pr]
 
   # Atlas data lake tests

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -425,7 +425,7 @@ def create_atlas_connect_variants():
             get_variant_name("Atlas connect", host),
             tags=["pr"],
             host=DEFAULT_HOST,
-            expansions = dict(TEST_NAME="atlas_connect")
+            expansions=dict(TEST_NAME="atlas_connect"),
         )
     ]
 

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -425,6 +425,7 @@ def create_atlas_connect_variants():
             get_variant_name("Atlas connect", host),
             tags=["pr"],
             host=DEFAULT_HOST,
+            expansions = dict(TEST_NAME="atlas_connect")
         )
     ]
 

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -417,7 +417,15 @@ def handle_test_env() -> None:
             run_command(f"bash {auth_aws_dir}/setup-secrets.sh")
 
     if test_name == "atlas_connect":
-        get_secrets("drivers/atlas_connect")
+        secrets = get_secrets("drivers/atlas_connect")
+
+        # Write file with Atlas X509 client certificate:
+        decoded = base64.b64decode(secrets["ATLAS_X509_DEV_CERT_BASE64"]).decode("utf8")
+        cert_file = ROOT / ".evergreen/atlas_x509_dev_client_certificate.pem"
+        with cert_file.open("w") as file:
+            file.write(decoded)
+        write_env("ATLAS_X509_DEV_WITH_CERT", secrets["ATLAS_X509_DEV"] + "&tlsCertificateKeyFile=" + str(cert_file))
+
         # We do not want the default client_context to be initialized.
         write_env("DISABLE_CONTEXT")
 

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -424,7 +424,10 @@ def handle_test_env() -> None:
         cert_file = ROOT / ".evergreen/atlas_x509_dev_client_certificate.pem"
         with cert_file.open("w") as file:
             file.write(decoded)
-        write_env("ATLAS_X509_DEV_WITH_CERT", secrets["ATLAS_X509_DEV"] + "&tlsCertificateKeyFile=" + str(cert_file))
+        write_env(
+            "ATLAS_X509_DEV_WITH_CERT",
+            secrets["ATLAS_X509_DEV"] + "&tlsCertificateKeyFile=" + str(cert_file),
+        )
 
         # We do not want the default client_context to be initialized.
         write_env("DISABLE_CONTEXT")

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ expansion.yml
 .evergreen/scripts/test-env.sh
 specifications/
 results.json
+.evergreen/atlas_x509_dev_client_certificate.pem
 
 # Lambda temp files
 test/lambda/.aws-sam

--- a/test/atlas/test_connection.py
+++ b/test/atlas/test_connection.py
@@ -42,6 +42,7 @@ URIS = {
     "ATLAS_SRV_FREE": os.environ.get("ATLAS_SRV_FREE"),
     "ATLAS_SRV_TLS11": os.environ.get("ATLAS_SRV_TLS11"),
     "ATLAS_SRV_TLS12": os.environ.get("ATLAS_SRV_TLS12"),
+    "ATLAS_X509_DEV_WITH_CERT": os.environ.get("ATLAS_X509_DEV_WITH_CERT"),
 }
 
 
@@ -90,6 +91,9 @@ class TestAtlasConnect(PyMongoTestCase):
 
     def test_srv_tls_12(self):
         self.connect_srv(URIS["ATLAS_SRV_TLS12"])
+
+    def test_x509_with_cert(self):
+        self.connect(URIS["ATLAS_X509_DEV_WITH_CERT"])
 
     def test_uniqueness(self):
         """Ensure that we don't accidentally duplicate the test URIs."""


### PR DESCRIPTION
# Summary
Resolves PYTHON-5373. Test MONGODB-X509 auth with Atlas on cloud-dev.

# Background & Motivation

Includes a follow-up to https://github.com/mongodb/mongo-python-driver/pull/2284 to add the expansion `TEST_NAME: atlas_connect` on the `Atlas connect RHEL8` variant to restore running the `TestAtlasConnect` tests. Tests were run in this [patch build](https://spruce.mongodb.com/version/686c2e96c75aca0007cc5ef3) (logs now show `TestAtlasConnect`).

Tests store the client certificate to the path: `.evergreen/atlas_x509_dev_client_certificate.pem`. This is similarly done for the [keytab file](https://github.com/mongodb/mongo-python-driver/blob/c77c15e369ddb9d9c63abb0adb9ac7d3f8ab11ef/.evergreen/scripts/setup_tests.py#L262). A [code scan alert](https://github.com/mongodb/mongo-python-driver/security/code-scanning/214) was dismissed due to being intentional.
