### PR TITLE
PYTHON-5798 - Overload retargeting prose tests do not ensure that sec…

### DIFF
--- a/test/asynchronous/test_retryable_reads.py
+++ b/test/asynchronous/test_retryable_reads.py
@@ -19,10 +19,10 @@ import os
 import pprint
 import sys
 import threading
-from test.asynchronous.utils import async_set_fail_point
+from test.asynchronous.utils import async_ensure_all_connected, async_set_fail_point
 from unittest import mock
 
-from pymongo import MongoClient
+from pymongo import MongoClient, ReadPreference
 from pymongo.common import MAX_ADAPTIVE_RETRIES
 from pymongo.errors import OperationFailure, PyMongoError
 
@@ -295,6 +295,9 @@ class TestRetryableReads(AsyncIntegrationTest):
             enableOverloadRetargeting=True,
         )
 
+        # Ensure the client has discovered all nodes.
+        await async_ensure_all_connected(client)
+
         # 2. Configure a fail point with the RetryableError and SystemOverloadedError error labels.
         command_args = {
             "configureFailPoint": "failCommand",
@@ -333,6 +336,9 @@ class TestRetryableReads(AsyncIntegrationTest):
         client = await self.async_rs_or_single_client(
             event_listeners=[listener], retryReads=True, readPreference="primaryPreferred"
         )
+
+        # Ensure the client has discovered all nodes.
+        await async_ensure_all_connected(client)
 
         # 2. Configure a fail point with the RetryableError error label.
         command_args = {
@@ -374,6 +380,9 @@ class TestRetryableReads(AsyncIntegrationTest):
             retryReads=True,
             readPreference="primaryPreferred",
         )
+
+        # Ensure the client has discovered all nodes.
+        await async_ensure_all_connected(client)
 
         # 2. Configure a fail point with the RetryableError and SystemOverloadedError error labels.
         command_args = {

--- a/test/asynchronous/test_retryable_reads.py
+++ b/test/asynchronous/test_retryable_reads.py
@@ -22,7 +22,7 @@ import threading
 from test.asynchronous.utils import async_ensure_all_connected, async_set_fail_point
 from unittest import mock
 
-from pymongo import MongoClient, ReadPreference
+from pymongo import MongoClient
 from pymongo.common import MAX_ADAPTIVE_RETRIES
 from pymongo.errors import OperationFailure, PyMongoError
 

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -22,7 +22,7 @@ import threading
 from test.utils import ensure_all_connected, set_fail_point
 from unittest import mock
 
-from pymongo import MongoClient, ReadPreference
+from pymongo import MongoClient
 from pymongo.common import MAX_ADAPTIVE_RETRIES
 from pymongo.errors import OperationFailure, PyMongoError
 

--- a/test/test_retryable_reads.py
+++ b/test/test_retryable_reads.py
@@ -19,10 +19,10 @@ import os
 import pprint
 import sys
 import threading
-from test.utils import set_fail_point
+from test.utils import ensure_all_connected, set_fail_point
 from unittest import mock
 
-from pymongo import MongoClient
+from pymongo import MongoClient, ReadPreference
 from pymongo.common import MAX_ADAPTIVE_RETRIES
 from pymongo.errors import OperationFailure, PyMongoError
 
@@ -293,6 +293,9 @@ class TestRetryableReads(IntegrationTest):
             enableOverloadRetargeting=True,
         )
 
+        # Ensure the client has discovered all nodes.
+        ensure_all_connected(client)
+
         # 2. Configure a fail point with the RetryableError and SystemOverloadedError error labels.
         command_args = {
             "configureFailPoint": "failCommand",
@@ -331,6 +334,9 @@ class TestRetryableReads(IntegrationTest):
         client = self.rs_or_single_client(
             event_listeners=[listener], retryReads=True, readPreference="primaryPreferred"
         )
+
+        # Ensure the client has discovered all nodes.
+        ensure_all_connected(client)
 
         # 2. Configure a fail point with the RetryableError error label.
         command_args = {
@@ -372,6 +378,9 @@ class TestRetryableReads(IntegrationTest):
             retryReads=True,
             readPreference="primaryPreferred",
         )
+
+        # Ensure the client has discovered all nodes.
+        ensure_all_connected(client)
 
         # 2. Configure a fail point with the RetryableError and SystemOverloadedError error labels.
         command_args = {


### PR DESCRIPTION
…ondaries are discovered

<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
[JIRA TICKET]: Issue Title

If you are an external contributor and there is no JIRA ticket associated with your change, then use your best judgement
for the PR title. A MongoDB employee will create a JIRA ticket and edit the name and links as appropriate.

Note on AI Contributions:
We only accept pull requests that are authored and submitted by human contributors who fully understand the changes they are proposing.
All contributions must be written and understood by human contributors. Please read about our policy in our contributing guide.
-->
[PYTHON-5798](https://jira.mongodb.org/browse/PYTHON-5798)

## Changes in this PR
<!-- What changes did you make to the code? What new APIs (public or private) were added, removed, or edited to generate
the desired outcome explained in the above summary? -->
Make overload retargeting retryable read tests wait until all nodes in the replica set have been discovered.

## Test Plan
<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why.
All code should be tested in some way – so please list what your validation strategy was. -->

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [ ] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
