### PR TITLE
PYTHON-5521 - Update TestBsonSizeBatches.test_06_insert_fails_over_16MiB error codes

### DIFF
--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -1268,7 +1268,7 @@ class TestBsonSizeBatches(AsyncEncryptionIntegrationTest):
         with self.assertRaises(BulkWriteError) as ctx:
             await self.coll_encrypted.bulk_write([InsertOne(doc)])
         err = ctx.exception.details["writeErrors"][0]
-        self.assertEqual(2, err["code"])
+        self.assertIn(err["code"], [2, 10334])
         self.assertIn("object to insert too large", err["errmsg"])
 
 

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -1264,7 +1264,7 @@ class TestBsonSizeBatches(EncryptionIntegrationTest):
         with self.assertRaises(BulkWriteError) as ctx:
             self.coll_encrypted.bulk_write([InsertOne(doc)])
         err = ctx.exception.details["writeErrors"][0]
-        self.assertEqual(2, err["code"])
+        self.assertIn(err["code"], [2, 10334])
         self.assertIn("object to insert too large", err["errmsg"])
 
 


### PR DESCRIPTION
Passing patch build (failures will be fixed by [PYTHON-5524](https://jira.mongodb.org/browse/PYTHON-5524)): https://spruce.mongodb.com/task/mongo_python_driver_encryption_crypt_shared_macos_test_non_standard_latest_python3.13_noauth_ssl_replica_set_patch_b756bbd2a392ee9a810dd9b5df97fc4e16cfae37_68b84ec042cef20007b55293_25_09_03_14_21_42/tests?execution=0&limit=100&page=0&sorts=STATUS%3AASC
