### PR TITLE
PYTHON-5506 Prototype adaptive token bucket retry

### DIFF
--- a/pymongo/asynchronous/collection.py
+++ b/pymongo/asynchronous/collection.py
@@ -253,6 +253,7 @@ class AsyncCollection(common.BaseObject, Generic[_DocumentType]):
             unicode_decode_error_handler="replace", document_class=dict
         )
         self._timeout = database.client.options.timeout
+        self._retry_policy = database.client._retry_policy
 
         if create or kwargs:
             if _IS_SYNC:

--- a/pymongo/asynchronous/database.py
+++ b/pymongo/asynchronous/database.py
@@ -136,6 +136,7 @@ class AsyncDatabase(common.BaseObject, Generic[_DocumentType]):
         self._name = name
         self._client: AsyncMongoClient[_DocumentType] = client
         self._timeout = client.options.timeout
+        self._retry_policy = client._retry_policy
 
     @property
     def client(self) -> AsyncMongoClient[_DocumentType]:

--- a/pymongo/asynchronous/helpers.py
+++ b/pymongo/asynchronous/helpers.py
@@ -141,7 +141,7 @@ class _RetryPolicy:
         self.backoff_initial = backoff_initial
         self.backoff_max = backoff_max
 
-    async def record_success(self, retry: bool):
+    async def record_success(self, retry: bool) -> None:
         """Record a successful operation."""
         await self.token_bucket.deposit(retry)
 

--- a/pymongo/asynchronous/helpers.py
+++ b/pymongo/asynchronous/helpers.py
@@ -21,7 +21,7 @@ import functools
 import random
 import socket
 import sys
-import time
+import time as time  # noqa: PLC0414 # needed in sync version
 from typing import (
     Any,
     Callable,
@@ -83,7 +83,6 @@ _BACKOFF_MAX = 10
 # DRIVERS-3240 will determine these defaults.
 DEFAULT_RETRY_TOKEN_CAPACITY = 1000.0
 DEFAULT_RETRY_TOKEN_RETURN = 0.1
-_TIME = time  # Added so synchro script doesn't remove the time import.
 
 
 def _backoff(

--- a/pymongo/asynchronous/helpers.py
+++ b/pymongo/asynchronous/helpers.py
@@ -34,6 +34,7 @@ from pymongo.errors import (
     PyMongoError,
 )
 from pymongo.helpers_shared import _REAUTHENTICATION_REQUIRED_CODE
+from pymongo.lock import _async_create_lock
 
 _IS_SYNC = False
 
@@ -78,7 +79,10 @@ def _handle_reauth(func: F) -> F:
 _MAX_RETRIES = 3
 _BACKOFF_INITIAL = 0.05
 _BACKOFF_MAX = 10
-_TIME = time
+# DRIVERS-3240 will determine these defaults.
+DEFAULT_RETRY_TOKEN_CAPACITY = 1000.0
+DEFAULT_RETRY_TOKEN_RETURN = 0.1
+_TIME = time  # Added so synchro script doesn't remove the time import.
 
 
 async def _backoff(
@@ -89,23 +93,95 @@ async def _backoff(
     await asyncio.sleep(backoff)
 
 
+class _TokenBucket:
+    """A token bucket implementation for rate limiting."""
+
+    def __init__(
+        self,
+        capacity: float = DEFAULT_RETRY_TOKEN_CAPACITY,
+        return_rate: float = DEFAULT_RETRY_TOKEN_RETURN,
+    ):
+        self.lock = _async_create_lock()
+        self.capacity = capacity
+        # DRIVERS-3240 will determine how full the bucket should start.
+        self.tokens = capacity
+        self.return_rate = return_rate
+
+    async def consume(self) -> bool:
+        """Consume a token from the bucket if available."""
+        async with self.lock:
+            if self.tokens >= 1:
+                self.tokens -= 1
+                return True
+            return False
+
+    async def deposit(self, retry: bool = False) -> None:
+        """Deposit a token back into the bucket."""
+        retry_token = 1 if retry else 0
+        async with self.lock:
+            self.tokens = min(self.capacity, self.tokens + retry_token + self.return_rate)
+
+
+class _RetryPolicy:
+    """A retry limiter that performs exponential backoff with jitter.
+
+    Retry attempts are limited by a token bucket to prevent overwhelming the server during
+    a prolonged outage or high load.
+    """
+
+    def __init__(
+        self,
+        token_bucket: _TokenBucket,
+        attempts: int = _MAX_RETRIES,
+        backoff_initial: float = _BACKOFF_INITIAL,
+        backoff_max: float = _BACKOFF_MAX,
+    ):
+        self.token_bucket = token_bucket
+        self.attempts = attempts
+        self.backoff_initial = backoff_initial
+        self.backoff_max = backoff_max
+
+    async def record_success(self, retry: bool):
+        """Record a successful operation."""
+        await self.token_bucket.deposit(retry)
+
+    async def backoff(self, attempt: int) -> None:
+        """Return the backoff duration for the given ."""
+        await _backoff(max(0, attempt - 1), self.backoff_initial, self.backoff_max)
+
+    async def should_retry(self, attempt: int) -> bool:
+        """Return if we have budget to retry and how long to backoff."""
+        # TODO: Check CSOT deadline here.
+        if attempt > self.attempts:
+            return False
+        # Check token bucket last since we only want to consume a token if we actually retry.
+        if not await self.token_bucket.consume():
+            # DRIVERS-3246 Improve diagnostics when this case happens.
+            # We could add info to the exception and log.
+            return False
+        return True
+
+
 def _retry_overload(func: F) -> F:
     @functools.wraps(func)
-    async def inner(*args: Any, **kwargs: Any) -> Any:
+    async def inner(self: Any, *args: Any, **kwargs: Any) -> Any:
+        retry_policy = self._retry_policy
         attempt = 0
         while True:
             try:
-                return await func(*args, **kwargs)
+                res = await func(self, *args, **kwargs)
+                await retry_policy.record_success(retry=attempt > 0)
+                return res
             except PyMongoError as exc:
                 if not exc.has_error_label("Retryable"):
                     raise
                 attempt += 1
-                if attempt > _MAX_RETRIES:
+                if not await retry_policy.should_retry(attempt):
                     raise
 
                 # Implement exponential backoff on retry.
                 if exc.has_error_label("SystemOverloaded"):
-                    await _backoff(attempt)
+                    await retry_policy.backoff(attempt)
                 continue
 
     return cast(F, inner)

--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
-import time
+import time as time  # noqa: PLC0414 # needed in sync version
 import warnings
 import weakref
 from collections import defaultdict
@@ -174,8 +174,6 @@ _WriteOp = Union[
     UpdateOne,
     UpdateMany,
 ]
-
-_TIME = time  # Added so synchro script doesn't remove the time import.
 
 
 class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):

--- a/pymongo/synchronous/collection.py
+++ b/pymongo/synchronous/collection.py
@@ -256,6 +256,7 @@ class Collection(common.BaseObject, Generic[_DocumentType]):
             unicode_decode_error_handler="replace", document_class=dict
         )
         self._timeout = database.client.options.timeout
+        self._retry_policy = database.client._retry_policy
 
         if create or kwargs:
             if _IS_SYNC:

--- a/pymongo/synchronous/database.py
+++ b/pymongo/synchronous/database.py
@@ -136,6 +136,7 @@ class Database(common.BaseObject, Generic[_DocumentType]):
         self._name = name
         self._client: MongoClient[_DocumentType] = client
         self._timeout = client.options.timeout
+        self._retry_policy = client._retry_policy
 
     @property
     def client(self) -> MongoClient[_DocumentType]:

--- a/pymongo/synchronous/helpers.py
+++ b/pymongo/synchronous/helpers.py
@@ -141,7 +141,7 @@ class _RetryPolicy:
         self.backoff_initial = backoff_initial
         self.backoff_max = backoff_max
 
-    def record_success(self, retry: bool):
+    def record_success(self, retry: bool) -> None:
         """Record a successful operation."""
         self.token_bucket.deposit(retry)
 

--- a/pymongo/synchronous/helpers.py
+++ b/pymongo/synchronous/helpers.py
@@ -21,7 +21,7 @@ import functools
 import random
 import socket
 import sys
-import time
+import time as time  # noqa: PLC0414 # needed in sync version
 from typing import (
     Any,
     Callable,
@@ -83,7 +83,6 @@ _BACKOFF_MAX = 10
 # DRIVERS-3240 will determine these defaults.
 DEFAULT_RETRY_TOKEN_CAPACITY = 1000.0
 DEFAULT_RETRY_TOKEN_RETURN = 0.1
-_TIME = time  # Added so synchro script doesn't remove the time import.
 
 
 def _backoff(

--- a/pymongo/synchronous/helpers.py
+++ b/pymongo/synchronous/helpers.py
@@ -34,6 +34,7 @@ from pymongo.errors import (
     PyMongoError,
 )
 from pymongo.helpers_shared import _REAUTHENTICATION_REQUIRED_CODE
+from pymongo.lock import _create_lock
 
 _IS_SYNC = True
 
@@ -78,7 +79,10 @@ def _handle_reauth(func: F) -> F:
 _MAX_RETRIES = 3
 _BACKOFF_INITIAL = 0.05
 _BACKOFF_MAX = 10
-_TIME = time
+# DRIVERS-3240 will determine these defaults.
+DEFAULT_RETRY_TOKEN_CAPACITY = 1000.0
+DEFAULT_RETRY_TOKEN_RETURN = 0.1
+_TIME = time  # Added so synchro script doesn't remove the time import.
 
 
 def _backoff(
@@ -89,23 +93,95 @@ def _backoff(
     time.sleep(backoff)
 
 
+class _TokenBucket:
+    """A token bucket implementation for rate limiting."""
+
+    def __init__(
+        self,
+        capacity: float = DEFAULT_RETRY_TOKEN_CAPACITY,
+        return_rate: float = DEFAULT_RETRY_TOKEN_RETURN,
+    ):
+        self.lock = _create_lock()
+        self.capacity = capacity
+        # DRIVERS-3240 will determine how full the bucket should start.
+        self.tokens = capacity
+        self.return_rate = return_rate
+
+    def consume(self) -> bool:
+        """Consume a token from the bucket if available."""
+        with self.lock:
+            if self.tokens >= 1:
+                self.tokens -= 1
+                return True
+            return False
+
+    def deposit(self, retry: bool = False) -> None:
+        """Deposit a token back into the bucket."""
+        retry_token = 1 if retry else 0
+        with self.lock:
+            self.tokens = min(self.capacity, self.tokens + retry_token + self.return_rate)
+
+
+class _RetryPolicy:
+    """A retry limiter that performs exponential backoff with jitter.
+
+    Retry attempts are limited by a token bucket to prevent overwhelming the server during
+    a prolonged outage or high load.
+    """
+
+    def __init__(
+        self,
+        token_bucket: _TokenBucket,
+        attempts: int = _MAX_RETRIES,
+        backoff_initial: float = _BACKOFF_INITIAL,
+        backoff_max: float = _BACKOFF_MAX,
+    ):
+        self.token_bucket = token_bucket
+        self.attempts = attempts
+        self.backoff_initial = backoff_initial
+        self.backoff_max = backoff_max
+
+    def record_success(self, retry: bool):
+        """Record a successful operation."""
+        self.token_bucket.deposit(retry)
+
+    def backoff(self, attempt: int) -> None:
+        """Return the backoff duration for the given ."""
+        _backoff(max(0, attempt - 1), self.backoff_initial, self.backoff_max)
+
+    def should_retry(self, attempt: int) -> bool:
+        """Return if we have budget to retry and how long to backoff."""
+        # TODO: Check CSOT deadline here.
+        if attempt > self.attempts:
+            return False
+        # Check token bucket last since we only want to consume a token if we actually retry.
+        if not self.token_bucket.consume():
+            # DRIVERS-3246 Improve diagnostics when this case happens.
+            # We could add info to the exception and log.
+            return False
+        return True
+
+
 def _retry_overload(func: F) -> F:
     @functools.wraps(func)
-    def inner(*args: Any, **kwargs: Any) -> Any:
+    def inner(self: Any, *args: Any, **kwargs: Any) -> Any:
+        retry_policy = self._retry_policy
         attempt = 0
         while True:
             try:
-                return func(*args, **kwargs)
+                res = func(self, *args, **kwargs)
+                retry_policy.record_success(retry=attempt > 0)
+                return res
             except PyMongoError as exc:
                 if not exc.has_error_label("Retryable"):
                     raise
                 attempt += 1
-                if attempt > _MAX_RETRIES:
+                if not retry_policy.should_retry(attempt):
                     raise
 
                 # Implement exponential backoff on retry.
                 if exc.has_error_label("SystemOverloaded"):
-                    _backoff(attempt)
+                    retry_policy.backoff(attempt)
                 continue
 
     return cast(F, inner)

--- a/pymongo/synchronous/helpers.py
+++ b/pymongo/synchronous/helpers.py
@@ -29,6 +29,7 @@ from typing import (
     cast,
 )
 
+from pymongo import _csot
 from pymongo.errors import (
     OperationFailure,
     PyMongoError,
@@ -87,10 +88,9 @@ _TIME = time  # Added so synchro script doesn't remove the time import.
 
 def _backoff(
     attempt: int, initial_delay: float = _BACKOFF_INITIAL, max_delay: float = _BACKOFF_MAX
-) -> None:
+) -> float:
     jitter = random.random()  # noqa: S311
-    backoff = jitter * min(initial_delay * (2**attempt), max_delay)
-    time.sleep(backoff)
+    return jitter * min(initial_delay * (2**attempt), max_delay)
 
 
 class _TokenBucket:
@@ -145,15 +145,20 @@ class _RetryPolicy:
         """Record a successful operation."""
         self.token_bucket.deposit(retry)
 
-    def backoff(self, attempt: int) -> None:
+    def backoff(self, attempt: int) -> float:
         """Return the backoff duration for the given ."""
-        _backoff(max(0, attempt - 1), self.backoff_initial, self.backoff_max)
+        return _backoff(max(0, attempt - 1), self.backoff_initial, self.backoff_max)
 
-    def should_retry(self, attempt: int) -> bool:
+    def should_retry(self, attempt: int, delay: float) -> bool:
         """Return if we have budget to retry and how long to backoff."""
-        # TODO: Check CSOT deadline here.
         if attempt > self.attempts:
             return False
+
+        # If the delay would exceed the deadline, bail early before consuming a token.
+        if _csot.get_timeout():
+            if time.monotonic() + delay > _csot.get_deadline():
+                return False
+
         # Check token bucket last since we only want to consume a token if we actually retry.
         if not self.token_bucket.consume():
             # DRIVERS-3246 Improve diagnostics when this case happens.
@@ -176,12 +181,15 @@ def _retry_overload(func: F) -> F:
                 if not exc.has_error_label("Retryable"):
                     raise
                 attempt += 1
-                if not retry_policy.should_retry(attempt):
+                delay = 0
+                if exc.has_error_label("SystemOverloaded"):
+                    delay = retry_policy.backoff(attempt)
+                if not retry_policy.should_retry(attempt, delay):
                     raise
 
                 # Implement exponential backoff on retry.
-                if exc.has_error_label("SystemOverloaded"):
-                    retry_policy.backoff(attempt)
+                if delay:
+                    time.sleep(delay)
                 continue
 
     return cast(F, inner)

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
-import time
+import time as time  # noqa: PLC0414 # needed in sync version
 import warnings
 import weakref
 from collections import defaultdict
@@ -171,8 +171,6 @@ _WriteOp = Union[
     UpdateOne,
     UpdateMany,
 ]
-
-_TIME = time  # Added so synchro script doesn't remove the time import.
 
 
 class MongoClient(common.BaseObject, Generic[_DocumentType]):

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -110,7 +110,11 @@ from pymongo.synchronous.change_stream import ChangeStream, ClusterChangeStream
 from pymongo.synchronous.client_bulk import _ClientBulk
 from pymongo.synchronous.client_session import _EmptyServerSession
 from pymongo.synchronous.command_cursor import CommandCursor
-from pymongo.synchronous.helpers import _MAX_RETRIES, _backoff, _retry_overload
+from pymongo.synchronous.helpers import (
+    _retry_overload,
+    _RetryPolicy,
+    _TokenBucket,
+)
 from pymongo.synchronous.settings import TopologySettings
 from pymongo.synchronous.topology import Topology, _ErrorContext
 from pymongo.topology_description import TOPOLOGY_TYPE, TopologyDescription
@@ -774,6 +778,7 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
         self._timeout: float | None = None
         self._topology_settings: TopologySettings = None  # type: ignore[assignment]
         self._event_listeners: _EventListeners | None = None
+        self._retry_policy = _RetryPolicy(_TokenBucket())
 
         # _pool_class, _monitor_class, and _condition_class are for deep
         # customization of PyMongo, e.g. Motor.
@@ -2730,7 +2735,7 @@ class _ClientConnectionRetryable(Generic[T]):
         self._always_retryable = False
         self._multiple_retries = _csot.get_timeout() is not None
         self._client = mongo_client
-
+        self._retry_policy = mongo_client._retry_policy
         self._func = func
         self._bulk = bulk
         self._session = session
@@ -2765,7 +2770,9 @@ class _ClientConnectionRetryable(Generic[T]):
         while True:
             self._check_last_error(check_csot=True)
             try:
-                return self._read() if self._is_read else self._write()
+                res = self._read() if self._is_read else self._write()
+                self._retry_policy.record_success(self._attempt_number > 0)
+                return res
             except ServerSelectionTimeoutError:
                 # The application may think the write was never attempted
                 # if we raise ServerSelectionTimeoutError on the retry
@@ -2836,13 +2843,13 @@ class _ClientConnectionRetryable(Generic[T]):
 
                 self._always_retryable = always_retryable
                 if always_retryable:
-                    if self._attempt_number > _MAX_RETRIES:
+                    if not self._retry_policy.should_retry(self._attempt_number):
                         if exc_to_check.has_error_label("NoWritesPerformed") and self._last_error:
                             raise self._last_error from exc
                         else:
                             raise
                     if overloaded:
-                        _backoff(self._attempt_number)
+                        self._retry_policy.backoff(self._attempt_number)
 
     def _is_not_eligible_for_retry(self) -> bool:
         """Checks if the exchange is not eligible for retry"""

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import time
 import warnings
 import weakref
 from collections import defaultdict
@@ -170,6 +171,8 @@ _WriteOp = Union[
     UpdateOne,
     UpdateMany,
 ]
+
+_TIME = time  # Added so synchro script doesn't remove the time import.
 
 
 class MongoClient(common.BaseObject, Generic[_DocumentType]):
@@ -2843,13 +2846,14 @@ class _ClientConnectionRetryable(Generic[T]):
 
                 self._always_retryable = always_retryable
                 if always_retryable:
-                    if not self._retry_policy.should_retry(self._attempt_number):
+                    delay = self._retry_policy.backoff(self._attempt_number) if overloaded else 0
+                    if not self._retry_policy.should_retry(self._attempt_number, delay):
                         if exc_to_check.has_error_label("NoWritesPerformed") and self._last_error:
                             raise self._last_error from exc
                         else:
                             raise
                     if overloaded:
-                        self._retry_policy.backoff(self._attempt_number)
+                        time.sleep(delay)
 
     def _is_not_eligible_for_retry(self) -> bool:
         """Checks if the exchange is not eligible for retry"""

--- a/test/asynchronous/test_backpressure.py
+++ b/test/asynchronous/test_backpressure.py
@@ -150,6 +150,28 @@ class TestBackpressure(AsyncIntegrationTest):
 
         self.assertIn("Retryable", str(error.exception))
 
+    @async_client_context.require_failCommand_appName
+    async def test_limit_retry_command(self):
+        client = await self.async_rs_or_single_client()
+        client._retry_policy.token_bucket.tokens = 1
+        db = client.pymongo_test
+        await db.t.insert_one({"x": 1})
+
+        # Ensure command is retried once overload error.
+        fail_many = mock_overload_error.copy()
+        fail_many["mode"] = {"times": 1}
+        async with self.fail_point(fail_many):
+            await db.command("find", "t")
+
+        # Ensure command stops retrying when there are no tokens left.
+        fail_too_many = mock_overload_error.copy()
+        fail_too_many["mode"] = {"times": 2}
+        async with self.fail_point(fail_too_many):
+            with self.assertRaises(PyMongoError) as error:
+                await db.command("find", "t")
+
+        self.assertIn("Retryable", str(error.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_backpressure.py
+++ b/test/test_backpressure.py
@@ -15,7 +15,10 @@
 """Test Client Backpressure spec."""
 from __future__ import annotations
 
+import asyncio
 import sys
+
+import pymongo
 
 sys.path[0:0] = [""]
 
@@ -187,12 +190,12 @@ class TestRetryPolicy(PyMongoTestCase):
         self.assertEqual(retry_policy.backoff_initial, helpers._BACKOFF_INITIAL)
         self.assertEqual(retry_policy.backoff_max, helpers._BACKOFF_MAX)
         for i in range(1, helpers._MAX_RETRIES + 1):
-            self.assertTrue(retry_policy.should_retry(i))
-        self.assertFalse(retry_policy.should_retry(helpers._MAX_RETRIES + 1))
+            self.assertTrue(retry_policy.should_retry(i, 0))
+        self.assertFalse(retry_policy.should_retry(helpers._MAX_RETRIES + 1, 0))
         for i in range(capacity - helpers._MAX_RETRIES):
-            self.assertTrue(retry_policy.should_retry(1))
+            self.assertTrue(retry_policy.should_retry(1, 0))
         # No tokens left, should not retry.
-        self.assertFalse(retry_policy.should_retry(1))
+        self.assertFalse(retry_policy.should_retry(1, 0))
         self.assertEqual(retry_policy.token_bucket.tokens, 0)
 
         # record_success should generate tokens.
@@ -200,17 +203,27 @@ class TestRetryPolicy(PyMongoTestCase):
             retry_policy.record_success(retry=False)
         self.assertAlmostEqual(retry_policy.token_bucket.tokens, 2)
         for i in range(2):
-            self.assertTrue(retry_policy.should_retry(1))
-        self.assertFalse(retry_policy.should_retry(1))
+            self.assertTrue(retry_policy.should_retry(1, 0))
+        self.assertFalse(retry_policy.should_retry(1, 0))
 
         # Recording a successful retry should return 1 additional token.
         retry_policy.record_success(retry=True)
         self.assertAlmostEqual(
             retry_policy.token_bucket.tokens, 1 + helpers.DEFAULT_RETRY_TOKEN_RETURN
         )
-        self.assertTrue(retry_policy.should_retry(1))
-        self.assertFalse(retry_policy.should_retry(1))
+        self.assertTrue(retry_policy.should_retry(1, 0))
+        self.assertFalse(retry_policy.should_retry(1, 0))
         self.assertAlmostEqual(retry_policy.token_bucket.tokens, helpers.DEFAULT_RETRY_TOKEN_RETURN)
+
+    def test_retry_policy_csot(self):
+        retry_policy = _RetryPolicy(_TokenBucket())
+        self.assertTrue(retry_policy.should_retry(1, 0.5))
+        with pymongo.timeout(0.5):
+            self.assertTrue(retry_policy.should_retry(1, 0))
+            self.assertTrue(retry_policy.should_retry(1, 0.1))
+            # Would exceed the timeout, should not retry.
+            self.assertFalse(retry_policy.should_retry(1, 1.0))
+        self.assertTrue(retry_policy.should_retry(1, 1.0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
PYTHON-5506 Prototype adaptive token bucket retry

Description:
Add adaptive token bucket based retry policy.
Successfully completed commands deposit 0.1 token. 
Failed retry attempts consume 1 token. 
A retry is only permitted if there is an available token.
For simplicity, this POC adds a retry bucket per MongoClient. In the future we will consider adding a retry bucket per server.

Patch with perf benchmarks: https://spruce.mongodb.com/version/68a7b69b74baee000728de31/tasks