### PR TITLE
Fix In-Use Encryption examples

### DIFF
--- a/doc/examples/encryption.rst
+++ b/doc/examples/encryption.rst
@@ -647,7 +647,7 @@ as demonstrated by the following example:
   import os
   from bson.codec_options import CodecOptions
   from pymongo import MongoClient
-  from pymongo.encryption import Algorithm, ClientEncryption, QueryType
+  from pymongo.encryption import ClientEncryption
   from pymongo.encryption_options import AutoEncryptionOpts
 
   local_master_key = os.urandom(96)

--- a/doc/examples/encryption.rst
+++ b/doc/examples/encryption.rst
@@ -614,7 +614,7 @@ An application using Azure credentials would look like, this time using
     from pymongo.encryption_options import AutoEncryptionOpts
 
     # The empty dictionary enables on-demand credentials.
-    kms_providers = ({"azure": {}},)
+    kms_providers = {"azure": {}}
     key_vault_namespace = "keyvault.datakeys"
     auto_encryption_opts = AutoEncryptionOpts(kms_providers, key_vault_namespace)
     client = MongoClient(auto_encryption_opts=auto_encryption_opts)

--- a/doc/examples/encryption.rst
+++ b/doc/examples/encryption.rst
@@ -766,8 +766,6 @@ using an ``encrypted_fields`` mapping, as demonstrated by the following example:
         unindexed_key_id = client_encryption.create_data_key("local")
 
         encrypted_fields = {
-            "escCollection": "enxcol_.default.esc",
-            "ecocCollection": "enxcol_.default.ecoc",
             "fields": [
                 {
                     "keyId": indexed_key_id,

--- a/doc/examples/encryption.rst
+++ b/doc/examples/encryption.rst
@@ -670,8 +670,6 @@ as demonstrated by the following example:
 
   encrypted_fields_map = {
       "default.encryptedCollection": {
-          "escCollection": "encryptedCollection.esc",
-          "ecocCollection": "encryptedCollection.ecoc",
           "fields": [
               {
                   "path": "firstName",


### PR DESCRIPTION
This PR is intended to make small fixes and improvements to the [In-Use Encryption](https://pymongo.readthedocs.io/en/stable/examples/encryption.html) examples:

- Remove incorrect collection names in the [Automatic Queryable Encryption](https://pymongo.readthedocs.io/en/stable/examples/encryption.html#queryable-encryption):
    ```
    pymongo.errors.EncryptionError: Encrypted State Collection name should follow enxcol_.<collection>.esc naming pattern
    ```
    DRIVERS-2565 describes the server change that required the metadata collection names to fit this pattern. libmongocrypt [applies the collection names](https://github.com/mongodb/libmongocrypt/blob/b36115cacad817de9dda8cef3b07b4b35e4d01c6/src/mc-schema-broker.c#L647-L659), so it is not necessary to specify. This PR removes the names from the examples.

- Remove incorrect tuple wrapping in the Azure [CSFLE on-demand credentials](https://pymongo.readthedocs.io/en/stable/examples/encryption.html#csfle-on-demand-credentials):
    ```
    ValueError: kms_providers must be a dict
    ```

- Remove unused imports.