### PR TITLE
PYTHON-5598 Add generate_config method to ensure auth is tested on free-threaded python 3.14t

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4766,3 +4766,351 @@ tasks:
       - standalone-noauth-nossl
       - noauth
       - pypy
+
+  # Test standard auth tests
+  - name: test-standard-auth-v4.2-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-standard-auth
+      - server-4.2
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - auth
+  - name: test-standard-auth-v4.2-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.2"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-standard-auth
+      - server-4.2
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy
+  - name: test-standard-auth-v4.4-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-standard-auth
+      - server-4.4
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - auth
+  - name: test-standard-auth-v4.4-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-standard-auth
+      - server-4.4
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy
+  - name: test-standard-auth-v5.0-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: "3.12"
+    tags:
+      - test-standard-auth
+      - server-5.0
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - auth
+  - name: test-standard-auth-v5.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "5.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-standard-auth
+      - server-5.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy
+  - name: test-standard-auth-v6.0-python3.13-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: "3.13"
+    tags:
+      - test-standard-auth
+      - server-6.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+      - auth
+  - name: test-standard-auth-v6.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "6.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-standard-auth
+      - server-6.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy
+  - name: test-standard-auth-v7.0-python3.14t-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: 3.14t
+    tags:
+      - test-standard-auth
+      - server-7.0
+      - python-3.14t
+      - sharded_cluster-auth-ssl
+      - auth
+      - free-threaded
+  - name: test-standard-auth-v7.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-standard-auth
+      - server-7.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy
+  - name: test-standard-auth-v8.0-python3.14-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: "3.14"
+    tags:
+      - test-standard-auth
+      - server-8.0
+      - python-3.14
+      - sharded_cluster-auth-ssl
+      - auth
+  - name: test-standard-auth-v8.0-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-standard-auth
+      - server-8.0
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy
+  - name: test-standard-auth-latest-python3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: "3.11"
+    tags:
+      - test-standard-auth
+      - server-latest
+      - python-3.11
+      - sharded_cluster-auth-ssl
+      - auth
+      - pr
+  - name: test-standard-auth-latest-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-standard-auth
+      - server-latest
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy
+  - name: test-standard-auth-rapid-python3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: "3.10"
+    tags:
+      - test-standard-auth
+      - server-rapid
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - auth
+  - name: test-standard-auth-rapid-pypy3.10-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          PYTHON_VERSION: pypy3.10
+    tags:
+      - test-standard-auth
+      - server-rapid
+      - python-pypy3.10
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -244,7 +244,7 @@ buildvariants:
   # Enterprise auth tests
   - name: auth-enterprise-rhel8
     tasks:
-      - name: .test-non-standard .auth !.free-threaded
+      - name: .test-standard-auth .auth !.free-threaded
     display_name: Auth Enterprise RHEL8
     run_on:
       - rhel87-small
@@ -253,7 +253,7 @@ buildvariants:
       AUTH: auth
   - name: auth-enterprise-macos
     tasks:
-      - name: .test-non-standard !.pypy .auth !.free-threaded
+      - name: .test-standard-auth !.pypy .auth !.free-threaded
     display_name: Auth Enterprise macOS
     run_on:
       - macos-14
@@ -262,7 +262,7 @@ buildvariants:
       AUTH: auth
   - name: auth-enterprise-win64
     tasks:
-      - name: .test-non-standard !.pypy .auth
+      - name: .test-standard-auth !.pypy .auth
     display_name: Auth Enterprise Win64
     run_on:
       - windows-64-vsMulti-small

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -202,12 +202,12 @@ def create_enterprise_auth_variants():
     for host in ["rhel8", "macos", "win64"]:
         expansions = dict(TEST_NAME="enterprise_auth", AUTH="auth")
         display_name = get_variant_name("Auth Enterprise", host)
-        tasks = [".test-non-standard .auth !.free-threaded"]
+        tasks = [".test-standard-auth .auth !.free-threaded"]
         # https://jira.mongodb.org/browse/PYTHON-5586
         if host == "macos":
-            tasks = [".test-non-standard !.pypy .auth !.free-threaded"]
+            tasks = [".test-standard-auth !.pypy .auth !.free-threaded"]
         if host == "win64":
-            tasks = [".test-non-standard !.pypy .auth"]
+            tasks = [".test-standard-auth !.pypy .auth"]
         variant = create_variant(tasks, display_name, host=host, expansions=expansions)
         variants.append(variant)
     return variants


### PR DESCRIPTION
Creates new method create_test_standard_auth_tasks that creates tasks "test-standard-auth-*" that only include sharded-cluster. Because the list of clusters is one, we get a task that contains auth and python 3.14t.