### PR TITLE
PYTHON-5504 Prototype exponential backoff in with_transaction

### DIFF
--- a/pymongo/asynchronous/client_session.py
+++ b/pymongo/asynchronous/client_session.py
@@ -135,7 +135,9 @@ Classes
 
 from __future__ import annotations
 
+import asyncio
 import collections
+import random
 import time
 import uuid
 from collections.abc import Mapping as _Mapping
@@ -471,6 +473,8 @@ _UNKNOWN_COMMIT_ERROR_CODES: frozenset = _RETRYABLE_ERROR_CODES | frozenset(  # 
 # This limit is non-configurable and was chosen to be twice the 60 second
 # default value of MongoDB's `transactionLifetimeLimitSeconds` parameter.
 _WITH_TRANSACTION_RETRY_TIME_LIMIT = 120
+_BACKOFF_MAX = 1
+_BACKOFF_INITIAL = 0.050  # 50ms initial backoff
 
 
 def _within_time_limit(start_time: float) -> bool:
@@ -700,7 +704,13 @@ class AsyncClientSession:
             https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.md#handling-errors-inside-the-callback
         """
         start_time = time.monotonic()
+        retry = 0
         while True:
+            if retry > 1:  # Implement exponential backoff after the first retry.
+                jitter = random.random()  # noqa: S311
+                backoff = jitter * min(_BACKOFF_INITIAL * (2 ** (retry - 1)), _BACKOFF_MAX)
+                await asyncio.sleep(backoff)
+            retry += 1
             await self.start_transaction(
                 read_concern, write_concern, read_preference, max_commit_time_ms
             )

--- a/pymongo/asynchronous/client_session.py
+++ b/pymongo/asynchronous/client_session.py
@@ -706,9 +706,9 @@ class AsyncClientSession:
         start_time = time.monotonic()
         retry = 0
         while True:
-            if retry > 1:  # Implement exponential backoff after the first retry.
+            if retry:  # Implement exponential backoff on retry.
                 jitter = random.random()  # noqa: S311
-                backoff = jitter * min(_BACKOFF_INITIAL * (2 ** (retry - 1)), _BACKOFF_MAX)
+                backoff = jitter * min(_BACKOFF_INITIAL * (2**retry), _BACKOFF_MAX)
                 await asyncio.sleep(backoff)
             retry += 1
             await self.start_transaction(

--- a/pymongo/synchronous/client_session.py
+++ b/pymongo/synchronous/client_session.py
@@ -704,9 +704,9 @@ class ClientSession:
         start_time = time.monotonic()
         retry = 0
         while True:
-            if retry > 1:  # Implement exponential backoff after the first retry.
+            if retry:  # Implement exponential backoff on retry.
                 jitter = random.random()  # noqa: S311
-                backoff = jitter * min(_BACKOFF_INITIAL * (2 ** (retry - 1)), _BACKOFF_MAX)
+                backoff = jitter * min(_BACKOFF_INITIAL * (2**retry), _BACKOFF_MAX)
                 time.sleep(backoff)
             retry += 1
             self.start_transaction(read_concern, write_concern, read_preference, max_commit_time_ms)

--- a/pymongo/synchronous/client_session.py
+++ b/pymongo/synchronous/client_session.py
@@ -136,6 +136,7 @@ Classes
 from __future__ import annotations
 
 import collections
+import random
 import time
 import uuid
 from collections.abc import Mapping as _Mapping
@@ -470,6 +471,8 @@ _UNKNOWN_COMMIT_ERROR_CODES: frozenset = _RETRYABLE_ERROR_CODES | frozenset(  # 
 # This limit is non-configurable and was chosen to be twice the 60 second
 # default value of MongoDB's `transactionLifetimeLimitSeconds` parameter.
 _WITH_TRANSACTION_RETRY_TIME_LIMIT = 120
+_BACKOFF_MAX = 1
+_BACKOFF_INITIAL = 0.050  # 50ms initial backoff
 
 
 def _within_time_limit(start_time: float) -> bool:
@@ -699,7 +702,13 @@ class ClientSession:
             https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.md#handling-errors-inside-the-callback
         """
         start_time = time.monotonic()
+        retry = 0
         while True:
+            if retry > 1:  # Implement exponential backoff after the first retry.
+                jitter = random.random()  # noqa: S311
+                backoff = jitter * min(_BACKOFF_INITIAL * (2 ** (retry - 1)), _BACKOFF_MAX)
+                time.sleep(backoff)
+            retry += 1
             self.start_transaction(read_concern, write_concern, read_preference, max_commit_time_ms)
             try:
                 ret = callback(self)


### PR DESCRIPTION
PYTHON-5504 Prototype exponential backoff in with_transaction.

Using the repro scrip in jira which runs 200 concurrent transactions in 200 threads all updating the same document shows a significant reduction in wasted retry attempts and latency (from p50 to p100). Before this change:
```
$ python3.13t repro-with_transaction-write-conflict-storm.py
Completed 200 transactions in 200 threads in 4.8626720905303955 seconds
Total retry attempts: 8132
avg latency: 3.04s p50: 3.36s p90: 4.59s p99: 4.83s p100: 4.84s
```

After (with 50ms initial backoff, 1000ms max backoff, and full jitter, backoff starting on the _second_ retry attempt):
```
$ python3.13t repro-with_transaction-write-conflict-storm.py
Completed 200 transactions in 200 threads in 4.251200914382935 seconds
Total retry attempts: 1089
avg latency: 1.53s p50: 1.45s p90: 2.77s p99: 3.69s p100: 4.24s
```

Backoff starting on the _first_ retry attempt appears to work even better:
```
$ python3.13t repro-with_transaction-write-conflict-storm.py
Completed 200 transactions in 200 threads in 3.272695779800415 seconds
Total retry attempts: 886
avg latency: 1.33s p50: 1.21s p90: 2.50s p99: 3.22s p100: 3.25s
```

Note I'm using free-threaded mode to make this repro more similar to the behavior of other languages and other deployment types (eg many single threaded clients running on different machines).