### PR TITLE
fix deprecated functions

### DIFF
--- a/bson/__init__.py
+++ b/bson/__init__.py
@@ -113,7 +113,7 @@ except ImportError:
 
 
 EPOCH_AWARE = datetime.datetime.fromtimestamp(0, utc)
-EPOCH_NAIVE = datetime.datetime.utcfromtimestamp(0)
+EPOCH_AWARE = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
 
 
 BSONNUM = b"\x01" # Floating point


### PR DESCRIPTION
datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes.