### PR TITLE
PYTHON-5800 - Simple collation is included in index information

### DIFF
--- a/test/asynchronous/test_collation.py
+++ b/test/asynchronous/test_collation.py
@@ -257,7 +257,6 @@ class TestCollation(AsyncIntegrationTest):
         self.assertEqual(
             ja_collation.document["locale"], indexes["japanese_version"]["collation"]["locale"]
         )
-        self.assertNotIn("collation", indexes["simple"])
         await self.db.test.drop_index("fieldname_1")
         indexes = await self.db.test.index_information()
         self.assertIn("japanese_version", indexes)

--- a/test/test_collation.py
+++ b/test/test_collation.py
@@ -257,7 +257,6 @@ class TestCollation(IntegrationTest):
         self.assertEqual(
             ja_collation.document["locale"], indexes["japanese_version"]["collation"]["locale"]
         )
-        self.assertNotIn("collation", indexes["simple"])
         self.db.test.drop_index("fieldname_1")
         indexes = self.db.test.index_information()
         self.assertIn("japanese_version", indexes)


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
[JIRA TICKET]: Issue Title

If you are an external contributor and there is no JIRA ticket associated with your change, then use your best judgement
for the PR title. A MongoDB employee will create a JIRA ticket and edit the name and links as appropriate.

Note on AI Contributions:
We only accept pull requests that are authored and submitted by human contributors who fully understand the changes they are proposing.
All contributions must be written and understood by human contributors. Please read about our policy in our contributing guide.
-->
[PYTHON-5800](https://jira.mongodb.org/browse/PYTHON-5800)

## Changes in this PR
<!-- What changes did you make to the code? What new APIs (public or private) were added, removed, or edited to generate
the desired outcome explained in the above summary? -->
Update`test_indexes_same_keys_different_collations` test to not check for the exclusion of `{local: "simple"}` in index collation parameters.

## Test Plan
<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why.
All code should be tested in some way – so please list what your validation strategy was. -->

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [ ] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
