### PR TITLE
PYTHON-5585 Set linkcheck_allow_unauthorized

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -95,6 +95,10 @@ linkcheck_ignore = [
 # Allow for flaky links.
 linkcheck_retries = 3
 
+# Avoid unauthorized links causing build failures: PYTHON-5585
+linkcheck_allow_unauthorized = True
+
+
 # -- Options for extensions ----------------------------------------------------
 autoclass_content = "init"
 


### PR DESCRIPTION
linkcheck_allow_unauthorized=True in sphinx conf to not break builds because of links to jira release notes in changelog. For example:

`PyMongo 4.6.3 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=38360`