### PR TITLE
PYTHON-5788 - Refine withTransaction timeout error wrapping semantics…

### DIFF
--- a/pymongo/asynchronous/client_session.py
+++ b/pymongo/asynchronous/client_session.py
@@ -516,9 +516,14 @@ def _within_time_limit(start_time: float, backoff: float = 0) -> bool:
 def _make_timeout_error(error: BaseException) -> PyMongoError:
     """Convert error to a NetworkTimeout or ExecutionTimeout as appropriate."""
     if _csot.remaining() is not None:
-        return ExecutionTimeout(str(error), 50, {"ok": 0, "errmsg": str(error), "code": 50})
+        timeout_error: PyMongoError = ExecutionTimeout(
+            str(error), 50, {"ok": 0, "errmsg": str(error), "code": 50}
+        )
     else:
-        return NetworkTimeout(str(error))
+        timeout_error = NetworkTimeout(str(error))
+    if isinstance(error, PyMongoError):
+        timeout_error._error_labels = error._error_labels.copy()
+    return timeout_error
 
 
 _T = TypeVar("_T")
@@ -804,15 +809,17 @@ class AsyncClientSession:
                     await self.commit_transaction()
                 except PyMongoError as exc:
                     last_error = exc
-                    if not _within_time_limit(start_time):
-                        raise _make_timeout_error(last_error) from exc
                     if exc.has_error_label(
                         "UnknownTransactionCommitResult"
                     ) and not _max_time_expired_error(exc):
+                        if not _within_time_limit(start_time):
+                            raise _make_timeout_error(last_error) from exc
                         # Retry the commit.
                         continue
 
                     if exc.has_error_label("TransientTransactionError"):
+                        if not _within_time_limit(start_time):
+                            raise _make_timeout_error(last_error) from exc
                         # Retry the entire transaction.
                         break
                     raise

--- a/pymongo/synchronous/client_session.py
+++ b/pymongo/synchronous/client_session.py
@@ -514,9 +514,14 @@ def _within_time_limit(start_time: float, backoff: float = 0) -> bool:
 def _make_timeout_error(error: BaseException) -> PyMongoError:
     """Convert error to a NetworkTimeout or ExecutionTimeout as appropriate."""
     if _csot.remaining() is not None:
-        return ExecutionTimeout(str(error), 50, {"ok": 0, "errmsg": str(error), "code": 50})
+        timeout_error: PyMongoError = ExecutionTimeout(
+            str(error), 50, {"ok": 0, "errmsg": str(error), "code": 50}
+        )
     else:
-        return NetworkTimeout(str(error))
+        timeout_error = NetworkTimeout(str(error))
+    if isinstance(error, PyMongoError):
+        timeout_error._error_labels = error._error_labels.copy()
+    return timeout_error
 
 
 _T = TypeVar("_T")
@@ -800,15 +805,17 @@ class ClientSession:
                     self.commit_transaction()
                 except PyMongoError as exc:
                     last_error = exc
-                    if not _within_time_limit(start_time):
-                        raise _make_timeout_error(last_error) from exc
                     if exc.has_error_label(
                         "UnknownTransactionCommitResult"
                     ) and not _max_time_expired_error(exc):
+                        if not _within_time_limit(start_time):
+                            raise _make_timeout_error(last_error) from exc
                         # Retry the commit.
                         continue
 
                     if exc.has_error_label("TransientTransactionError"):
+                        if not _within_time_limit(start_time):
+                            raise _make_timeout_error(last_error) from exc
                         # Retry the entire transaction.
                         break
                     raise

--- a/test/asynchronous/test_transactions.py
+++ b/test/asynchronous/test_transactions.py
@@ -500,10 +500,12 @@ class TestTransactionsConvenientAPI(AsyncTransactionsBase):
         listener.reset()
         async with client.start_session() as s:
             with PatchSessionTimeout(0):
-                with self.assertRaises(NetworkTimeout):
+                with self.assertRaises(NetworkTimeout) as context:
                     await s.with_transaction(callback)
 
         self.assertEqual(listener.started_command_names(), ["insert", "abortTransaction"])
+        # Assert that the timeout error has the same labels as the error it wraps.
+        self.assertTrue(context.exception.has_error_label("TransientTransactionError"))
 
     @async_client_context.require_test_commands
     @async_client_context.require_transactions
@@ -534,10 +536,12 @@ class TestTransactionsConvenientAPI(AsyncTransactionsBase):
 
         async with client.start_session() as s:
             with PatchSessionTimeout(0):
-                with self.assertRaises(NetworkTimeout):
+                with self.assertRaises(NetworkTimeout) as context:
                     await s.with_transaction(callback)
 
         self.assertEqual(listener.started_command_names(), ["insert", "commitTransaction"])
+        # Assert that the timeout error has the same labels as the error it wraps.
+        self.assertTrue(context.exception.has_error_label("TransientTransactionError"))
 
     @async_client_context.require_test_commands
     @async_client_context.require_transactions
@@ -565,7 +569,7 @@ class TestTransactionsConvenientAPI(AsyncTransactionsBase):
 
         async with client.start_session() as s:
             with PatchSessionTimeout(0):
-                with self.assertRaises(NetworkTimeout):
+                with self.assertRaises(NetworkTimeout) as context:
                     await s.with_transaction(callback)
 
         # One insert for the callback and two commits (includes the automatic
@@ -573,6 +577,8 @@ class TestTransactionsConvenientAPI(AsyncTransactionsBase):
         self.assertEqual(
             listener.started_command_names(), ["insert", "commitTransaction", "commitTransaction"]
         )
+        # Assert that the timeout error has the same labels as the error it wraps.
+        self.assertTrue(context.exception.has_error_label("UnknownTransactionCommitResult"))
 
     @async_client_context.require_transactions
     async def test_callback_not_retried_after_csot_timeout(self):

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -492,10 +492,12 @@ class TestTransactionsConvenientAPI(TransactionsBase):
         listener.reset()
         with client.start_session() as s:
             with PatchSessionTimeout(0):
-                with self.assertRaises(NetworkTimeout):
+                with self.assertRaises(NetworkTimeout) as context:
                     s.with_transaction(callback)
 
         self.assertEqual(listener.started_command_names(), ["insert", "abortTransaction"])
+        # Assert that the timeout error has the same labels as the error it wraps.
+        self.assertTrue(context.exception.has_error_label("TransientTransactionError"))
 
     @client_context.require_test_commands
     @client_context.require_transactions
@@ -524,10 +526,12 @@ class TestTransactionsConvenientAPI(TransactionsBase):
 
         with client.start_session() as s:
             with PatchSessionTimeout(0):
-                with self.assertRaises(NetworkTimeout):
+                with self.assertRaises(NetworkTimeout) as context:
                     s.with_transaction(callback)
 
         self.assertEqual(listener.started_command_names(), ["insert", "commitTransaction"])
+        # Assert that the timeout error has the same labels as the error it wraps.
+        self.assertTrue(context.exception.has_error_label("TransientTransactionError"))
 
     @client_context.require_test_commands
     @client_context.require_transactions
@@ -553,7 +557,7 @@ class TestTransactionsConvenientAPI(TransactionsBase):
 
         with client.start_session() as s:
             with PatchSessionTimeout(0):
-                with self.assertRaises(NetworkTimeout):
+                with self.assertRaises(NetworkTimeout) as context:
                     s.with_transaction(callback)
 
         # One insert for the callback and two commits (includes the automatic
@@ -561,6 +565,8 @@ class TestTransactionsConvenientAPI(TransactionsBase):
         self.assertEqual(
             listener.started_command_names(), ["insert", "commitTransaction", "commitTransaction"]
         )
+        # Assert that the timeout error has the same labels as the error it wraps.
+        self.assertTrue(context.exception.has_error_label("UnknownTransactionCommitResult"))
 
     @client_context.require_transactions
     def test_callback_not_retried_after_csot_timeout(self):


### PR DESCRIPTION
… and label propagation in spec and prose tests

<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
[JIRA TICKET]: Issue Title

If you are an external contributor and there is no JIRA ticket associated with your change, then use your best judgement
for the PR title. A MongoDB employee will create a JIRA ticket and edit the name and links as appropriate.

Note on AI Contributions:
We only accept pull requests that are authored and submitted by human contributors who fully understand the changes they are proposing.
All contributions must be written and understood by human contributors. Please read about our policy in our contributing guide.
-->
[PYTHON-5788](https://jira.mongodb.org/browse/PYTHON-5788)

## Changes in this PR
<!-- What changes did you make to the code? What new APIs (public or private) were added, removed, or edited to generate
the desired outcome explained in the above summary? -->
- Only wrap retryable errors thrown during `withTransaction` calls with `_make_timeout_error`.
- Update prose tests to assert that the labels of propagated timeout errors match the error labels of the wrapped error.

## Test Plan
<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why.
All code should be tested in some way – so please list what your validation strategy was. -->
Updated existing prose tests.

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- [X] Did you update the changelog (if necessary)?
- [X] Is there test coverage?
- [X] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
