### PR TITLE
PYTHON-5555 Fix AWS Lambda build

### DIFF
--- a/pymongo/asynchronous/srv_resolver.py
+++ b/pymongo/asynchronous/srv_resolver.py
@@ -113,6 +113,7 @@ class _SrvResolver:
         return (b"&".join([b"".join(res.strings) for res in results])).decode("utf-8")  # type: ignore[attr-defined]
 
     async def _resolve_uri(self, encapsulate_errors: bool) -> resolver.Answer:
+        print(f"{self.__srv=} {self.__fqdn=}")  # noqa: T201
         try:
             results = await _resolve(
                 "_" + self.__srv + "._tcp." + self.__fqdn, "SRV", lifetime=self.__connect_timeout

--- a/pymongo/asynchronous/srv_resolver.py
+++ b/pymongo/asynchronous/srv_resolver.py
@@ -122,7 +122,7 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
-            raise ValueError(f"{self.__srv=} {self.__fqdn=}") from None
+            raise ValueError(f"{self.__srv=} {self.__fqdn=} {exc=}") from None
             raise ConfigurationError(str(exc)) from None
         return results
 

--- a/pymongo/asynchronous/srv_resolver.py
+++ b/pymongo/asynchronous/srv_resolver.py
@@ -93,8 +93,8 @@ class _SrvResolver:
         try:
             split_fqdn = self.__fqdn.split(".")
             self.__plist = split_fqdn[1:] if len(split_fqdn) > 2 else split_fqdn
-        except Exception:
-            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,)) from None
+        except Exception as exc:
+            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,)) from exc
         self.__slen = len(self.__plist)
         self.nparts = len(split_fqdn)
 
@@ -107,7 +107,7 @@ class _SrvResolver:
             # No TXT records
             return None
         except Exception as exc:
-            raise ConfigurationError(str(exc)) from None
+            raise ConfigurationError(str(exc)) from exc
         if len(results) > 1:
             raise ConfigurationError("Only one TXT record is supported")
         return (b"&".join([b"".join(res.strings) for res in results])).decode("utf-8")  # type: ignore[attr-defined]
@@ -122,8 +122,7 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
-            raise ValueError(f"{self.__srv=} {self.__fqdn=} {exc=}") from None
-            raise ConfigurationError(str(exc)) from None
+            raise ConfigurationError(str(exc)) from exc
         return results
 
     async def _get_srv_response_and_hosts(
@@ -146,8 +145,8 @@ class _SrvResolver:
                 )
             try:
                 nlist = srv_host.split(".")[1:][-self.__slen :]
-            except Exception:
-                raise ConfigurationError(f"Invalid SRV host: {node[0]}") from None
+            except Exception as exc:
+                raise ConfigurationError(f"Invalid SRV host: {node[0]}") from exc
             if self.__plist != nlist:
                 raise ConfigurationError(f"Invalid SRV host: {node[0]}")
         if self.__srv_max_hosts:

--- a/pymongo/asynchronous/srv_resolver.py
+++ b/pymongo/asynchronous/srv_resolver.py
@@ -124,7 +124,9 @@ class _SrvResolver:
             # Else, raise all errors as ConfigurationError.
             import traceback
 
-            raise ConfigurationError(traceback.format_exception(exc)) from exc
+            raise ConfigurationError(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            ) from exc
         return results
 
     async def _get_srv_response_and_hosts(

--- a/pymongo/asynchronous/srv_resolver.py
+++ b/pymongo/asynchronous/srv_resolver.py
@@ -122,7 +122,9 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
-            raise ConfigurationError(str(exc)) from exc
+            import traceback
+
+            raise ConfigurationError(traceback.format_exception(exc)) from exc
         return results
 
     async def _get_srv_response_and_hosts(

--- a/pymongo/asynchronous/srv_resolver.py
+++ b/pymongo/asynchronous/srv_resolver.py
@@ -93,8 +93,8 @@ class _SrvResolver:
         try:
             split_fqdn = self.__fqdn.split(".")
             self.__plist = split_fqdn[1:] if len(split_fqdn) > 2 else split_fqdn
-        except Exception as exc:
-            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,)) from exc
+        except Exception:
+            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,)) from None
         self.__slen = len(self.__plist)
         self.nparts = len(split_fqdn)
 
@@ -122,11 +122,7 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
-            import traceback
-
-            raise ConfigurationError(
-                traceback.format_exception(type(exc), exc, exc.__traceback__)
-            ) from exc
+            raise ConfigurationError(str(exc)) from exc
         return results
 
     async def _get_srv_response_and_hosts(

--- a/pymongo/asynchronous/srv_resolver.py
+++ b/pymongo/asynchronous/srv_resolver.py
@@ -113,7 +113,6 @@ class _SrvResolver:
         return (b"&".join([b"".join(res.strings) for res in results])).decode("utf-8")  # type: ignore[attr-defined]
 
     async def _resolve_uri(self, encapsulate_errors: bool) -> resolver.Answer:
-        print(f"{self.__srv=} {self.__fqdn=}")  # noqa: T201
         try:
             results = await _resolve(
                 "_" + self.__srv + "._tcp." + self.__fqdn, "SRV", lifetime=self.__connect_timeout
@@ -123,6 +122,7 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
+            raise ValueError(f"{self.__srv=} {self.__fqdn=}") from None
             raise ConfigurationError(str(exc)) from None
         return results
 

--- a/pymongo/synchronous/srv_resolver.py
+++ b/pymongo/synchronous/srv_resolver.py
@@ -124,7 +124,9 @@ class _SrvResolver:
             # Else, raise all errors as ConfigurationError.
             import traceback
 
-            raise ConfigurationError(traceback.format_exception(exc)) from exc
+            raise ConfigurationError(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            ) from exc
         return results
 
     def _get_srv_response_and_hosts(

--- a/pymongo/synchronous/srv_resolver.py
+++ b/pymongo/synchronous/srv_resolver.py
@@ -122,7 +122,7 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
-            raise ValueError(f"{self.__srv=} {self.__fqdn=}") from None
+            raise ValueError(f"{self.__srv=} {self.__fqdn=} {exc=}") from None
             raise ConfigurationError(str(exc)) from None
         return results
 

--- a/pymongo/synchronous/srv_resolver.py
+++ b/pymongo/synchronous/srv_resolver.py
@@ -93,8 +93,8 @@ class _SrvResolver:
         try:
             split_fqdn = self.__fqdn.split(".")
             self.__plist = split_fqdn[1:] if len(split_fqdn) > 2 else split_fqdn
-        except Exception:
-            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,)) from None
+        except Exception as exc:
+            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,)) from exc
         self.__slen = len(self.__plist)
         self.nparts = len(split_fqdn)
 
@@ -107,7 +107,7 @@ class _SrvResolver:
             # No TXT records
             return None
         except Exception as exc:
-            raise ConfigurationError(str(exc)) from None
+            raise ConfigurationError(str(exc)) from exc
         if len(results) > 1:
             raise ConfigurationError("Only one TXT record is supported")
         return (b"&".join([b"".join(res.strings) for res in results])).decode("utf-8")  # type: ignore[attr-defined]
@@ -122,8 +122,7 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
-            raise ValueError(f"{self.__srv=} {self.__fqdn=} {exc=}") from None
-            raise ConfigurationError(str(exc)) from None
+            raise ConfigurationError(str(exc)) from exc
         return results
 
     def _get_srv_response_and_hosts(
@@ -146,8 +145,8 @@ class _SrvResolver:
                 )
             try:
                 nlist = srv_host.split(".")[1:][-self.__slen :]
-            except Exception:
-                raise ConfigurationError(f"Invalid SRV host: {node[0]}") from None
+            except Exception as exc:
+                raise ConfigurationError(f"Invalid SRV host: {node[0]}") from exc
             if self.__plist != nlist:
                 raise ConfigurationError(f"Invalid SRV host: {node[0]}")
         if self.__srv_max_hosts:

--- a/pymongo/synchronous/srv_resolver.py
+++ b/pymongo/synchronous/srv_resolver.py
@@ -93,8 +93,8 @@ class _SrvResolver:
         try:
             split_fqdn = self.__fqdn.split(".")
             self.__plist = split_fqdn[1:] if len(split_fqdn) > 2 else split_fqdn
-        except Exception as exc:
-            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,)) from exc
+        except Exception:
+            raise ConfigurationError(_INVALID_HOST_MSG % (fqdn,)) from None
         self.__slen = len(self.__plist)
         self.nparts = len(split_fqdn)
 
@@ -122,11 +122,7 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
-            import traceback
-
-            raise ConfigurationError(
-                traceback.format_exception(type(exc), exc, exc.__traceback__)
-            ) from exc
+            raise ConfigurationError(str(exc)) from exc
         return results
 
     def _get_srv_response_and_hosts(

--- a/pymongo/synchronous/srv_resolver.py
+++ b/pymongo/synchronous/srv_resolver.py
@@ -113,6 +113,7 @@ class _SrvResolver:
         return (b"&".join([b"".join(res.strings) for res in results])).decode("utf-8")  # type: ignore[attr-defined]
 
     def _resolve_uri(self, encapsulate_errors: bool) -> resolver.Answer:
+        print(f"{self.__srv=} {self.__fqdn=}")  # noqa: T201
         try:
             results = _resolve(
                 "_" + self.__srv + "._tcp." + self.__fqdn, "SRV", lifetime=self.__connect_timeout

--- a/pymongo/synchronous/srv_resolver.py
+++ b/pymongo/synchronous/srv_resolver.py
@@ -122,7 +122,9 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
-            raise ConfigurationError(str(exc)) from exc
+            import traceback
+
+            raise ConfigurationError(traceback.format_exception(exc)) from exc
         return results
 
     def _get_srv_response_and_hosts(

--- a/pymongo/synchronous/srv_resolver.py
+++ b/pymongo/synchronous/srv_resolver.py
@@ -113,7 +113,6 @@ class _SrvResolver:
         return (b"&".join([b"".join(res.strings) for res in results])).decode("utf-8")  # type: ignore[attr-defined]
 
     def _resolve_uri(self, encapsulate_errors: bool) -> resolver.Answer:
-        print(f"{self.__srv=} {self.__fqdn=}")  # noqa: T201
         try:
             results = _resolve(
                 "_" + self.__srv + "._tcp." + self.__fqdn, "SRV", lifetime=self.__connect_timeout
@@ -123,6 +122,7 @@ class _SrvResolver:
                 # Raise the original error.
                 raise
             # Else, raise all errors as ConfigurationError.
+            raise ValueError(f"{self.__srv=} {self.__fqdn=}") from None
             raise ConfigurationError(str(exc)) from None
         return results
 

--- a/test/lambda/build_internal.sh
+++ b/test/lambda/build_internal.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
 
 cd /src
-PYTHON=/opt/python/cp39-cp39/bin/python
+PYTHON=/opt/python/cp310-cp310/bin/python
 $PYTHON -m pip install -v -e .

--- a/test/lambda/template.yaml
+++ b/test/lambda/template.yaml
@@ -23,7 +23,7 @@ Resources:
         Variables:
           MONGODB_URI: !Ref MongoDbUri
       Handler: app.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.10
       Architectures:
         - x86_64
       Events:


### PR DESCRIPTION
Updated to use Python 3.10, which solved a dns resolve error on lambda.

I did not find the root cause, but since 3.9 is EOL next month I left it at this solution.

I also updated the errors raised by srv_resolver to include the original error, which was useful in debugging the problem.

Passing build: https://spruce.mongodb.com/task/mongo_python_driver_faas_lambda_test_aws_lambda_deployed_patch_eca38b730b8227c52cd5f0c655f617e969743ee1_68c9e481e31406000770e31e_25_09_16_22_28_25/logs?execution=0