### PR TITLE
fix async tutorial documentation for AsyncMongoClient.aconnect() method

### DIFF
--- a/doc/async-tutorial.rst
+++ b/doc/async-tutorial.rst
@@ -60,7 +60,7 @@ To explicitly connect before performing an operation, use :meth:`~pymongo.asynch
 
 .. code-block:: pycon
 
-  >>> client = await AsyncMongoClient().aconnect()
+  >>> await AsyncMongoClient().aconnect()
 
 Getting a Database
 ------------------


### PR DESCRIPTION
API documentation suggests to use `client = await AsyncMongoClient().aconnect()` however aconnect() returns None, see https://github.com/mongodb/mongo-python-driver/blob/ffb372aec73d119f03810c1d7816f6278fe14afe/pymongo/asynchronous/mongo_client.py#L1010