### PR TITLE
PYTHON-4019 Infinite loop in generic transactional provider due to dup keys

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -86,6 +86,7 @@ pygments_style = "sphinx"
 # sourceforge.net is giving a 403 error, but is still accessible from the browser.
 linkcheck_ignore = [
     "https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-monitoring.md#requesting-an-immediate-check",
+    "https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.md#handling-errors-inside-the-callback",
     "https://github.com/mongodb/libmongocrypt/blob/master/bindings/python/README.rst#installing-from-source",
     r"https://wiki.centos.org/[\w/]*",
     r"https://sourceforge.net/",

--- a/pymongo/asynchronous/client_session.py
+++ b/pymongo/asynchronous/client_session.py
@@ -663,7 +663,8 @@ class AsyncClientSession:
         The ``callback`` MUST NOT silently handle command errors
         without allowing such errors to propagate. Command errors may abort the
         transaction on the server, and an attempt to commit the transaction will
-        be rejected with a ``NoSuchTransaction`` error.
+        be rejected with a ``NoSuchTransaction`` error.  For more information see
+        the `transactions specification`_.
 
         When :meth:`~AsyncClientSession.commit_transaction` raises an exception with
         the ``"UnknownTransactionCommitResult"`` error label,
@@ -694,6 +695,9 @@ class AsyncClientSession:
         :return: The return value of the ``callback``.
 
         .. versionadded:: 3.9
+
+        .. _tranactions specification:
+            https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.md#handling-errors-inside-the-callback
         """
         start_time = time.monotonic()
         while True:

--- a/pymongo/asynchronous/client_session.py
+++ b/pymongo/asynchronous/client_session.py
@@ -696,7 +696,7 @@ class AsyncClientSession:
 
         .. versionadded:: 3.9
 
-        .. _tranactions specification:
+        .. _transactions specification:
             https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.md#handling-errors-inside-the-callback
         """
         start_time = time.monotonic()

--- a/pymongo/asynchronous/client_session.py
+++ b/pymongo/asynchronous/client_session.py
@@ -660,6 +660,11 @@ class AsyncClientSession:
         ``with_transaction`` starts a new transaction and re-executes
         the ``callback``.
 
+        The ``callback`` MUST NOT silently handle command errors
+        without allowing such errors to propagate. Command errors may abort the
+        transaction on the server, and an attempt to commit the transaction will
+        be rejected with a ``NoSuchTransaction`` error.
+
         When :meth:`~AsyncClientSession.commit_transaction` raises an exception with
         the ``"UnknownTransactionCommitResult"`` error label,
         ``with_transaction`` retries the commit until the result of the

--- a/pymongo/synchronous/client_session.py
+++ b/pymongo/synchronous/client_session.py
@@ -662,7 +662,8 @@ class ClientSession:
         The ``callback`` MUST NOT silently handle command errors
         without allowing such errors to propagate. Command errors may abort the
         transaction on the server, and an attempt to commit the transaction will
-        be rejected with a ``NoSuchTransaction`` error.
+        be rejected with a ``NoSuchTransaction`` error.  For more information see
+        the `transactions specification`_.
 
         When :meth:`~ClientSession.commit_transaction` raises an exception with
         the ``"UnknownTransactionCommitResult"`` error label,
@@ -693,6 +694,9 @@ class ClientSession:
         :return: The return value of the ``callback``.
 
         .. versionadded:: 3.9
+
+        .. _tranactions specification:
+            https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.md#handling-errors-inside-the-callback
         """
         start_time = time.monotonic()
         while True:

--- a/pymongo/synchronous/client_session.py
+++ b/pymongo/synchronous/client_session.py
@@ -659,6 +659,11 @@ class ClientSession:
         ``with_transaction`` starts a new transaction and re-executes
         the ``callback``.
 
+        The ``callback`` MUST NOT silently handle command errors
+        without allowing such errors to propagate. Command errors may abort the
+        transaction on the server, and an attempt to commit the transaction will
+        be rejected with a ``NoSuchTransaction`` error.
+
         When :meth:`~ClientSession.commit_transaction` raises an exception with
         the ``"UnknownTransactionCommitResult"`` error label,
         ``with_transaction`` retries the commit until the result of the

--- a/pymongo/synchronous/client_session.py
+++ b/pymongo/synchronous/client_session.py
@@ -695,7 +695,7 @@ class ClientSession:
 
         .. versionadded:: 3.9
 
-        .. _tranactions specification:
+        .. _transactions specification:
             https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.md#handling-errors-inside-the-callback
         """
         start_time = time.monotonic()


### PR DESCRIPTION
Copies the recommended warning from the [spec change](https://github.com/mongodb/specifications/commit/13117d601fb6ea177e485880175b5be1651a7e46).