### PR TITLE
PYTHON-5520 Add windows arm64 wheel support

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           cache: 'pip'
-          python-version: ${{ matrix.buildplat[0] == 'windows-11-arm' && 3.11 || 3.9 }}
+          python-version: 3.11
           cache-dependency-path: 'pyproject.toml'
           allow-prereleases: true
 


### PR DESCRIPTION
[PYTHON-5520](https://jira.mongodb.org/browse/PYTHON-5520) Add windows arm64 wheel support

This would add builds to create windows arm64 wheels.