### PR TITLE
Remove Python 2 compatibility SON methods

### DIFF
--- a/bson/son.py
+++ b/bson/son.py
@@ -98,17 +98,6 @@ class SON(Dict[_Key, _Value]):
     def __iter__(self) -> Iterator[_Key]:
         yield from self.__keys
 
-    def has_key(self, key: _Key) -> bool:
-        return key in self.__keys
-
-    def iterkeys(self) -> Iterator[_Key]:
-        return self.__iter__()
-
-    # fourth level uses definitions from lower levels
-    def itervalues(self) -> Iterator[_Value]:
-        for _, v in self.items():
-            yield v
-
     def values(self) -> list[_Value]:  # type: ignore[override]
         return [v for _, v in self.items()]
 

--- a/test/test_son.py
+++ b/test/test_son.py
@@ -144,14 +144,12 @@ class TestSON(unittest.TestCase):
         for ele in test_son:
             self.assertEqual(ele * 100, test_son[ele])
 
-    def test_contains_has(self):
+    def test_contains(self):
         """has_key and __contains__"""
         test_son = SON([(1, 100), (2, 200), (3, 300)])
         self.assertIn(1, test_son)
         self.assertIn(2, test_son, "in failed")
         self.assertNotIn(22, test_son, "in succeeded when it shouldn't")
-        self.assertTrue(test_son.has_key(2), "has_key failed")
-        self.assertFalse(test_son.has_key(22), "has_key succeeded when it shouldn't")
 
     def test_clears(self):
         """Test clear()"""


### PR DESCRIPTION
Python 3.0 [removed `dict.has_key()`](https://docs.python.org/3/whatsnew/3.0.html#views-and-iterators-instead-of-lists:~:text=Removed%2E%20dict%2Ehas%5Fkey%28%29) and [the `dict.iter*()` methods](https://docs.python.org/3/whatsnew/3.0.html#views-and-iterators-instead-of-lists:~:text=Also%2C%20the%20dict%2Eiterkeys%28%29%2C%20dict%2Eiteritems%28%29%20and%20dict%2Eitervalues%28%29%20methods%20are%20no%20longer%20supported).

fcedc510e1039ab47b1c2d52f1392f298feaf81b removed `SON.iteritems()` to align with its removal in Python 3. This commit cleans up by removing the remaining compatibility methods: `has_key()`, `iterkeys()`, and `itervalues()`.