### PR TITLE
PYTHON-5253 Automated Spec Resync Quick Followup/Fix

### DIFF
--- a/.evergreen/scripts/resync-all-specs.sh
+++ b/.evergreen/scripts/resync-all-specs.sh
@@ -33,7 +33,7 @@ then
   # we're running locally
   python3 ./.evergreen/scripts/resync-all-specs.py
 else
-  /opt/devtools/bin/python3.11 ./.evergreen/scripts/resync-all-specs.py "$PR_DESC"
+  /opt/devtools/bin/python3.11 ./.evergreen/scripts/resync-all-specs.py --filename "$PR_DESC"
   if [[ -f $PR_DESC ]]; then
     # changes were made -> call scrypt to create PR for us
     .evergreen/scripts/create-spec-pr.sh "$PR_DESC"


### PR DESCRIPTION
Accidentally left out the name of the flag when calling one of the scripts! 

But now it definitely works -- ran a patch build to confirm and it generated: https://github.com/mongodb/mongo-python-driver/pull/2442

Let that be the spec resync pr that should've ran this morning :) 