### PR TITLE
PYTHON-4755 - Stop supporting and testing against Eventlet

### DIFF
--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -319,14 +319,6 @@ buildvariants:
     tags: []
 
   # Green framework tests
-  - name: green-eventlet-rhel8
-    tasks:
-      - name: .test-standard .python-3.9 .sync
-    display_name: Green Eventlet RHEL8
-    run_on:
-      - rhel87-small
-    expansions:
-      GREEN_FRAMEWORK: eventlet
   - name: green-gevent-rhel8
     tasks:
       - name: .test-standard .sync

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -300,12 +300,8 @@ def create_stable_api_variants():
 def create_green_framework_variants():
     variants = []
     host = DEFAULT_HOST
-    for framework in ["eventlet", "gevent"]:
+    for framework in ["gevent"]:
         tasks = [".test-standard .sync"]
-        if framework == "eventlet":
-            # Eventlet has issues with dnspython > 2.0 and newer versions of CPython
-            # https://jira.mongodb.org/browse/PYTHON-5284
-            tasks = [".test-standard .python-3.9 .sync"]
         expansions = dict(GREEN_FRAMEWORK=framework)
         display_name = get_variant_name(f"Green {framework.capitalize()}", host)
         variant = create_variant(tasks, display_name, host=host, expansions=expansions)

--- a/.evergreen/scripts/run_tests.py
+++ b/.evergreen/scripts/run_tests.py
@@ -67,13 +67,7 @@ def handle_perf(start_time: datetime):
 
 
 def handle_green_framework() -> None:
-    if GREEN_FRAMEWORK == "eventlet":
-        import eventlet
-
-        # https://github.com/eventlet/eventlet/issues/401
-        eventlet.sleep()
-        eventlet.monkey_patch()
-    elif GREEN_FRAMEWORK == "gevent":
+    if GREEN_FRAMEWORK == "gevent":
         from gevent import monkey
 
         monkey.patch_all()

--- a/.evergreen/scripts/utils.py
+++ b/.evergreen/scripts/utils.py
@@ -104,7 +104,7 @@ def get_test_options(
         parser.add_argument(
             "--green-framework",
             nargs=1,
-            choices=["eventlet", "gevent"],
+            choices=["gevent"],
             help="Optional green framework to test against.",
         )
         parser.add_argument(

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,8 @@ PyMongo 4.16 brings a number of changes including:
 - Removed invalid documents from :class:`bson.errors.InvalidDocument` error messages as
   doing so may leak sensitive user data.
   Instead, invalid documents are stored in :attr:`bson.errors.InvalidDocument.document`.
+- Removed support for Eventlet.
+  Eventlet is actively being sunset by its maintainers and has compatibility issues with PyMongo's dnspython dependency.
 
 Changes in Version 4.15.1 (2025/09/16)
 --------------------------------------

--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -628,7 +628,7 @@ class AsyncConnection:
         # signals and throws KeyboardInterrupt into the current frame on the
         # main thread.
         #
-        # But in Gevent and Eventlet, the polling mechanism (epoll, kqueue,
+        # But in Gevent, the polling mechanism (epoll, kqueue,
         # ..) is called in Python code, which experiences the signal as a
         # KeyboardInterrupt from the start, rather than as an initial
         # socket.error, so we catch that, close the socket, and reraise it.

--- a/pymongo/pool_shared.py
+++ b/pymongo/pool_shared.py
@@ -138,13 +138,11 @@ def _raise_connection_failure(
         msg = msg_prefix + msg
     if "configured timeouts" not in msg:
         msg += format_timeout_details(timeout_details)
-    if isinstance(error, socket.timeout):
-        raise NetworkTimeout(msg) from error
-    elif isinstance(error, SSLErrors) and "timed out" in str(error):
-        # Eventlet does not distinguish TLS network timeouts from other
-        # SSLErrors (https://github.com/eventlet/eventlet/issues/692).
-        # Luckily, we can work around this limitation because the phrase
-        # 'timed out' appears in all the timeout related SSLErrors raised.
+    if (
+        isinstance(error, socket.timeout)
+        or isinstance(error, SSLErrors)
+        and "timed out" in str(error)
+    ):
         raise NetworkTimeout(msg) from error
     else:
         raise AutoReconnect(msg) from error

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -626,7 +626,7 @@ class Connection:
         # signals and throws KeyboardInterrupt into the current frame on the
         # main thread.
         #
-        # But in Gevent and Eventlet, the polling mechanism (epoll, kqueue,
+        # But in Gevent, the polling mechanism (epoll, kqueue,
         # ..) is called in Python code, which experiences the signal as a
         # KeyboardInterrupt from the start, rather than as an initial
         # socket.error, so we catch that, close the socket, and reraise it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dev = [
 pip = ["pip"]
 # TODO: PYTHON-5464
 gevent = ["gevent", "cffi>=2.0.0b1;python_version=='3.14'"]
-eventlet = ["eventlet"]
 coverage = [
     "pytest-cov",
     "coverage>=5,<=7.10.6"
@@ -113,15 +112,12 @@ filterwarnings = [
     "module:.*WindowsSelectorEventLoopPolicy:DeprecationWarning",
     "module:.*et_event_loop_policy:DeprecationWarning",
     # TODO: Remove as part of PYTHON-3923.
-    "module:unclosed <eventlet.green.ssl.GreenSSLSocket:ResourceWarning",
     "module:unclosed <socket.socket:ResourceWarning",
     "module:unclosed <ssl.SSLSocket:ResourceWarning",
     "module:unclosed <socket object:ResourceWarning",
     "module:unclosed transport:ResourceWarning",
     # pytest-asyncio known issue: https://github.com/pytest-dev/pytest-asyncio/issues/724
     "module:unclosed event loop:ResourceWarning",
-    # https://github.com/eventlet/eventlet/issues/818
-    "module:please use dns.resolver.Resolver.resolve:DeprecationWarning",
     # https://github.com/dateutil/dateutil/issues/1314
     "module:datetime.datetime.utc:DeprecationWarning",
 ]

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -399,7 +399,7 @@ class TestClientSimple(AsyncEncryptionIntegrationTest):
     )
     @unittest.skipIf(
         is_greenthread_patched(),
-        "gevent and eventlet do not support POSIX-style forking.",
+        "gevent does not support POSIX-style forking.",
     )
     @async_client_context.require_sync
     async def test_fork(self):

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -399,7 +399,7 @@ class TestClientSimple(EncryptionIntegrationTest):
     )
     @unittest.skipIf(
         is_greenthread_patched(),
-        "gevent and eventlet do not support POSIX-style forking.",
+        "gevent does not support POSIX-style forking.",
     )
     @client_context.require_sync
     def test_fork(self):

--- a/test/test_fork.py
+++ b/test/test_fork.py
@@ -34,7 +34,7 @@ from bson.objectid import ObjectId
 )
 @unittest.skipIf(
     is_greenthread_patched(),
-    "gevent and eventlet do not support POSIX-style forking.",
+    "gevent does not support POSIX-style forking.",
 )
 class TestFork(IntegrationTest):
     def test_lock_client(self):

--- a/test/utils_shared.py
+++ b/test/utils_shared.py
@@ -528,15 +528,8 @@ def gevent_monkey_patched():
         return False
 
 
-def eventlet_monkey_patched():
-    """Check if eventlet's monkey patching is active."""
-    import threading
-
-    return threading.current_thread.__module__ == "eventlet.green.threading"
-
-
 def is_greenthread_patched():
-    return gevent_monkey_patched() or eventlet_monkey_patched()
+    return gevent_monkey_patched()
 
 
 def parse_read_preference(pref):

--- a/uv.lock
+++ b/uv.lock
@@ -698,19 +698,6 @@ wheels = [
 ]
 
 [[package]]
-name = "eventlet"
-version = "0.40.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dnspython" },
-    { name = "greenlet" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/a3/500893510ad316fc571d116d407ea17d6007a8ecdb0a456badb66eee42ae/eventlet-0.40.2.tar.gz", hash = "sha256:42636c277f761d026905cd0ba0a11edec7600001be401d6ae7e9546559c8d8b0", size = 565548, upload-time = "2025-07-22T14:49:54.317Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/41/2e2d46f31ed22c1c147936145badb86e0e28ba7fe7d7a54aa69849a93a52/eventlet-0.40.2-py3-none-any.whl", hash = "sha256:590c67b982015bc6b753a5303f3ec7356bc7890a39efd65176179f0113f5d35e", size = 364228, upload-time = "2025-07-22T14:49:52.082Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1277,9 +1264,6 @@ coverage = [
 dev = [
     { name = "pre-commit" },
 ]
-eventlet = [
-    { name = "eventlet" },
-]
 gevent = [
     { name = "cffi", version = "2.0.0b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.14.*'" },
     { name = "gevent" },
@@ -1309,7 +1293,7 @@ requires-dist = [
     { name = "furo", marker = "extra == 'docs'", specifier = "==2025.7.19" },
     { name = "importlib-metadata", marker = "python_full_version < '3.13' and extra == 'test'", specifier = ">=7.0" },
     { name = "pykerberos", marker = "os_name != 'nt' and extra == 'gssapi'" },
-    { name = "pymongo-auth-aws", marker = "extra == 'aws'", specifier = ">=1.1.1,<2.0.0" },
+    { name = "pymongo-auth-aws", marker = "extra == 'aws'", specifier = ">=1.1.0,<2.0.0" },
     { name = "pymongo-auth-aws", marker = "extra == 'encryption'", specifier = ">=1.1.0,<2.0.0" },
     { name = "pymongocrypt", marker = "extra == 'encryption'", specifier = ">=1.13.0,<2.0.0" },
     { name = "pyopenssl", marker = "extra == 'ocsp'", specifier = ">=17.2.0" },
@@ -1334,7 +1318,6 @@ coverage = [
     { name = "pytest-cov" },
 ]
 dev = [{ name = "pre-commit", specifier = ">=4.0" }]
-eventlet = [{ name = "eventlet" }]
 gevent = [
     { name = "cffi", marker = "python_full_version == '3.14.*'", specifier = ">=2.0.0b1" },
     { name = "gevent" },


### PR DESCRIPTION
## Summary
[Eventlet is deprecated](https://eventlet.readthedocs.io/en/latest/asyncio/migration.html#migration-guide), and we should not continue supporting and testing against it.

## Changes in this PR

Remove Eventlet testing variants and code specific to Eventlet.

## Test Plan

Run a full test matrix to verify no regressions. 

### Screenshots (optional)

N/A

## Checklist

### Checklist for Author

- [X] Did you update the changelog (if necessary)?   
- [x] Is the intention of the code captured in relevant tests?  
- [x] If there are new TODOs, has a related JIRA ticket been created? ([PYTHON-5573](https://jira.mongodb.org/browse/PYTHON-5573))

### Checklist for Reviewer 

- [] Does the title of the PR reference a JIRA Ticket?  
- [] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)  
- [] Have you checked for spelling & grammar errors?  
- [] Is all relevant documentation (README or docstring) updated?

## Focus Areas for Reviewer
* Are code changes limited to Eventlet-specific logic and functionality?