### PR TITLE
PYTHON-5289 Fixes indentation in docstring of Binary.from_vector

### DIFF
--- a/bson/binary.py
+++ b/bson/binary.py
@@ -444,7 +444,7 @@ class Binary(bytes):
         :return: Binary packed data identified by dtype and padding.
 
         .. versionchanged:: 4.14
-        When padding is non-zero, ignored bits should be zero. Raise exception on encoding, warn on decoding.
+           When padding is non-zero, ignored bits should be zero. Raise exception on encoding, warn on decoding.
 
         .. versionadded:: 4.10
         """


### PR DESCRIPTION
`just docs` was failing and wasn't picked up during code review.