### PR TITLE
PYTHON-5492 Fix handling of MaxTimeMSExpired responses

### DIFF
--- a/.evergreen/scripts/install-dependencies.sh
+++ b/.evergreen/scripts/install-dependencies.sh
@@ -48,6 +48,7 @@ if ! command -v just &>/dev/null; then
     _TARGET="--target x86_64-pc-windows-msvc"
   fi
   _BIN_DIR=$PYMONGO_BIN_DIR
+  mkdir -p ${_BIN_DIR}
   echo "Installing just..."
   mkdir -p "$_BIN_DIR" 2>/dev/null || true
   curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- $_TARGET --to "$_BIN_DIR" || {
@@ -59,6 +60,7 @@ fi
 # Ensure uv is installed.
 if ! command -v uv &>/dev/null; then
   _BIN_DIR=$PYMONGO_BIN_DIR
+  mkdir -p ${_BIN_DIR}
   echo "Installing uv..."
   # On most systems we can install directly.
   curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="$_BIN_DIR" INSTALLER_NO_MODIFY_PATH=1 sh || {

--- a/pymongo/asynchronous/server.py
+++ b/pymongo/asynchronous/server.py
@@ -38,6 +38,7 @@ from pymongo.logger import (
     _SDAMStatusMessage,
 )
 from pymongo.message import _convert_exception, _GetMore, _OpMsg, _Query
+from pymongo.pool_shared import _get_timeout_details, format_timeout_details
 from pymongo.response import PinnedResponse, Response
 
 if TYPE_CHECKING:
@@ -224,6 +225,10 @@ class Server:
             if use_cmd:
                 first = docs[0]
                 await operation.client._process_response(first, operation.session)  # type: ignore[misc, arg-type]
+                # Append timeout details to MaxTimeMSExpired responses.
+                if first.get("code") == 50:
+                    timeout_details = _get_timeout_details(conn.opts)
+                    first["errmsg"] += format_timeout_details(timeout_details)
                 _check_command_response(first, conn.max_wire_version)
         except Exception as exc:
             duration = datetime.now() - start

--- a/pymongo/asynchronous/server.py
+++ b/pymongo/asynchronous/server.py
@@ -227,8 +227,8 @@ class Server:
                 await operation.client._process_response(first, operation.session)  # type: ignore[misc, arg-type]
                 # Append timeout details to MaxTimeMSExpired responses.
                 if first.get("code") == 50:
-                    timeout_details = _get_timeout_details(conn.opts)
-                    first["errmsg"] += format_timeout_details(timeout_details)
+                    timeout_details = _get_timeout_details(conn.opts)  # type:ignore[has-type]
+                    first["errmsg"] += format_timeout_details(timeout_details)  # type:ignore[index]
                 _check_command_response(first, conn.max_wire_version)
         except Exception as exc:
             duration = datetime.now() - start

--- a/pymongo/synchronous/server.py
+++ b/pymongo/synchronous/server.py
@@ -37,6 +37,7 @@ from pymongo.logger import (
     _SDAMStatusMessage,
 )
 from pymongo.message import _convert_exception, _GetMore, _OpMsg, _Query
+from pymongo.pool_shared import _get_timeout_details, format_timeout_details
 from pymongo.response import PinnedResponse, Response
 from pymongo.synchronous.helpers import _handle_reauth
 
@@ -224,6 +225,10 @@ class Server:
             if use_cmd:
                 first = docs[0]
                 operation.client._process_response(first, operation.session)  # type: ignore[misc, arg-type]
+                # Append timeout details to MaxTimeMSExpired responses.
+                if first.get("code") == 50:
+                    timeout_details = _get_timeout_details(conn.opts)
+                    first["errmsg"] += format_timeout_details(timeout_details)
                 _check_command_response(first, conn.max_wire_version)
         except Exception as exc:
             duration = datetime.now() - start

--- a/pymongo/synchronous/server.py
+++ b/pymongo/synchronous/server.py
@@ -227,8 +227,8 @@ class Server:
                 operation.client._process_response(first, operation.session)  # type: ignore[misc, arg-type]
                 # Append timeout details to MaxTimeMSExpired responses.
                 if first.get("code") == 50:
-                    timeout_details = _get_timeout_details(conn.opts)
-                    first["errmsg"] += format_timeout_details(timeout_details)
+                    timeout_details = _get_timeout_details(conn.opts)  # type:ignore[has-type]
+                    first["errmsg"] += format_timeout_details(timeout_details)  # type:ignore[index]
                 _check_command_response(first, conn.max_wire_version)
         except Exception as exc:
             duration = datetime.now() - start

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -429,7 +429,6 @@ class TestPooling(_TestPoolingBase):
         # maxConnecting = unbounded: 30+ connections in ~0.140+ seconds
         print(len(pool.conns))
 
-    @flaky(reason="PYTHON-5492", affects_cpython_linux=True)
     @async_client_context.require_failCommand_appName
     async def test_csot_timeout_message(self):
         client = await self.async_rs_or_single_client(appName="connectionTimeoutApp")

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -429,7 +429,7 @@ class TestPooling(_TestPoolingBase):
         # maxConnecting = unbounded: 30+ connections in ~0.140+ seconds
         print(len(pool.conns))
 
-    @flaky(reason="PYTHON-5492")
+    @flaky(reason="PYTHON-5492", affects_cpython_linux=True)
     @async_client_context.require_failCommand_appName
     async def test_csot_timeout_message(self):
         client = await self.async_rs_or_single_client(appName="connectionTimeoutApp")

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -429,7 +429,7 @@ class TestPooling(_TestPoolingBase):
         # maxConnecting = unbounded: 30+ connections in ~0.140+ seconds
         print(len(pool.conns))
 
-    @flaky(reason="PYTHON-5492")
+    @flaky(reason="PYTHON-5492", affects_cpython_linux=True)
     @client_context.require_failCommand_appName
     def test_csot_timeout_message(self):
         client = self.rs_or_single_client(appName="connectionTimeoutApp")

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -429,7 +429,6 @@ class TestPooling(_TestPoolingBase):
         # maxConnecting = unbounded: 30+ connections in ~0.140+ seconds
         print(len(pool.conns))
 
-    @flaky(reason="PYTHON-5492", affects_cpython_linux=True)
     @client_context.require_failCommand_appName
     def test_csot_timeout_message(self):
         client = self.rs_or_single_client(appName="connectionTimeoutApp")


### PR DESCRIPTION
It turns out we did have a race condition as to whether we'd get a client side or server side timeout.  This ensures we get the same information either way.

Also fixes a sporadic bug when installing `just` by ensuring that the bin dir exists before attempting to install into it.