### PR TITLE
PYTHON-5491 Skip non-idempotent dropIndex tests

### DIFF
--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -535,6 +535,8 @@ buildvariants:
     display_name: "* MongoDB v4.2"
     run_on:
       - rhel87-small
+    expansions:
+      VERSION: "4.2"
     tags: [coverage_tag]
   - name: mongodb-v4.4
     tasks:
@@ -542,6 +544,8 @@ buildvariants:
     display_name: "* MongoDB v4.4"
     run_on:
       - rhel87-small
+    expansions:
+      VERSION: "4.4"
     tags: [coverage_tag]
   - name: mongodb-v5.0
     tasks:
@@ -549,6 +553,8 @@ buildvariants:
     display_name: "* MongoDB v5.0"
     run_on:
       - rhel87-small
+    expansions:
+      VERSION: "5.0"
     tags: [coverage_tag]
   - name: mongodb-v6.0
     tasks:
@@ -556,6 +562,8 @@ buildvariants:
     display_name: "* MongoDB v6.0"
     run_on:
       - rhel87-small
+    expansions:
+      VERSION: "6.0"
     tags: [coverage_tag]
   - name: mongodb-v7.0
     tasks:
@@ -563,6 +571,8 @@ buildvariants:
     display_name: "* MongoDB v7.0"
     run_on:
       - rhel87-small
+    expansions:
+      VERSION: "7.0"
     tags: [coverage_tag]
   - name: mongodb-v8.0
     tasks:
@@ -570,6 +580,8 @@ buildvariants:
     display_name: "* MongoDB v8.0"
     run_on:
       - rhel87-small
+    expansions:
+      VERSION: "8.0"
     tags: [coverage_tag]
   - name: mongodb-rapid
     tasks:
@@ -577,6 +589,8 @@ buildvariants:
     display_name: "* MongoDB rapid"
     run_on:
       - rhel87-small
+    expansions:
+      VERSION: rapid
     tags: [coverage_tag]
   - name: mongodb-latest
     tasks:
@@ -584,6 +598,8 @@ buildvariants:
     display_name: "* MongoDB latest"
     run_on:
       - rhel87-small
+    expansions:
+      VERSION: latest
     tags: [coverage_tag]
 
   # Stable api tests

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -74,7 +74,11 @@ def create_server_version_variants() -> list[BuildVariant]:
     for version in ALL_VERSIONS:
         display_name = get_variant_name("* MongoDB", version=version)
         variant = create_variant(
-            [".server-version"], display_name, host=DEFAULT_HOST, tags=["coverage_tag"]
+            [".server-version"],
+            display_name,
+            version=version,
+            host=DEFAULT_HOST,
+            tags=["coverage_tag"],
         )
         variants.append(variant)
     return variants

--- a/test/asynchronous/test_collection.py
+++ b/test/asynchronous/test_collection.py
@@ -335,6 +335,8 @@ class AsyncTestCollection(AsyncIntegrationTest):
         await db.test.create_index(["hello", ("world", DESCENDING)])
         await db.test.create_index({"hello": 1}.items())  # type:ignore[arg-type]
 
+    # TODO: PYTHON-5491 - remove version max
+    @async_client_context.require_version_max(8, 0, -1)
     async def test_drop_index(self):
         db = self.db
         await db.test.drop_indexes()

--- a/test/asynchronous/unified_format.py
+++ b/test/asynchronous/unified_format.py
@@ -564,6 +564,8 @@ class UnifiedSpecTestMixinV1(AsyncIntegrationTest):
                 self.skipTest("CSOT not implemented for watch()")
             if "cursors" in class_name:
                 self.skipTest("CSOT not implemented for cursors")
+            if "dropindex on collection" in description:
+                self.skipTest("PYTHON-5491")
             if (
                 "tailable" in class_name
                 or "tailable" in description

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -333,6 +333,8 @@ class TestCollection(IntegrationTest):
         db.test.create_index(["hello", ("world", DESCENDING)])
         db.test.create_index({"hello": 1}.items())  # type:ignore[arg-type]
 
+    # TODO: PYTHON-5491 - remove version max
+    @client_context.require_version_max(8, 0, -1)
     def test_drop_index(self):
         db = self.db
         db.test.drop_indexes()

--- a/test/unified_format.py
+++ b/test/unified_format.py
@@ -563,6 +563,8 @@ class UnifiedSpecTestMixinV1(IntegrationTest):
                 self.skipTest("CSOT not implemented for watch()")
             if "cursors" in class_name:
                 self.skipTest("CSOT not implemented for cursors")
+            if "dropindex on collection" in description:
+                self.skipTest("PYTHON-5491")
             if (
                 "tailable" in class_name
                 or "tailable" in description


### PR DESCRIPTION
Also fixes the server version tests to actually use the server version.