### PR TITLE
PYTHON-5588 Fix python binary used in FIPS tests

### DIFF
--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -9,6 +9,7 @@ buildvariants:
     batchtime: 1440
     expansions:
       VERSION: latest
+      PYTHON_BINARY: /usr/bin/python3.11
       NO_EXT: "1"
       REQUIRE_FIPS: "1"
     tags: []
@@ -21,6 +22,7 @@ buildvariants:
     batchtime: 1440
     expansions:
       VERSION: latest
+      PYTHON_BINARY: /usr/bin/python3.11
       NO_EXT: "1"
     tags: []
   - name: other-hosts-rhel8-power8-latest
@@ -32,6 +34,7 @@ buildvariants:
     batchtime: 1440
     expansions:
       VERSION: latest
+      PYTHON_BINARY: /usr/bin/python3.11
       NO_EXT: "1"
     tags: []
   - name: other-hosts-rhel8-arm64-latest
@@ -43,6 +46,7 @@ buildvariants:
     batchtime: 1440
     expansions:
       VERSION: latest
+      PYTHON_BINARY: /usr/bin/python3.11
       NO_EXT: "1"
     tags: []
   - name: other-hosts-amazon2023-latest
@@ -54,6 +58,7 @@ buildvariants:
     batchtime: 1440
     expansions:
       VERSION: latest
+      PYTHON_BINARY: /usr/bin/python3.11
       NO_EXT: "1"
     tags: [pr]
 

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -469,7 +469,8 @@ def create_alternative_hosts_variants():
 
     version = "latest"
     for host_name in OTHER_HOSTS:
-        expansions = dict(VERSION="latest")
+        # Use explicit Python 3.11 binary on the host since the default python3 is 3.9.
+        expansions = dict(VERSION="latest", PYTHON_BINARY="/usr/bin/python3.11")
         handle_c_ext(C_EXTS[0], expansions)
         host = HOSTS[host_name]
         tags = []


### PR DESCRIPTION
Passing build: https://spruce.mongodb.com/version/68e42c782b320700072d0c64/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC