### PR TITLE
PYTHON-3414 Improve error message when using incompatible dependencies

### DIFF
--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -66,7 +66,12 @@ from pymongo.asynchronous.database import AsyncDatabase
 from pymongo.asynchronous.mongo_client import AsyncMongoClient
 from pymongo.common import CONNECT_TIMEOUT
 from pymongo.daemon import _spawn_daemon
-from pymongo.encryption_options import AutoEncryptionOpts, RangeOpts, TextOpts
+from pymongo.encryption_options import (
+    AutoEncryptionOpts,
+    RangeOpts,
+    TextOpts,
+    check_min_pymongocrypt,
+)
 from pymongo.errors import (
     ConfigurationError,
     EncryptedCollectionError,
@@ -674,6 +679,8 @@ class AsyncClientEncryption(Generic[_DocumentType]):
                 "library: install a compatible version with: "
                 "python -m pip install --upgrade 'pymongo[encryption]'"
             )
+
+        check_min_pymongocrypt()
 
         if not isinstance(codec_options, CodecOptions):
             raise TypeError(

--- a/pymongo/asynchronous/srv_resolver.py
+++ b/pymongo/asynchronous/srv_resolver.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 
 import ipaddress
 import random
+from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from pymongo.common import CONNECT_TIMEOUT
+from pymongo.common import CONNECT_TIMEOUT, check_for_min_version
 from pymongo.errors import ConfigurationError
 
 if TYPE_CHECKING:
@@ -31,6 +32,15 @@ _IS_SYNC = False
 def _have_dnspython() -> bool:
     try:
         import dns  # noqa: F401
+
+        dns_version = version("dnspython")
+        required_version, is_valid = check_for_min_version(dns_version, "dnspython")
+        if not is_valid:
+            raise RuntimeError(
+                f"pymongo requires dnspython>={required_version}, "
+                f"found version {dns_version}. "
+                "Install a compatible version with pip"
+            )
 
         return True
     except ImportError:
@@ -80,6 +90,8 @@ class _SrvResolver:
         srv_service_name: str,
         srv_max_hosts: int = 0,
     ):
+        # Ensure the version of dnspython is compatible.
+        _have_dnspython()
         self.__fqdn = fqdn
         self.__srv = srv_service_name
         self.__connect_timeout = connect_timeout or CONNECT_TIMEOUT

--- a/pymongo/asynchronous/srv_resolver.py
+++ b/pymongo/asynchronous/srv_resolver.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import ipaddress
 import random
-from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pymongo.common import CONNECT_TIMEOUT, check_for_min_version
@@ -33,8 +32,7 @@ def _have_dnspython() -> bool:
     try:
         import dns  # noqa: F401
 
-        dns_version = version("dnspython")
-        required_version, is_valid = check_for_min_version(dns_version, "dnspython")
+        dns_version, required_version, is_valid = check_for_min_version("dnspython")
         if not is_valid:
             raise RuntimeError(
                 f"pymongo requires dnspython>={required_version}, "

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -1171,4 +1171,4 @@ def check_for_min_version(package_version: str, package_name: str) -> tuple[str,
     if ";" in requirement:
         requirement = requirement.split(";")[0]
     required_version = requirement[requirement.find(">=") + 2 :]
-    return required_version, package_version > Version.from_string(required_version)
+    return required_version, package_version >= Version.from_string(required_version)

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -1096,6 +1096,8 @@ def has_c() -> bool:
 
 
 class Version(tuple):
+    """A class that can be used to compare version strings."""
+
     def __new__(cls, *version):
         padded_version = cls._padded(version, 4)
         return super().__new__(cls, tuple(padded_version))
@@ -1161,8 +1163,12 @@ class Version(tuple):
 
 def check_for_min_version(package_version: str, package_name: str) -> tuple[str, bool]:
     package_version = Version.from_string(package_version)
-    requirement = (
-        [i for i in requires("pymongo") if i.startswith(package_name)].next().split(";").next()
-    )
+    # Dependency is expected to be in one of the forms:
+    # "pymongocrypt<2.0.0,>=1.13.0; extra == 'encryption'"
+    # 'dnspython<3.0.0,>=1.16.0'
+    #
+    requirement = [i for i in requires("pymongo") if i.startswith(package_name)][0]  # noqa: RUF015
+    if ";" in requirement:
+        requirement = requirement.split(";")[0]
     required_version = requirement[requirement.find(">=") + 2 :]
     return required_version, package_version > Version.from_string(required_version)

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -1123,6 +1123,10 @@ class Version(tuple[int, ...]):
         elif version_string.endswith("-"):
             version_string = version_string[0:-1]
             mod = -1
+        # Deal with .devX substrings
+        if ".dev" in version_string:
+            version_string = version_string[0 : version_string.find(".dev")]
+            mod = -1
         # Deal with '-rcX' substrings
         if "-rc" in version_string:
             version_string = version_string[0 : version_string.find("-rc")]

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -1095,7 +1095,7 @@ def has_c() -> bool:
         return False
 
 
-class Version(tuple[int]):
+class Version(tuple[int, ...]):
     """A class that can be used to compare version strings."""
 
     def __new__(cls, *version: int) -> Version:

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, TypedDict
 from pymongo.uri_parser_shared import _parse_kms_tls_options
 
 try:
-    from pymongocrypt import __version__ as pymongocrypt_version  # type:ignore[import-untyped]
+    import pymongocrypt  # type:ignore[import-untyped]  # noqa: F401
 
     # Check for pymongocrypt>=1.10.
     from pymongocrypt import synchronous as _  # noqa: F401
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 
 def check_min_pymongocrypt() -> None:
     """Raise an appropriate error if the min pymongocrypt is not installed."""
-    required_version, is_valid = check_for_min_version(pymongocrypt_version, "pymongocrypt")
+    pymongocrypt_version, required_version, is_valid = check_for_min_version("pymongocrypt")
     if not is_valid:
         raise ConfigurationError(
             f"client side encryption requires pymongocrypt>={required_version}, "

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -45,7 +45,7 @@ def check_min_pymongocrypt() -> None:
     required_version, is_valid = check_for_min_version(pymongocrypt_version, "pymongocrypt")
     if not is_valid:
         raise ConfigurationError(
-            f"client side encryption requires the pymongocrypt>={required_version}, "
+            f"client side encryption requires pymongocrypt>={required_version}, "
             f"found version {pymongocrypt_version}. "
             "Install a compatible version with: "
             "python -m pip install 'pymongo[encryption]'"

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -61,7 +61,12 @@ from bson.raw_bson import DEFAULT_RAW_BSON_OPTIONS, RawBSONDocument, _inflate_bs
 from pymongo import _csot
 from pymongo.common import CONNECT_TIMEOUT
 from pymongo.daemon import _spawn_daemon
-from pymongo.encryption_options import AutoEncryptionOpts, RangeOpts, TextOpts
+from pymongo.encryption_options import (
+    AutoEncryptionOpts,
+    RangeOpts,
+    TextOpts,
+    check_min_pymongocrypt,
+)
 from pymongo.errors import (
     ConfigurationError,
     EncryptedCollectionError,
@@ -671,6 +676,8 @@ class ClientEncryption(Generic[_DocumentType]):
                 "library: install a compatible version with: "
                 "python -m pip install --upgrade 'pymongo[encryption]'"
             )
+
+        check_min_pymongocrypt()
 
         if not isinstance(codec_options, CodecOptions):
             raise TypeError(

--- a/pymongo/synchronous/srv_resolver.py
+++ b/pymongo/synchronous/srv_resolver.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import ipaddress
 import random
-from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pymongo.common import CONNECT_TIMEOUT, check_for_min_version
@@ -33,8 +32,7 @@ def _have_dnspython() -> bool:
     try:
         import dns  # noqa: F401
 
-        dns_version = version("dnspython")
-        required_version, is_valid = check_for_min_version(dns_version, "dnspython")
+        dns_version, required_version, is_valid = check_for_min_version("dnspython")
         if not is_valid:
             raise RuntimeError(
                 f"pymongo requires dnspython>={required_version}, "

--- a/pymongo/synchronous/srv_resolver.py
+++ b/pymongo/synchronous/srv_resolver.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 
 import ipaddress
 import random
+from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from pymongo.common import CONNECT_TIMEOUT
+from pymongo.common import CONNECT_TIMEOUT, check_for_min_version
 from pymongo.errors import ConfigurationError
 
 if TYPE_CHECKING:
@@ -31,6 +32,15 @@ _IS_SYNC = True
 def _have_dnspython() -> bool:
     try:
         import dns  # noqa: F401
+
+        dns_version = version("dnspython")
+        required_version, is_valid = check_for_min_version(dns_version, "dnspython")
+        if not is_valid:
+            raise RuntimeError(
+                f"pymongo requires dnspython>={required_version}, "
+                f"found version {dns_version}. "
+                "Install a compatible version with pip"
+            )
 
         return True
     except ImportError:
@@ -80,6 +90,8 @@ class _SrvResolver:
         srv_service_name: str,
         srv_max_hosts: int = 0,
     ):
+        # Ensure the version of dnspython is compatible.
+        _have_dnspython()
         self.__fqdn = fqdn
         self.__srv = srv_service_name
         self.__connect_timeout = connect_timeout or CONNECT_TIMEOUT

--- a/test/version.py
+++ b/test/version.py
@@ -15,64 +15,10 @@
 """Some tools for running tests based on MongoDB server version."""
 from __future__ import annotations
 
+from pymongo.common import Version as BaseVersion
 
-class Version(tuple):
-    def __new__(cls, *version):
-        padded_version = cls._padded(version, 4)
-        return super().__new__(cls, tuple(padded_version))
 
-    @classmethod
-    def _padded(cls, iter, length, padding=0):
-        l = list(iter)
-        if len(l) < length:
-            for _ in range(length - len(l)):
-                l.append(padding)
-        return l
-
-    @classmethod
-    def from_string(cls, version_string):
-        mod = 0
-        bump_patch_level = False
-        if version_string.endswith("+"):
-            version_string = version_string[0:-1]
-            mod = 1
-        elif version_string.endswith("-pre-"):
-            version_string = version_string[0:-5]
-            mod = -1
-        elif version_string.endswith("-"):
-            version_string = version_string[0:-1]
-            mod = -1
-        # Deal with '-rcX' substrings
-        if "-rc" in version_string:
-            version_string = version_string[0 : version_string.find("-rc")]
-            mod = -1
-        # Deal with git describe generated substrings
-        elif "-" in version_string:
-            version_string = version_string[0 : version_string.find("-")]
-            mod = -1
-            bump_patch_level = True
-
-        version = [int(part) for part in version_string.split(".")]
-        version = cls._padded(version, 3)
-        # Make from_string and from_version_array agree. For example:
-        # MongoDB Enterprise > db.runCommand('buildInfo').versionArray
-        # [ 3, 2, 1, -100 ]
-        # MongoDB Enterprise > db.runCommand('buildInfo').version
-        # 3.2.0-97-g1ef94fe
-        if bump_patch_level:
-            version[-1] += 1
-        version.append(mod)
-
-        return Version(*version)
-
-    @classmethod
-    def from_version_array(cls, version_array):
-        version = list(version_array)
-        if version[-1] < 0:
-            version[-1] = -1
-        version = cls._padded(version, 3)
-        return Version(*version)
-
+class Version(BaseVersion):
     @classmethod
     def from_client(cls, client):
         info = client.server_info()
@@ -86,9 +32,3 @@ class Version(tuple):
         if "versionArray" in info:
             return cls.from_version_array(info["versionArray"])
         return cls.from_string(info["version"])
-
-    def at_least(self, *other_version):
-        return self >= Version(*other_version)
-
-    def __str__(self):
-        return ".".join(map(str, self))


### PR DESCRIPTION
Example errors:

```python
>>> from pymongo.encryption_options import AutoEncryptionOpts
>>> AutoEncryptionOpts({}, "foo.bar")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/steve.silvester/workspace/mongo-python-driver/pymongo/encryption_options.py", line 230, in __init__
    check_min_pymongocrypt()
  File "/Users/steve.silvester/workspace/mongo-python-driver/pymongo/encryption_options.py", line 47, in check_min_pymongocrypt
    raise ConfigurationError(
pymongo.errors.ConfigurationError: client side encryption requires pymongocrypt>=1.13.0, found version 1.11.0. Install a compatible version with: python -m pip install 'pymongo[encryption]'
```

```python
>>> from pymongo.asynchronous.srv_resolver import _SrvResolver
>>> _SrvResolver('1', 1, '1')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/steve.silvester/workspace/mongo-python-driver/pymongo/asynchronous/srv_resolver.py", line 93, in __init__
    _have_dnspython()
  File "/Users/steve.silvester/workspace/mongo-python-driver/pymongo/asynchronous/srv_resolver.py", line 38, in _have_dnspython
    raise RuntimeError(
RuntimeError: pymongo requires dnspython>=1.16.0, found version 1.15.0. Install a compatible version with pip
```