### PR TITLE
PYTHON-5604 Skip ECS tests until we can test on Ubuntu 22

### DIFF
--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -71,7 +71,7 @@ buildvariants:
   # Aws auth tests
   - name: auth-aws-ubuntu-20
     tasks:
-      - name: .auth-aws
+      - name: .auth-aws !.auth-aws-ecs
     display_name: Auth AWS Ubuntu-20
     run_on:
       - ubuntu2004-small

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -438,7 +438,8 @@ def create_aws_auth_variants():
 
     for host_name in ["ubuntu20", "win64", "macos"]:
         expansions = dict()
-        tasks = [".auth-aws"]
+        # PYTHON-5604 - we need to skip ECS tests for now.
+        tasks = [".auth-aws !.auth-aws-ecs"]
         tags = []
         if host_name == "macos":
             tasks = [".auth-aws !.auth-aws-web-identity !.auth-aws-ecs !.auth-aws-ec2"]


### PR DESCRIPTION
Patch build with all supported AWS auth tests: https://spruce.mongodb.com/version/68e528f7b49fea0007c0b700/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC