### PR TITLE
PYTHON-5315 Mark test_recover_from_initially_erroring_seedlist as flaky

### DIFF
--- a/test/asynchronous/test_cursor.py
+++ b/test/asynchronous/test_cursor.py
@@ -1411,7 +1411,7 @@ class TestCursor(AsyncIntegrationTest):
     async def test_to_list_csot_applied(self):
         client = await self.async_single_client(timeoutMS=500, w=1)
         coll = client.pymongo.test
-        # Initialize the client with a larger timeout to help make test less flakey
+        # Initialize the client with a larger timeout to help make test less flaky
         with pymongo.timeout(10):
             await coll.insert_many([{} for _ in range(5)])
         cursor = coll.find({"$where": delay(1)})
@@ -1453,7 +1453,7 @@ class TestCursor(AsyncIntegrationTest):
     async def test_command_cursor_to_list_csot_applied(self):
         client = await self.async_single_client(timeoutMS=500, w=1)
         coll = client.pymongo.test
-        # Initialize the client with a larger timeout to help make test less flakey
+        # Initialize the client with a larger timeout to help make test less flaky
         with pymongo.timeout(10):
             await coll.insert_many([{} for _ in range(5)])
         fail_command = {

--- a/test/asynchronous/test_retryable_reads.py
+++ b/test/asynchronous/test_retryable_reads.py
@@ -87,7 +87,7 @@ class TestPoolPausedError(AsyncIntegrationTest):
     async def test_pool_paused_error_is_retryable(self):
         if "PyPy" in sys.version:
             # Tracked in PYTHON-3519
-            self.skipTest("Test is flakey on PyPy")
+            self.skipTest("Test is flaky on PyPy")
         cmap_listener = CMAPListener()
         cmd_listener = OvertCommandListener()
         client = await self.async_rs_or_single_client(

--- a/test/asynchronous/test_srv_polling.py
+++ b/test/asynchronous/test_srv_polling.py
@@ -262,6 +262,7 @@ class TestSrvPolling(AsyncPyMongoTestCase):
 
         await self._test_recover_from_initial(empty_seedlist)
 
+    @flaky(reason="PYTHON-5315")
     async def test_recover_from_initially_erroring_seedlist(self):
         def erroring_seedlist():
             raise ConfigurationError

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -1402,7 +1402,7 @@ class TestCursor(IntegrationTest):
     def test_to_list_csot_applied(self):
         client = self.single_client(timeoutMS=500, w=1)
         coll = client.pymongo.test
-        # Initialize the client with a larger timeout to help make test less flakey
+        # Initialize the client with a larger timeout to help make test less flaky
         with pymongo.timeout(10):
             coll.insert_many([{} for _ in range(5)])
         cursor = coll.find({"$where": delay(1)})
@@ -1444,7 +1444,7 @@ class TestCursor(IntegrationTest):
     def test_command_cursor_to_list_csot_applied(self):
         client = self.single_client(timeoutMS=500, w=1)
         coll = client.pymongo.test
-        # Initialize the client with a larger timeout to help make test less flakey
+        # Initialize the client with a larger timeout to help make test less flaky
         with pymongo.timeout(10):
             coll.insert_many([{} for _ in range(5)])
         fail_command = {

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -87,7 +87,7 @@ class TestPoolPausedError(IntegrationTest):
     def test_pool_paused_error_is_retryable(self):
         if "PyPy" in sys.version:
             # Tracked in PYTHON-3519
-            self.skipTest("Test is flakey on PyPy")
+            self.skipTest("Test is flaky on PyPy")
         cmap_listener = CMAPListener()
         cmd_listener = OvertCommandListener()
         client = self.rs_or_single_client(

--- a/test/test_srv_polling.py
+++ b/test/test_srv_polling.py
@@ -262,6 +262,7 @@ class TestSrvPolling(PyMongoTestCase):
 
         self._test_recover_from_initial(empty_seedlist)
 
+    @flaky(reason="PYTHON-5315")
     def test_recover_from_initially_erroring_seedlist(self):
         def erroring_seedlist():
             raise ConfigurationError


### PR DESCRIPTION
This was missed in #2395.

Also corrects the less common spelling of "flakey" to ensure search-ability.