### PR TITLE
PYTHON-5480 Update Python 3.9-specific tests to use Python 3.10

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -9,7 +9,7 @@ tasks:
     tags: [aws_lambda]
 
   # Aws tests
-  - name: test-auth-aws-4.4-regular-python3.9
+  - name: test-auth-aws-4.4-regular-python3.10
     commands:
       - func: run server
         vars:
@@ -20,9 +20,9 @@ tasks:
         vars:
           TEST_NAME: auth_aws
           SUB_TEST_NAME: regular
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
     tags: [auth-aws, auth-aws-regular]
-  - name: test-auth-aws-5.0-assume-role-python3.10
+  - name: test-auth-aws-5.0-assume-role-python3.9
     commands:
       - func: run server
         vars:
@@ -33,7 +33,7 @@ tasks:
         vars:
           TEST_NAME: auth_aws
           SUB_TEST_NAME: assume-role
-          PYTHON_VERSION: "3.10"
+          PYTHON_VERSION: "3.9"
     tags: [auth-aws, auth-aws-assume-role]
   - name: test-auth-aws-6.0-ec2-python3.11
     commands:
@@ -101,7 +101,7 @@ tasks:
           AWS_ROLE_SESSION_NAME: test
           PYTHON_VERSION: "3.14"
     tags: [auth-aws, auth-aws-web-identity]
-  - name: test-auth-aws-latest-ecs-python3.9
+  - name: test-auth-aws-latest-ecs-python3.10
     commands:
       - func: run server
         vars:
@@ -112,7 +112,7 @@ tasks:
         vars:
           TEST_NAME: auth_aws
           SUB_TEST_NAME: ecs
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
     tags: [auth-aws, auth-aws-ecs]
 
   # Backport pr tests
@@ -209,29 +209,29 @@ tasks:
     tags: [pr]
 
   # Mod wsgi tests
-  - name: mod-wsgi-replica-set-python3.9
+  - name: mod-wsgi-replica-set-python3.10
     commands:
       - func: run server
         vars:
           TOPOLOGY: replica_set
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
       - func: run tests
         vars:
           TEST_NAME: mod_wsgi
           SUB_TEST_NAME: standalone
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
     tags: [mod_wsgi, pr]
-  - name: mod-wsgi-embedded-mode-replica-set-python3.10
+  - name: mod-wsgi-embedded-mode-replica-set-python3.9
     commands:
       - func: run server
         vars:
           TOPOLOGY: replica_set
-          PYTHON_VERSION: "3.10"
+          PYTHON_VERSION: "3.9"
       - func: run tests
         vars:
           TEST_NAME: mod_wsgi
           SUB_TEST_NAME: embedded
-          PYTHON_VERSION: "3.10"
+          PYTHON_VERSION: "3.9"
     tags: [mod_wsgi, pr]
   - name: mod-wsgi-replica-set-python3.11
     commands:
@@ -283,13 +283,13 @@ tasks:
     tags: [mod_wsgi, pr]
 
   # No orchestration tests
-  - name: test-no-orchestration-python3.9
+  - name: test-no-orchestration-python3.10
     commands:
       - func: assume ec2 role
       - func: run tests
         vars:
-          PYTHON_VERSION: "3.9"
-    tags: [test-no-orchestration, python-3.9]
+          PYTHON_VERSION: "3.10"
+    tags: [test-no-orchestration, python-3.10]
   - name: test-no-orchestration-python3.14
     commands:
       - func: assume ec2 role
@@ -350,64 +350,64 @@ tasks:
     tags: [test-no-toolchain, sharded_cluster-auth-ssl]
 
   # Ocsp tests
-  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-ecdsa, "4.4"]
-  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-ecdsa, "5.0"]
-  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-ecdsa, "6.0"]
-  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-ecdsa, "7.0"]
-  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
-  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-ecdsa, rapid]
   - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-latest-python3.14
@@ -420,64 +420,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-ecdsa, latest]
-  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-ecdsa, "4.4"]
-  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-ecdsa, "5.0"]
-  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-ecdsa, "6.0"]
-  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-ecdsa, "7.0"]
-  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
-  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-ecdsa, rapid]
   - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-latest-python3.14
@@ -490,64 +490,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-ecdsa, latest]
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-ecdsa, "4.4"]
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-ecdsa, "5.0"]
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-ecdsa, "6.0"]
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-ecdsa, "7.0"]
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-ecdsa, rapid]
   - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-latest-python3.14
@@ -560,64 +560,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-ecdsa, latest]
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-ecdsa, "4.4"]
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-ecdsa, "5.0"]
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-ecdsa, "6.0"]
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-ecdsa, "7.0"]
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-ecdsa, rapid]
   - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-latest-python3.14
@@ -630,64 +630,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-ecdsa, latest]
-  - name: test-ocsp-ecdsa-soft-fail-v4.4-python3.9
+  - name: test-ocsp-ecdsa-soft-fail-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-ecdsa, "4.4"]
-  - name: test-ocsp-ecdsa-soft-fail-v5.0-python3.9
+  - name: test-ocsp-ecdsa-soft-fail-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-ecdsa, "5.0"]
-  - name: test-ocsp-ecdsa-soft-fail-v6.0-python3.9
+  - name: test-ocsp-ecdsa-soft-fail-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-ecdsa, "6.0"]
-  - name: test-ocsp-ecdsa-soft-fail-v7.0-python3.9
+  - name: test-ocsp-ecdsa-soft-fail-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-ecdsa, "7.0"]
-  - name: test-ocsp-ecdsa-soft-fail-v8.0-python3.9
+  - name: test-ocsp-ecdsa-soft-fail-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
-  - name: test-ocsp-ecdsa-soft-fail-rapid-python3.9
+  - name: test-ocsp-ecdsa-soft-fail-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-ecdsa, rapid]
   - name: test-ocsp-ecdsa-soft-fail-latest-python3.14
@@ -700,84 +700,84 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-ecdsa, latest]
-  - name: test-ocsp-ecdsa-valid-cert-server-staples-v4.4-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-staples-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "4.4"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-valid-cert-server-staples-v5.0-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-staples-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "5.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-valid-cert-server-staples-v6.0-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-staples-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "6.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-valid-cert-server-staples-v7.0-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-staples-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "7.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-valid-cert-server-staples-v8.0-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-staples-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "8.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-valid-cert-server-staples-rapid-python3.9
+  - name: test-ocsp-ecdsa-valid-cert-server-staples-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags:
       - ocsp
@@ -798,84 +798,84 @@ tasks:
       - ocsp-ecdsa
       - latest
       - ocsp-staple
-  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v4.4-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "4.4"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v5.0-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "5.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v6.0-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "6.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v7.0-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "7.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v8.0-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "8.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-invalid-cert-server-staples-rapid-python3.9
+  - name: test-ocsp-ecdsa-invalid-cert-server-staples-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags:
       - ocsp
@@ -896,84 +896,84 @@ tasks:
       - ocsp-ecdsa
       - latest
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v4.4-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "4.4"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v5.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "5.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v6.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "6.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v7.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "7.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v8.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "8.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-rapid-python3.9
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags:
       - ocsp
@@ -994,84 +994,84 @@ tasks:
       - ocsp-ecdsa
       - latest
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v4.4-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "4.4"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v5.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "5.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v6.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "6.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v7.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "7.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v8.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags:
       - ocsp
       - ocsp-ecdsa
       - "8.0"
       - ocsp-staple
-  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-rapid-python3.9
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags:
       - ocsp
@@ -1092,64 +1092,64 @@ tasks:
       - ocsp-ecdsa
       - latest
       - ocsp-staple
-  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-ecdsa, "4.4"]
-  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-ecdsa, "5.0"]
-  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-ecdsa, "6.0"]
-  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-ecdsa, "7.0"]
-  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
-  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-ecdsa, rapid]
   - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-latest-python3.14
@@ -1162,64 +1162,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-ecdsa, latest]
-  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-ecdsa, "4.4"]
-  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-ecdsa, "5.0"]
-  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-ecdsa, "6.0"]
-  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-ecdsa, "7.0"]
-  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
-  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-ecdsa, rapid]
   - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-latest-python3.14
@@ -1232,64 +1232,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-ecdsa, latest]
-  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-ecdsa, "4.4"]
-  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-ecdsa, "5.0"]
-  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-ecdsa, "6.0"]
-  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-ecdsa, "7.0"]
-  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
-  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-ecdsa, rapid]
   - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-latest-python3.14
@@ -1302,64 +1302,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-ecdsa, latest]
-  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-rsa, "4.4"]
-  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-rsa, "5.0"]
-  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-rsa, "6.0"]
-  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-rsa, "7.0"]
-  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-rsa, "8.0"]
-  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-rsa, rapid]
   - name: test-ocsp-rsa-valid-cert-server-does-not-staple-latest-python3.14
@@ -1372,64 +1372,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-rsa, latest]
-  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-rsa, "4.4"]
-  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-rsa, "5.0"]
-  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-rsa, "6.0"]
-  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-rsa, "7.0"]
-  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-rsa, "8.0"]
-  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-rsa, rapid]
   - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-latest-python3.14
@@ -1442,64 +1442,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-rsa, latest]
-  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-rsa, "4.4"]
-  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-rsa, "5.0"]
-  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-rsa, "6.0"]
-  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-rsa, "7.0"]
-  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-rsa, "8.0"]
-  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-rsa, rapid]
   - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-latest-python3.14
@@ -1512,64 +1512,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-rsa, latest]
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-rsa, "4.4"]
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-rsa, "5.0"]
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-rsa, "6.0"]
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-rsa, "7.0"]
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-rsa, "8.0"]
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-rsa, rapid]
   - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-latest-python3.14
@@ -1582,64 +1582,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-rsa, latest]
-  - name: test-ocsp-rsa-soft-fail-v4.4-python3.9
+  - name: test-ocsp-rsa-soft-fail-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-rsa, "4.4"]
-  - name: test-ocsp-rsa-soft-fail-v5.0-python3.9
+  - name: test-ocsp-rsa-soft-fail-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-rsa, "5.0"]
-  - name: test-ocsp-rsa-soft-fail-v6.0-python3.9
+  - name: test-ocsp-rsa-soft-fail-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-rsa, "6.0"]
-  - name: test-ocsp-rsa-soft-fail-v7.0-python3.9
+  - name: test-ocsp-rsa-soft-fail-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-rsa, "7.0"]
-  - name: test-ocsp-rsa-soft-fail-v8.0-python3.9
+  - name: test-ocsp-rsa-soft-fail-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-rsa, "8.0"]
-  - name: test-ocsp-rsa-soft-fail-rapid-python3.9
+  - name: test-ocsp-rsa-soft-fail-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-rsa, rapid]
   - name: test-ocsp-rsa-soft-fail-latest-python3.14
@@ -1652,84 +1652,84 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-rsa, latest]
-  - name: test-ocsp-rsa-valid-cert-server-staples-v4.4-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-staples-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags:
       - ocsp
       - ocsp-rsa
       - "4.4"
       - ocsp-staple
-  - name: test-ocsp-rsa-valid-cert-server-staples-v5.0-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-staples-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "5.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-valid-cert-server-staples-v6.0-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-staples-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "6.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-valid-cert-server-staples-v7.0-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-staples-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "7.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-valid-cert-server-staples-v8.0-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-staples-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "8.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-valid-cert-server-staples-rapid-python3.9
+  - name: test-ocsp-rsa-valid-cert-server-staples-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags:
       - ocsp
@@ -1750,84 +1750,84 @@ tasks:
       - ocsp-rsa
       - latest
       - ocsp-staple
-  - name: test-ocsp-rsa-invalid-cert-server-staples-v4.4-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-staples-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags:
       - ocsp
       - ocsp-rsa
       - "4.4"
       - ocsp-staple
-  - name: test-ocsp-rsa-invalid-cert-server-staples-v5.0-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-staples-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "5.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-invalid-cert-server-staples-v6.0-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-staples-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "6.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-invalid-cert-server-staples-v7.0-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-staples-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "7.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-invalid-cert-server-staples-v8.0-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-staples-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "8.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-invalid-cert-server-staples-rapid-python3.9
+  - name: test-ocsp-rsa-invalid-cert-server-staples-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags:
       - ocsp
@@ -1848,84 +1848,84 @@ tasks:
       - ocsp-rsa
       - latest
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v4.4-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags:
       - ocsp
       - ocsp-rsa
       - "4.4"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v5.0-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "5.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v6.0-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "6.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v7.0-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "7.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v8.0-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "8.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-rapid-python3.9
+  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: valid-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags:
       - ocsp
@@ -1946,84 +1946,84 @@ tasks:
       - ocsp-rsa
       - latest
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v4.4-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags:
       - ocsp
       - ocsp-rsa
       - "4.4"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v5.0-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "5.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v6.0-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "6.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v7.0-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "7.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v8.0-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags:
       - ocsp
       - ocsp-rsa
       - "8.0"
       - ocsp-staple
-  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-rapid-python3.9
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags:
       - ocsp
@@ -2044,64 +2044,64 @@ tasks:
       - ocsp-rsa
       - latest
       - ocsp-staple
-  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-rsa, "4.4"]
-  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-rsa, "5.0"]
-  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-rsa, "6.0"]
-  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-rsa, "7.0"]
-  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-rsa, "8.0"]
-  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-rsa, rapid]
   - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-latest-python3.14
@@ -2114,64 +2114,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-rsa, latest]
-  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-rsa, "4.4"]
-  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-rsa, "5.0"]
-  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-rsa, "6.0"]
-  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-rsa, "7.0"]
-  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-rsa, "8.0"]
-  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: revoked-delegate
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-rsa, rapid]
   - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-latest-python3.14
@@ -2184,64 +2184,64 @@ tasks:
           PYTHON_VERSION: "3.14"
           VERSION: latest
     tags: [ocsp, ocsp-rsa, latest]
-  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v4.4-python3.9
+  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v4.4-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "4.4"
     tags: [ocsp, ocsp-rsa, "4.4"]
-  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v5.0-python3.9
+  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v5.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "5.0"
     tags: [ocsp, ocsp-rsa, "5.0"]
-  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v6.0-python3.9
+  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v6.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "6.0"
     tags: [ocsp, ocsp-rsa, "6.0"]
-  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v7.0-python3.9
+  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v7.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "7.0"
     tags: [ocsp, ocsp-rsa, "7.0"]
-  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v8.0-python3.9
+  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v8.0-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: "8.0"
     tags: [ocsp, ocsp-rsa, "8.0"]
-  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-rapid-python3.9
+  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-rapid-python3.10
     commands:
       - func: run tests
         vars:
           ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
           OCSP_SERVER_TYPE: no-responder
           TEST_NAME: ocsp
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           VERSION: rapid
     tags: [ocsp, ocsp-rsa, rapid]
   - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-latest-python3.14
@@ -2366,28 +2366,7 @@ tasks:
     tags: [search_index]
 
   # Server version tests
-  - name: test-server-version-python3.9-sync-auth-ssl-standalone-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: standalone
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: standalone
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - server-version
-      - python-3.9
-      - standalone-auth-ssl
-      - sync
-  - name: test-server-version-python3.10-async-auth-ssl-standalone-cov
+  - name: test-server-version-python3.10-sync-auth-ssl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -2402,10 +2381,31 @@ tasks:
           TOPOLOGY: standalone
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
       - server-version
       - python-3.10
+      - standalone-auth-ssl
+      - sync
+  - name: test-server-version-python3.9-async-auth-ssl-standalone-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: standalone
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.9
       - standalone-auth-ssl
       - async
   - name: test-server-version-python3.11-sync-auth-nossl-standalone-cov
@@ -2512,7 +2512,7 @@ tasks:
       - standalone-noauth-nossl
       - sync
       - pr
-  - name: test-server-version-python3.9-async-noauth-nossl-standalone-cov
+  - name: test-server-version-python3.10-async-noauth-nossl-standalone-cov
     commands:
       - func: run server
         vars:
@@ -2526,15 +2526,15 @@ tasks:
           SSL: nossl
           TOPOLOGY: standalone
           COVERAGE: "1"
-          PYTHON_VERSION: "3.9"
+          PYTHON_VERSION: "3.10"
           TEST_NAME: default_async
     tags:
       - server-version
-      - python-3.9
+      - python-3.10
       - standalone-noauth-nossl
       - async
       - pr
-  - name: test-server-version-python3.10-sync-auth-ssl-replica-set-cov
+  - name: test-server-version-python3.9-sync-auth-ssl-replica-set-cov
     commands:
       - func: run server
         vars:
@@ -2548,11 +2548,11 @@ tasks:
           SSL: ssl
           TOPOLOGY: replica_set
           COVERAGE: "1"
-          PYTHON_VERSION: "3.10"
+          PYTHON_VERSION: "3.9"
           TEST_NAME: default_sync
     tags:
       - server-version
-      - python-3.10
+      - python-3.9
       - replica_set-auth-ssl
       - sync
   - name: test-server-version-python3.11-async-auth-ssl-replica-set-cov
@@ -2658,29 +2658,7 @@ tasks:
       - python-pypy3.10
       - replica_set-noauth-ssl
       - async
-  - name: test-server-version-python3.9-sync-noauth-nossl-replica-set-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: replica_set
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: replica_set
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - server-version
-      - python-3.9
-      - replica_set-noauth-nossl
-      - sync
-      - pr
-  - name: test-server-version-python3.10-async-noauth-nossl-replica-set-cov
+  - name: test-server-version-python3.10-sync-noauth-nossl-replica-set-cov
     commands:
       - func: run server
         vars:
@@ -2695,10 +2673,32 @@ tasks:
           TOPOLOGY: replica_set
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
       - server-version
       - python-3.10
+      - replica_set-noauth-nossl
+      - sync
+      - pr
+  - name: test-server-version-python3.9-async-noauth-nossl-replica-set-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: replica_set
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.9
       - replica_set-noauth-nossl
       - async
       - pr
@@ -2807,7 +2807,7 @@ tasks:
       - python-pypy3.10
       - sharded_cluster-noauth-ssl
       - sync
-  - name: test-server-version-python3.9-async-noauth-ssl-sharded-cluster-cov
+  - name: test-server-version-python3.10-async-noauth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -2819,34 +2819,34 @@ tasks:
         vars:
           AUTH: noauth
           SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
-    tags:
-      - server-version
-      - python-3.9
-      - sharded_cluster-noauth-ssl
-      - async
-  - name: test-server-version-python3.10-sync-noauth-nossl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
           TOPOLOGY: sharded_cluster
           COVERAGE: "1"
           PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
+          TEST_NAME: default_async
     tags:
       - server-version
       - python-3.10
+      - sharded_cluster-noauth-ssl
+      - async
+  - name: test-server-version-python3.9-sync-noauth-nossl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.9
       - sharded_cluster-noauth-nossl
       - sync
   - name: test-server-version-python3.11-async-noauth-nossl-sharded-cluster-cov
@@ -2869,48 +2869,6 @@ tasks:
       - server-version
       - python-3.11
       - sharded_cluster-noauth-nossl
-      - async
-  - name: test-server-version-python3.9-sync-auth-ssl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - server-version
-      - python-3.9
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-server-version-python3.9-async-auth-ssl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          COVERAGE: "1"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
-    tags:
-      - server-version
-      - python-3.9
-      - sharded_cluster-auth-ssl
       - async
   - name: test-server-version-python3.10-sync-auth-ssl-sharded-cluster-cov
     commands:
@@ -2952,6 +2910,48 @@ tasks:
     tags:
       - server-version
       - python-3.10
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-server-version-python3.9-sync-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - server-version
+      - python-3.9
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-server-version-python3.9-async-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          COVERAGE: "1"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - server-version
+      - python-3.9
       - sharded_cluster-auth-ssl
       - async
   - name: test-server-version-python3.11-async-auth-ssl-sharded-cluster-cov
@@ -3120,28 +3120,6 @@ tasks:
       - async
 
   # Standard tests
-  - name: test-standard-v4.2-python3.10-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-4.2
-      - python-3.10
-      - replica_set-noauth-ssl
-      - sync
   - name: test-standard-v4.2-python3.14-sync-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -3162,6 +3140,28 @@ tasks:
       - test-standard
       - server-4.2
       - python-3.14
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-standard-v4.2-python3.9-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-4.2
+      - python-3.9
       - replica_set-noauth-ssl
       - sync
   - name: test-standard-v4.2-python3.11-sync-auth-ssl-sharded-cluster
@@ -3209,6 +3209,28 @@ tasks:
       - sharded_cluster-auth-ssl
       - sync
       - pypy
+  - name: test-standard-v4.2-python3.10-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-4.2
+      - python-3.10
+      - standalone-noauth-nossl
+      - sync
   - name: test-standard-v4.2-python3.13-sync-noauth-nossl-standalone
     commands:
       - func: run server
@@ -3231,50 +3253,6 @@ tasks:
       - python-3.13
       - standalone-noauth-nossl
       - sync
-  - name: test-standard-v4.2-python3.9-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.2"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-4.2
-      - python-3.9
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-v4.4-python3.10-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-4.4
-      - python-3.10
-      - replica_set-noauth-ssl
-      - async
   - name: test-standard-v4.4-python3.14-async-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -3295,6 +3273,28 @@ tasks:
       - test-standard
       - server-4.4
       - python-3.14
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-v4.4-python3.9-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-4.4
+      - python-3.9
       - replica_set-noauth-ssl
       - async
   - name: test-standard-v4.4-python3.11-async-auth-ssl-sharded-cluster
@@ -3342,6 +3342,28 @@ tasks:
       - sharded_cluster-auth-ssl
       - async
       - pypy
+  - name: test-standard-v4.4-python3.10-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-4.4
+      - python-3.10
+      - standalone-noauth-nossl
+      - async
   - name: test-standard-v4.4-python3.13-async-noauth-nossl-standalone
     commands:
       - func: run server
@@ -3364,28 +3386,28 @@ tasks:
       - python-3.13
       - standalone-noauth-nossl
       - async
-  - name: test-standard-v4.4-python3.9-async-noauth-nossl-standalone
+  - name: test-standard-v5.0-python3.10-sync-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
       - func: run tests
         vars:
           AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "4.4"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
     tags:
       - test-standard
-      - server-4.4
-      - python-3.9
-      - standalone-noauth-nossl
-      - async
+      - server-5.0
+      - python-3.10
+      - replica_set-noauth-ssl
+      - sync
   - name: test-standard-v5.0-python3.13-sync-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -3408,50 +3430,6 @@ tasks:
       - python-3.13
       - replica_set-noauth-ssl
       - sync
-  - name: test-standard-v5.0-python3.9-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-5.0
-      - python-3.9
-      - replica_set-noauth-ssl
-      - sync
-  - name: test-standard-v5.0-python3.10-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-5.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-      - sync
   - name: test-standard-v5.0-python3.14-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -3472,6 +3450,28 @@ tasks:
       - test-standard
       - server-5.0
       - python-3.14
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-v5.0-python3.9-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-5.0
+      - python-3.9
       - sharded_cluster-auth-ssl
       - sync
   - name: test-standard-v5.0-python3.12-sync-noauth-nossl-standalone
@@ -3496,6 +3496,28 @@ tasks:
       - python-3.12
       - standalone-noauth-nossl
       - sync
+  - name: test-standard-v6.0-python3.10-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-6.0
+      - python-3.10
+      - replica_set-noauth-ssl
+      - async
   - name: test-standard-v6.0-python3.13-async-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -3518,50 +3540,6 @@ tasks:
       - python-3.13
       - replica_set-noauth-ssl
       - async
-  - name: test-standard-v6.0-python3.9-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-6.0
-      - python-3.9
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-v6.0-python3.10-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "6.0"
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-6.0
-      - python-3.10
-      - sharded_cluster-auth-ssl
-      - async
   - name: test-standard-v6.0-python3.14-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -3582,6 +3560,28 @@ tasks:
       - test-standard
       - server-6.0
       - python-3.14
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-v6.0-python3.9-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-6.0
+      - python-3.9
       - sharded_cluster-auth-ssl
       - async
   - name: test-standard-v6.0-python3.12-async-noauth-nossl-standalone
@@ -3628,6 +3628,28 @@ tasks:
       - python-3.12
       - replica_set-noauth-ssl
       - sync
+  - name: test-standard-v7.0-python3.10-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-7.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - sync
   - name: test-standard-v7.0-python3.13-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -3648,28 +3670,6 @@ tasks:
       - test-standard
       - server-7.0
       - python-3.13
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v7.0-python3.9-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-7.0
-      - python-3.9
       - sharded_cluster-auth-ssl
       - sync
   - name: test-standard-v7.0-python3.11-sync-noauth-nossl-standalone
@@ -3739,6 +3739,28 @@ tasks:
       - python-3.12
       - replica_set-noauth-ssl
       - async
+  - name: test-standard-v8.0-python3.10-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.10"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-8.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - async
   - name: test-standard-v8.0-python3.13-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
@@ -3759,28 +3781,6 @@ tasks:
       - test-standard
       - server-8.0
       - python-3.13
-      - sharded_cluster-auth-ssl
-      - async
-  - name: test-standard-v8.0-python3.9-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "8.0"
-          PYTHON_VERSION: "3.9"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-8.0
-      - python-3.9
       - sharded_cluster-auth-ssl
       - async
   - name: test-standard-v8.0-python3.11-async-noauth-nossl-standalone
@@ -3897,29 +3897,6 @@ tasks:
       - sharded_cluster-auth-ssl
       - async
       - pr
-  - name: test-standard-latest-python3.10-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-latest
-      - python-3.10
-      - standalone-noauth-nossl
-      - async
-      - pr
   - name: test-standard-latest-python3.14-async-noauth-nossl-standalone
     commands:
       - func: run server
@@ -3940,6 +3917,29 @@ tasks:
       - test-standard
       - server-latest
       - python-3.14
+      - standalone-noauth-nossl
+      - async
+      - pr
+  - name: test-standard-latest-python3.9-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          PYTHON_VERSION: "3.9"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-latest
+      - python-3.9
       - standalone-noauth-nossl
       - async
       - pr
@@ -4010,28 +4010,6 @@ tasks:
       - python-3.12
       - sharded_cluster-auth-ssl
       - sync
-  - name: test-standard-rapid-python3.10-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.10"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-rapid
-      - python-3.10
-      - standalone-noauth-nossl
-      - sync
   - name: test-standard-rapid-python3.14-sync-noauth-nossl-standalone
     commands:
       - func: run server
@@ -4054,48 +4032,70 @@ tasks:
       - python-3.14
       - standalone-noauth-nossl
       - sync
-
-  # Test non standard tests
-  - name: test-non-standard-v4.2-python3.9-noauth-nossl-standalone
+  - name: test-standard-rapid-python3.9-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "4.2"
+          VERSION: rapid
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "4.2"
+          VERSION: rapid
           PYTHON_VERSION: "3.9"
+          TEST_NAME: default_sync
     tags:
-      - test-non-standard
-      - server-4.2
+      - test-standard
+      - server-rapid
       - python-3.9
       - standalone-noauth-nossl
-      - noauth
-  - name: test-non-standard-v4.2-python3.10-noauth-ssl-replica-set
+      - sync
+
+  # Test non standard tests
+  - name: test-non-standard-v4.2-python3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
           AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
+          SSL: nossl
+          TOPOLOGY: standalone
           VERSION: "4.2"
       - func: run tests
         vars:
           AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
+          SSL: nossl
+          TOPOLOGY: standalone
           VERSION: "4.2"
           PYTHON_VERSION: "3.10"
     tags:
       - test-non-standard
       - server-4.2
       - python-3.10
+      - standalone-noauth-nossl
+      - noauth
+  - name: test-non-standard-v4.2-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-non-standard
+      - server-4.2
+      - python-3.9
       - replica_set-noauth-ssl
       - noauth
   - name: test-non-standard-v4.2-python3.11-auth-ssl-sharded-cluster
@@ -4182,7 +4182,7 @@ tasks:
       - python-3.14
       - sharded_cluster-auth-ssl
       - auth
-  - name: test-non-standard-v5.0-python3.9-noauth-nossl-standalone
+  - name: test-non-standard-v5.0-python3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -4195,33 +4195,33 @@ tasks:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "5.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-non-standard
-      - server-5.0
-      - python-3.9
-      - standalone-noauth-nossl
-      - noauth
-  - name: test-non-standard-v5.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
           VERSION: "5.0"
           PYTHON_VERSION: "3.10"
     tags:
       - test-non-standard
       - server-5.0
       - python-3.10
+      - standalone-noauth-nossl
+      - noauth
+  - name: test-non-standard-v5.0-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-non-standard
+      - server-5.0
+      - python-3.9
       - replica_set-noauth-ssl
       - noauth
   - name: test-non-standard-v5.0-python3.11-auth-ssl-sharded-cluster
@@ -4308,7 +4308,7 @@ tasks:
       - python-3.14
       - sharded_cluster-auth-ssl
       - auth
-  - name: test-non-standard-v7.0-python3.9-noauth-nossl-standalone
+  - name: test-non-standard-v7.0-python3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -4321,33 +4321,33 @@ tasks:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: "7.0"
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-non-standard
-      - server-7.0
-      - python-3.9
-      - standalone-noauth-nossl
-      - noauth
-  - name: test-non-standard-v7.0-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
           VERSION: "7.0"
           PYTHON_VERSION: "3.10"
     tags:
       - test-non-standard
       - server-7.0
       - python-3.10
+      - standalone-noauth-nossl
+      - noauth
+  - name: test-non-standard-v7.0-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "7.0"
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-non-standard
+      - server-7.0
+      - python-3.9
       - replica_set-noauth-ssl
       - noauth
   - name: test-non-standard-v7.0-python3.11-auth-ssl-sharded-cluster
@@ -4434,7 +4434,7 @@ tasks:
       - python-3.14
       - sharded_cluster-auth-ssl
       - auth
-  - name: test-non-standard-rapid-python3.9-noauth-nossl-standalone
+  - name: test-non-standard-rapid-python3.10-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -4447,33 +4447,33 @@ tasks:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: rapid
-          PYTHON_VERSION: "3.9"
-    tags:
-      - test-non-standard
-      - server-rapid
-      - python-3.9
-      - standalone-noauth-nossl
-      - noauth
-  - name: test-non-standard-rapid-python3.10-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
           VERSION: rapid
           PYTHON_VERSION: "3.10"
     tags:
       - test-non-standard
       - server-rapid
       - python-3.10
+      - standalone-noauth-nossl
+      - noauth
+  - name: test-non-standard-rapid-python3.9-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          PYTHON_VERSION: "3.9"
+    tags:
+      - test-non-standard
+      - server-rapid
+      - python-3.9
       - replica_set-noauth-ssl
       - noauth
   - name: test-non-standard-rapid-python3.11-auth-ssl-sharded-cluster

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -153,17 +153,17 @@ buildvariants:
       - rhel87-small
 
   # Disable test commands tests
-  - name: disable-test-commands-rhel8-python3.9
+  - name: disable-test-commands-rhel8-python3.10
     tasks:
       - name: .test-standard .server-latest
-    display_name: Disable test commands RHEL8 Python3.9
+    display_name: Disable test commands RHEL8 Python3.10
     run_on:
       - rhel87-small
     expansions:
       AUTH: auth
       SSL: ssl
       DISABLE_TEST_COMMANDS: "1"
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
+      PYTHON_BINARY: /opt/python/3.10/bin/python3
 
   # Doctests tests
   - name: doctests-rhel8
@@ -500,14 +500,14 @@ buildvariants:
       SUB_TEST_NAME: pyopenssl
 
   # Search index tests
-  - name: search-index-helpers-rhel8-python3.9
+  - name: search-index-helpers-rhel8-python3.10
     tasks:
       - name: .search_index
-    display_name: Search Index Helpers RHEL8 Python3.9
+    display_name: Search Index Helpers RHEL8 Python3.10
     run_on:
       - rhel87-small
     expansions:
-      PYTHON_BINARY: /opt/python/3.9/bin/python3
+      PYTHON_BINARY: /opt/python/3.10/bin/python3
 
   # Server version tests
   - name: mongodb-v4.2

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -153,17 +153,16 @@ buildvariants:
       - rhel87-small
 
   # Disable test commands tests
-  - name: disable-test-commands-rhel8-python3.10
+  - name: disable-test-commands-rhel8
     tasks:
       - name: .test-standard .server-latest
-    display_name: Disable test commands RHEL8 Python3.10
+    display_name: Disable test commands RHEL8
     run_on:
       - rhel87-small
     expansions:
       AUTH: auth
       SSL: ssl
       DISABLE_TEST_COMMANDS: "1"
-      PYTHON_BINARY: /opt/python/3.10/bin/python3
 
   # Doctests tests
   - name: doctests-rhel8

--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -20,7 +20,7 @@ fi
 set -o xtrace
 
 # Install python with pip.
-PYTHON_VER="python3.9"
+PYTHON_VER="python3.10"
 apt-get -qq update  < /dev/null > /dev/null
 apt-get -qq install $PYTHON_VER $PYTHON_VER-venv build-essential $PYTHON_VER-dev -y  < /dev/null > /dev/null
 

--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -22,6 +22,11 @@ set -o xtrace
 # Install python with pip.
 PYTHON_VER="python3.10"
 apt-get -qq update  < /dev/null > /dev/null
+apt-get -q install -y software-properties-common
+# Use openpgp to avoid gpg key timeout.
+mkdir -p $HOME/.gnupg
+echo "keyserver keys.openpgp.org" >> $HOME/.gnupg/gpg.conf
+add-apt-repository -y 'ppa:deadsnakes/ppa'
 apt-get -qq install $PYTHON_VER $PYTHON_VER-venv build-essential $PYTHON_VER-dev -y  < /dev/null > /dev/null
 
 export PYTHON_BINARY=$PYTHON_VER

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -485,11 +485,11 @@ def create_alternative_hosts_variants():
     variants.append(
         create_variant(
             [".test-no-toolchain"],
-            get_variant_name("OpenSSL 1.0.2", host, python=CPYTHONS[0], version=version),
+            get_variant_name("OpenSSL 1.0.2", host, python="3.9", version=version),
             host=host,
-            python=CPYTHONS[0],
+            python="3.9",
             batchtime=batchtime,
-            expansions=dict(VERSION=version, PYTHON_VERSION=CPYTHONS[0]),
+            expansions=dict(VERSION=version, PYTHON_VERSION="3.9"),
         )
     )
 

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -330,10 +330,9 @@ def create_mod_wsgi_variants():
 def create_disable_test_commands_variants():
     host = DEFAULT_HOST
     expansions = dict(AUTH="auth", SSL="ssl", DISABLE_TEST_COMMANDS="1")
-    python = CPYTHONS[0]
-    display_name = get_variant_name("Disable test commands", host, python=python)
+    display_name = get_variant_name("Disable test commands", host)
     tasks = [".test-standard .server-latest"]
-    return [create_variant(tasks, display_name, host=host, python=python, expansions=expansions)]
+    return [create_variant(tasks, display_name, host=host, expansions=expansions)]
 
 
 def create_oidc_auth_variants():

--- a/.evergreen/scripts/generate_config_utils.py
+++ b/.evergreen/scripts/generate_config_utils.py
@@ -22,7 +22,7 @@ from shrub.v3.shrub_service import ShrubService
 ##############
 
 ALL_VERSIONS = ["4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"]
-CPYTHONS = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+CPYTHONS = ["3.10", "3.9", "3.11", "3.12", "3.13", "3.14"]
 PYPYS = ["pypy3.10"]
 ALL_PYTHONS = CPYTHONS + PYPYS
 MIN_MAX_PYTHON = [CPYTHONS[0], CPYTHONS[-1]]

--- a/.evergreen/scripts/kms_tester.py
+++ b/.evergreen/scripts/kms_tester.py
@@ -33,7 +33,7 @@ def _setup_azure_vm(base_env: dict[str, str]) -> None:
     env["AZUREKMS_CMD"] = "sudo apt-get install -y python3-dev build-essential"
     run_command(f"{azure_dir}/run-command.sh", env=env)
 
-    env["AZUREKMS_CMD"] = "bash .evergreen/just.sh setup-tests kms azure-remote"
+    env["AZUREKMS_CMD"] = "NO_EXT=1 bash .evergreen/just.sh setup-tests kms azure-remote"
     run_command(f"{azure_dir}/run-command.sh", env=env)
     LOGGER.info("Setting up Azure VM... done.")
 
@@ -53,7 +53,7 @@ def _setup_gcp_vm(base_env: dict[str, str]) -> None:
     env["GCPKMS_CMD"] = "sudo apt-get install -y python3-dev build-essential"
     run_command(f"{gcp_dir}/run-command.sh", env=env)
 
-    env["GCPKMS_CMD"] = "bash ./.evergreen/just.sh setup-tests kms gcp-remote"
+    env["GCPKMS_CMD"] = "NO_EXT=1 bash ./.evergreen/just.sh setup-tests kms gcp-remote"
     run_command(f"{gcp_dir}/run-command.sh", env=env)
     LOGGER.info("Setting up GCP VM...")
 
@@ -97,6 +97,13 @@ def setup_kms(sub_test_name: str) -> None:
         create_archive()
         if sub_test_target == "azure":
             os.environ["AZUREKMS_VMNAME_PREFIX"] = "PYTHON_DRIVER"
+
+            # Found using "az vm image list --output table"
+            os.environ[
+                "AZUREKMS_IMAGE"
+            ] = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+        else:
+            os.environ["GCPKMS_IMAGEFAMILY"] = "debian-12"
 
         run_command("./setup.sh", cwd=kms_dir)
         base_env = _load_kms_config(sub_test_target)

--- a/.evergreen/scripts/oidc_tester.py
+++ b/.evergreen/scripts/oidc_tester.py
@@ -42,6 +42,11 @@ def setup_oidc(sub_test_name: str) -> dict[str, str] | None:
     if sub_test_name == "azure":
         env["AZUREOIDC_VMNAME_PREFIX"] = "PYTHON_DRIVER"
     if "-remote" not in sub_test_name:
+        if sub_test_name == "azure":
+            # Found using "az vm image list --output table"
+            env["AZUREOIDC_IMAGE"] = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+        else:
+            env["GCPKMS_IMAGEFAMILY"] = "debian-12"
         run_command(f"bash {target_dir}/setup.sh", env=env)
     if sub_test_name in K8S_NAMES:
         run_command(f"bash {target_dir}/setup-pod.sh {sub_test_name}")
@@ -84,7 +89,7 @@ def test_oidc_send_to_remote(sub_test_name: str) -> None:
         env[f"{upper_name}OIDC_DRIVERS_TAR_FILE"] = TMP_DRIVER_FILE
         env[
             f"{upper_name}OIDC_TEST_CMD"
-        ] = f"OIDC_ENV={sub_test_name} ./.evergreen/run-mongodb-oidc-test.sh"
+        ] = f"NO_EXT=1 OIDC_ENV={sub_test_name} ./.evergreen/run-mongodb-oidc-test.sh"
     elif sub_test_name in K8S_NAMES:
         env["K8S_DRIVERS_TAR_FILE"] = TMP_DRIVER_FILE
         env["K8S_TEST_CMD"] = "OIDC_ENV=k8s ./.evergreen/run-mongodb-oidc-test.sh"

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -90,6 +90,13 @@ def setup_libmongocrypt():
         distro = get_distro()
         if distro.name.startswith("Debian"):
             target = f"debian{distro.version_id}"
+        elif distro.name.startswith("Ubuntu"):
+            if distro.version_id == "20.04":
+                target = "debian11"
+            elif distro.version_id == "22.04":
+                target = "debian12"
+            elif distro.version_id == "24.04":
+                target = "debian13"
         elif distro.name.startswith("Red Hat"):
             if distro.version_id.startswith("7"):
                 target = "rhel-70-64-bit"

--- a/.evergreen/scripts/setup_tests.py
+++ b/.evergreen/scripts/setup_tests.py
@@ -53,7 +53,7 @@ EXTRAS_MAP = {
 GROUP_MAP = dict(mockupdb="mockupdb", perf="perf")
 
 # The python version used for perf tests.
-PERF_PYTHON_VERSION = "3.9.13"
+PERF_PYTHON_VERSION = "3.10.11"
 
 
 def is_set(var: str) -> bool:

--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -2059,7 +2059,7 @@ class TestClient(AsyncIntegrationTest):
     async def test_handshake_01_aws(self):
         await self._test_handshake(
             {
-                "AWS_EXECUTION_ENV": "AWS_Lambda_python3.9",
+                "AWS_EXECUTION_ENV": "AWS_Lambda_python3.10",
                 "AWS_REGION": "us-east-2",
                 "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
             },
@@ -2097,7 +2097,7 @@ class TestClient(AsyncIntegrationTest):
 
     async def test_handshake_05_multiple(self):
         await self._test_handshake(
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "FUNCTIONS_WORKER_RUNTIME": "python"},
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.10", "FUNCTIONS_WORKER_RUNTIME": "python"},
             None,
         )
         # Extra cases for other combos.
@@ -2109,13 +2109,16 @@ class TestClient(AsyncIntegrationTest):
 
     async def test_handshake_06_region_too_long(self):
         await self._test_handshake(
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_REGION": "a" * 512},
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.10", "AWS_REGION": "a" * 512},
             {"name": "aws.lambda"},
         )
 
     async def test_handshake_07_memory_invalid_int(self):
         await self._test_handshake(
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "big"},
+            {
+                "AWS_EXECUTION_ENV": "AWS_Lambda_python3.10",
+                "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "big",
+            },
             {"name": "aws.lambda"},
         )
 

--- a/test/asynchronous/test_discovery_and_monitoring.py
+++ b/test/asynchronous/test_discovery_and_monitoring.py
@@ -485,7 +485,7 @@ class TestServerMonitoringMode(AsyncIntegrationTest):
 
     async def test_rtt_connection_is_disabled_auto(self):
         envs = [
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9"},
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.10"},
             {"FUNCTIONS_WORKER_RUNTIME": "python"},
             {"K_SERVICE": "gcpservicename"},
             {"FUNCTION_NAME": "gcpfunctionname"},

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -2016,7 +2016,7 @@ class TestClient(IntegrationTest):
     def test_handshake_01_aws(self):
         self._test_handshake(
             {
-                "AWS_EXECUTION_ENV": "AWS_Lambda_python3.9",
+                "AWS_EXECUTION_ENV": "AWS_Lambda_python3.10",
                 "AWS_REGION": "us-east-2",
                 "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
             },
@@ -2054,7 +2054,7 @@ class TestClient(IntegrationTest):
 
     def test_handshake_05_multiple(self):
         self._test_handshake(
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "FUNCTIONS_WORKER_RUNTIME": "python"},
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.10", "FUNCTIONS_WORKER_RUNTIME": "python"},
             None,
         )
         # Extra cases for other combos.
@@ -2066,13 +2066,16 @@ class TestClient(IntegrationTest):
 
     def test_handshake_06_region_too_long(self):
         self._test_handshake(
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_REGION": "a" * 512},
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.10", "AWS_REGION": "a" * 512},
             {"name": "aws.lambda"},
         )
 
     def test_handshake_07_memory_invalid_int(self):
         self._test_handshake(
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9", "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "big"},
+            {
+                "AWS_EXECUTION_ENV": "AWS_Lambda_python3.10",
+                "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "big",
+            },
             {"name": "aws.lambda"},
         )
 

--- a/test/test_discovery_and_monitoring.py
+++ b/test/test_discovery_and_monitoring.py
@@ -483,7 +483,7 @@ class TestServerMonitoringMode(IntegrationTest):
 
     def test_rtt_connection_is_disabled_auto(self):
         envs = [
-            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.9"},
+            {"AWS_EXECUTION_ENV": "AWS_Lambda_python3.10"},
             {"FUNCTIONS_WORKER_RUNTIME": "python"},
             {"K_SERVICE": "gcpservicename"},
             {"FUNCTION_NAME": "gcpfunctionname"},


### PR DESCRIPTION
Passing build: https://spruce.mongodb.com/version/68d52a934baed30008fb62df/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC