### PR TITLE
PYTHON-5500 [v4.14] Mark test_dns_failures_logging as flaky

### DIFF
--- a/.evergreen/scripts/install-dependencies.sh
+++ b/.evergreen/scripts/install-dependencies.sh
@@ -52,6 +52,8 @@ if ! command -v just &>/dev/null; then
   echo "Installing just..."
   mkdir -p "$_BIN_DIR" 2>/dev/null || true
   curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- $_TARGET --to "$_BIN_DIR" || {
+    # Remove just file if it exists (can be created if there was an install error).
+    rm -f ${_BIN_DIR}/just
     _pip_install rust-just just
   }
   echo "Installing just... done."

--- a/test/asynchronous/test_srv_polling.py
+++ b/test/asynchronous/test_srv_polling.py
@@ -225,6 +225,20 @@ class TestSrvPolling(AsyncPyMongoTestCase):
 
             await self.run_scenario(response_callback, False)
 
+    @flaky(reason="PYTHON-5500")
+    async def test_dns_failures_logging(self):
+        from dns import exception
+
+        with self.assertLogs("pymongo.topology", level="DEBUG") as cm:
+
+            def response_callback(*args):
+                raise exception.Timeout("DNS Failure!")
+
+            await self.run_scenario(response_callback, False)
+
+        srv_failure_logs = [r for r in cm.records if "SRV monitor check failed" in r.getMessage()]
+        self.assertEqual(len(srv_failure_logs), 1)
+
     async def test_dns_record_lookup_empty(self):
         response: list = []
         await self.run_scenario(response, False)

--- a/test/test_srv_polling.py
+++ b/test/test_srv_polling.py
@@ -225,6 +225,20 @@ class TestSrvPolling(PyMongoTestCase):
 
             self.run_scenario(response_callback, False)
 
+    @flaky(reason="PYTHON-5500")
+    def test_dns_failures_logging(self):
+        from dns import exception
+
+        with self.assertLogs("pymongo.topology", level="DEBUG") as cm:
+
+            def response_callback(*args):
+                raise exception.Timeout("DNS Failure!")
+
+            self.run_scenario(response_callback, False)
+
+        srv_failure_logs = [r for r in cm.records if "SRV monitor check failed" in r.getMessage()]
+        self.assertEqual(len(srv_failure_logs), 1)
+
     def test_dns_record_lookup_empty(self):
         response: list = []
         self.run_scenario(response, False)


### PR DESCRIPTION
Manual backport of #2480 