### PR TITLE
PYTHON-5782 Coverage increase, remove old code in `message.py`

### DIFF
--- a/pymongo/message.py
+++ b/pymongo/message.py
@@ -652,7 +652,7 @@ def _raise_document_too_large(operation: str, doc_size: int, max_size: int) -> N
     else:
         # There's nothing intelligent we can say
         # about size for update and delete
-        raise DocumentTooLarge(f"{operation!r} command document too large")
+        raise DocumentTooLarge(f"{operation} command document too large")
 
 
 # From the Client Side Encryption spec:

--- a/pymongo/message.py
+++ b/pymongo/message.py
@@ -652,7 +652,7 @@ def _raise_document_too_large(operation: str, doc_size: int, max_size: int) -> N
     else:
         # There's nothing intelligent we can say
         # about size for update and delete
-        raise DocumentTooLarge(f"{operation} command document too large")
+        raise DocumentTooLarge(f"{operation!r} command document too large")
 
 
 # From the Client Side Encryption spec:

--- a/pymongo/message.py
+++ b/pymongo/message.py
@@ -171,14 +171,6 @@ def _convert_write_result(
     elif operation == "update":
         if "upserted" in result:
             res["upserted"] = [{"index": 0, "_id": result["upserted"]}]
-        # Versions of MongoDB before 2.6 don't return the _id for an
-        # upsert if _id is not an ObjectId.
-        elif result.get("updatedExisting") is False and affected == 1:
-            # If _id is in both the update document *and* the query spec
-            # the update document _id takes precedence.
-            update = command["updates"][0]
-            _id = update["u"].get("_id", update["q"].get("_id"))
-            res["upserted"] = [{"index": 0, "_id": _id}]
     return res
 
 

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -1,0 +1,586 @@
+# Copyright 2026-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for message.py."""
+
+from __future__ import annotations
+
+import struct
+import sys
+
+sys.path[0:0] = [""]
+
+from test import unittest
+
+from bson import CodecOptions
+from pymongo.errors import DocumentTooLarge
+from pymongo.message import (
+    MAX_INT32,
+    MIN_INT32,
+    _compress,
+    _convert_client_bulk_exception,
+    _convert_exception,
+    _convert_write_result,
+    _gen_find_command,
+    _gen_get_more_command,
+    _get_more,
+    _get_more_compressed,
+    _get_more_impl,
+    _get_more_uncompressed,
+    _maybe_add_read_preference,
+    _op_msg,
+    _op_msg_no_header,
+    _op_msg_uncompressed,
+    _query,
+    _query_compressed,
+    _query_impl,
+    _query_uncompressed,
+    _raise_document_too_large,
+    _randint,
+)
+from pymongo.read_preferences import Primary, ReadPreference, Secondary, SecondaryPreferred
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_OPTS = CodecOptions()
+
+
+class _MockCtx:
+    """Minimal compression context for testing _compress."""
+
+    compressor_id = 2  # zlib id
+
+    def compress(self, data: bytes) -> bytes:
+        import zlib
+
+        return zlib.compress(data)
+
+
+class _MockConn:
+    """Mock connection for _gen_get_more_command."""
+
+    max_wire_version = 9
+
+
+# ---------------------------------------------------------------------------
+# _randint
+# ---------------------------------------------------------------------------
+
+
+class TestRandint(unittest.TestCase):
+    def test_returns_int(self):
+        self.assertIsInstance(_randint(), int)
+
+    def test_in_range(self):
+        for _ in range(50):
+            r = _randint()
+            self.assertGreaterEqual(r, MIN_INT32)
+            self.assertLessEqual(r, MAX_INT32)
+
+
+# ---------------------------------------------------------------------------
+# _maybe_add_read_preference
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeAddReadPreference(unittest.TestCase):
+    def test_primary_no_read_preference_added(self):
+        spec: dict = {"find": "col"}
+        result = _maybe_add_read_preference(spec, ReadPreference.PRIMARY)
+        self.assertNotIn("$readPreference", result)
+        self.assertNotIn("$query", result)
+
+    def test_secondary_adds_read_preference(self):
+        spec: dict = {"find": "col"}
+        result = _maybe_add_read_preference(spec, ReadPreference.SECONDARY)
+        self.assertIn("$readPreference", result)
+        self.assertEqual(result["$readPreference"]["mode"], "secondary")
+        self.assertIn("$query", result)
+
+    def test_nearest_adds_read_preference(self):
+        spec: dict = {"find": "col"}
+        result = _maybe_add_read_preference(spec, ReadPreference.NEAREST)
+        self.assertIn("$readPreference", result)
+        self.assertEqual(result["$readPreference"]["mode"], "nearest")
+
+    def test_secondary_preferred_no_tags_does_not_add(self):
+        spec: dict = {"find": "col"}
+        result = _maybe_add_read_preference(spec, ReadPreference.SECONDARY_PREFERRED)
+        # SECONDARY_PREFERRED with no tags uses secondaryOk bit instead.
+        self.assertNotIn("$readPreference", result)
+
+    def test_secondary_preferred_with_tags_adds_read_preference(self):
+        pref = SecondaryPreferred(tag_sets=[{"dc": "east"}])
+        spec: dict = {"find": "col"}
+        result = _maybe_add_read_preference(spec, pref)
+        self.assertIn("$readPreference", result)
+
+    def test_existing_query_wrapper_preserved(self):
+        spec: dict = {"$query": {"x": 1}, "other": 2}
+        result = _maybe_add_read_preference(spec, ReadPreference.SECONDARY)
+        # $query already present, $readPreference is added directly.
+        self.assertIn("$readPreference", result)
+        self.assertEqual(result["$query"], {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# _convert_exception
+# ---------------------------------------------------------------------------
+
+
+class TestConvertException(unittest.TestCase):
+    def test_basic_exception(self):
+        exc = ValueError("bad value")
+        doc = _convert_exception(exc)
+        self.assertEqual(doc["errmsg"], "bad value")
+        self.assertEqual(doc["errtype"], "ValueError")
+
+    def test_runtime_error(self):
+        exc = RuntimeError("oops")
+        doc = _convert_exception(exc)
+        self.assertEqual(doc["errtype"], "RuntimeError")
+
+
+# ---------------------------------------------------------------------------
+# _convert_client_bulk_exception
+# ---------------------------------------------------------------------------
+
+
+class TestConvertClientBulkException(unittest.TestCase):
+    def test_includes_code(self):
+        from pymongo.errors import OperationFailure
+
+        exc = OperationFailure("failed", code=11000)
+        doc = _convert_client_bulk_exception(exc)
+        self.assertEqual(doc["errmsg"], "failed")
+        self.assertEqual(doc["code"], 11000)
+        self.assertEqual(doc["errtype"], "OperationFailure")
+
+
+# ---------------------------------------------------------------------------
+# _convert_write_result
+# ---------------------------------------------------------------------------
+
+
+class TestConvertWriteResult(unittest.TestCase):
+    def test_insert_basic(self):
+        cmd = {"documents": [{"_id": 1}, {"_id": 2}]}
+        result = _convert_write_result("insert", cmd, {"n": 0})
+        self.assertEqual(result["ok"], 1)
+        self.assertEqual(result["n"], 2)  # len(documents) overrides n
+
+    def test_update_basic(self):
+        cmd = {"updates": [{"q": {}, "u": {"$set": {"x": 1}}}]}
+        result = _convert_write_result("update", cmd, {"n": 1, "updatedExisting": True})
+        self.assertEqual(result["ok"], 1)
+        self.assertNotIn("upserted", result)
+
+    def test_update_with_upserted_id(self):
+        cmd = {"updates": [{"q": {}, "u": {"_id": 42}}]}
+        result = _convert_write_result("update", cmd, {"n": 1, "upserted": 42})
+        self.assertIn("upserted", result)
+        self.assertEqual(result["upserted"][0]["_id"], 42)
+
+    def test_update_implicit_upsert_from_updatedExisting_false(self):
+        cmd = {"updates": [{"q": {"_id": 99}, "u": {"$set": {"x": 1}}}]}
+        result = _convert_write_result(
+            "update", cmd, {"n": 1, "updatedExisting": False, "upserted": None}
+        )
+        # upserted is already in result, so it takes the fast path
+        self.assertIn("upserted", result)
+
+    def test_update_upsert_no_upserted_id_from_query(self):
+        cmd = {"updates": [{"q": {"_id": 77}, "u": {"$set": {"x": 1}}}]}
+        result = _convert_write_result("update", cmd, {"n": 1, "updatedExisting": False})
+        self.assertIn("upserted", result)
+        self.assertEqual(result["upserted"][0]["_id"], 77)
+
+    def test_delete_basic(self):
+        cmd = {"deletes": [{"q": {}, "limit": 1}]}
+        result = _convert_write_result("delete", cmd, {"n": 1})
+        self.assertEqual(result["ok"], 1)
+        self.assertEqual(result["n"], 1)
+
+    def test_write_error(self):
+        cmd = {"documents": [{"_id": 1}]}
+        gle = {"n": 0, "err": "duplicate key error", "code": 11000}
+        result = _convert_write_result("insert", cmd, gle)
+        self.assertIn("writeErrors", result)
+        self.assertEqual(result["writeErrors"][0]["code"], 11000)
+
+    def test_write_concern_timeout(self):
+        cmd = {"documents": [{"_id": 1}]}
+        gle = {"n": 1, "errmsg": "timeout", "wtimeout": True}
+        result = _convert_write_result("insert", cmd, gle)
+        self.assertIn("writeConcernError", result)
+        self.assertEqual(result["writeConcernError"]["code"], 64)
+
+    def test_write_error_with_err_info(self):
+        cmd = {"documents": [{"_id": 1}]}
+        gle = {"n": 0, "err": "err", "code": 123, "errInfo": {"detail": "x"}}
+        result = _convert_write_result("insert", cmd, gle)
+        self.assertIn("errInfo", result["writeErrors"][0])
+
+
+# ---------------------------------------------------------------------------
+# _compress
+# ---------------------------------------------------------------------------
+
+
+class TestCompress(unittest.TestCase):
+    def test_returns_request_id_and_bytes(self):
+        ctx = _MockCtx()
+        data = b"hello world"
+        request_id, msg = _compress(2013, data, ctx)
+        self.assertIsInstance(request_id, int)
+        self.assertIsInstance(msg, bytes)
+
+    def test_compressed_message_has_op_compressed_header(self):
+        ctx = _MockCtx()
+        data = b"hello world"
+        _request_id, msg = _compress(2013, data, ctx)
+        # Header: 4 bytes msglen, 4 bytes requestId, 4 bytes responseTo, 4 bytes opCode
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2012)  # OP_COMPRESSED
+
+
+# ---------------------------------------------------------------------------
+# _op_msg_no_header
+# ---------------------------------------------------------------------------
+
+
+class TestOpMsgNoHeader(unittest.TestCase):
+    def test_basic_command_no_docs(self):
+        cmd = {"ping": 1}
+        data, total_size, max_doc_size = _op_msg_no_header(0, cmd, "", None, _OPTS)
+        self.assertIsInstance(data, bytes)
+        self.assertGreater(total_size, 0)
+        self.assertEqual(max_doc_size, 0)
+
+    def test_command_with_docs(self):
+        cmd = {"insert": "col"}
+        docs = [{"_id": 1, "x": 2}, {"_id": 3, "x": 4}]
+        data, total_size, max_doc_size = _op_msg_no_header(0, cmd, "documents", docs, _OPTS)
+        self.assertIsInstance(data, bytes)
+        self.assertGreater(max_doc_size, 0)
+
+
+# ---------------------------------------------------------------------------
+# _op_msg_uncompressed / _op_msg_compressed
+# ---------------------------------------------------------------------------
+
+
+class TestOpMsgUncompressed(unittest.TestCase):
+    def test_returns_tuple(self):
+        cmd = {"ping": 1}
+        rid, msg, total_size, max_doc_size = _op_msg_uncompressed(0, cmd, "", None, _OPTS)
+        self.assertIsInstance(rid, int)
+        self.assertIsInstance(msg, bytes)
+
+    def test_msg_has_correct_op_code(self):
+        cmd = {"ping": 1}
+        _rid, msg, _ts, _mds = _op_msg_uncompressed(0, cmd, "", None, _OPTS)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2013)  # OP_MSG
+
+
+# ---------------------------------------------------------------------------
+# _op_msg
+# ---------------------------------------------------------------------------
+
+
+class TestOpMsg(unittest.TestCase):
+    def test_basic_uncompressed(self):
+        cmd: dict = {"ping": 1}
+        rid, msg, total_size, max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS)
+        self.assertIsInstance(rid, int)
+        self.assertIsInstance(msg, bytes)
+        self.assertEqual(cmd["$db"], "testdb")
+
+    def test_read_preference_added_for_non_primary(self):
+        cmd: dict = {"find": "col"}
+        _op_msg(0, cmd, "testdb", ReadPreference.SECONDARY, _OPTS)
+        self.assertIn("$readPreference", cmd)
+
+    def test_read_preference_not_added_for_primary(self):
+        cmd: dict = {"find": "col"}
+        _op_msg(0, cmd, "testdb", ReadPreference.PRIMARY, _OPTS)
+        self.assertNotIn("$readPreference", cmd)
+
+    def test_read_preference_skipped_if_already_present(self):
+        cmd: dict = {"find": "col", "$readPreference": {"mode": "nearest"}}
+        _op_msg(0, cmd, "testdb", ReadPreference.SECONDARY, _OPTS)
+        self.assertEqual(cmd["$readPreference"]["mode"], "nearest")
+
+    def test_none_read_preference_skipped(self):
+        cmd: dict = {"find": "col"}
+        _op_msg(0, cmd, "testdb", None, _OPTS)
+        self.assertNotIn("$readPreference", cmd)
+
+    def test_with_compression_context(self):
+        ctx = _MockCtx()
+        cmd: dict = {"ping": 1}
+        rid, msg, total_size, max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS, ctx)
+        self.assertIsInstance(rid, int)
+        # Compressed message uses OP_COMPRESSED (2012).
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2012)
+
+    def test_command_with_documents_field_is_restored(self):
+        docs = [{"_id": 1}]
+        cmd: dict = {"insert": "col", "documents": docs}
+        _op_msg(0, cmd, "testdb", None, _OPTS)
+        # The documents field should be restored after the call.
+        self.assertIn("documents", cmd)
+        self.assertEqual(cmd["documents"], docs)
+
+
+# ---------------------------------------------------------------------------
+# _query_impl / _query_uncompressed / _query_compressed / _query
+# ---------------------------------------------------------------------------
+
+
+class TestQueryImpl(unittest.TestCase):
+    def test_basic_query(self):
+        data, max_bson_size = _query_impl(0, "db.col", 0, 0, {"x": 1}, None, _OPTS)
+        self.assertIsInstance(data, bytes)
+        self.assertGreater(max_bson_size, 0)
+
+    def test_with_field_selector(self):
+        data, max_bson_size = _query_impl(0, "db.col", 0, 0, {"x": 1}, {"_id": 0}, _OPTS)
+        self.assertIsInstance(data, bytes)
+
+
+class TestQueryUncompressed(unittest.TestCase):
+    def test_returns_tuple(self):
+        rid, msg, max_bson_size = _query_uncompressed(0, "db.col", 0, 0, {}, None, _OPTS)
+        self.assertIsInstance(rid, int)
+        self.assertIsInstance(msg, bytes)
+
+    def test_op_code(self):
+        _rid, msg, _mbs = _query_uncompressed(0, "db.col", 0, 0, {}, None, _OPTS)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2004)  # OP_QUERY
+
+
+class TestQueryCompressed(unittest.TestCase):
+    def test_returns_compressed(self):
+        ctx = _MockCtx()
+        rid, msg, max_bson_size = _query_compressed(0, "db.col", 0, 0, {}, None, _OPTS, ctx)
+        self.assertIsInstance(rid, int)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2012)  # OP_COMPRESSED
+
+
+class TestQuery(unittest.TestCase):
+    def test_uncompressed_path(self):
+        rid, msg, max_bson_size = _query(0, "db.col", 0, 0, {}, None, _OPTS)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2004)
+
+    def test_compressed_path(self):
+        ctx = _MockCtx()
+        rid, msg, max_bson_size = _query(0, "db.col", 0, 0, {}, None, _OPTS, ctx)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2012)
+
+
+# ---------------------------------------------------------------------------
+# _get_more_impl / _get_more_uncompressed / _get_more_compressed / _get_more
+# ---------------------------------------------------------------------------
+
+
+class TestGetMoreImpl(unittest.TestCase):
+    def test_returns_bytes(self):
+        data = _get_more_impl("db.col", 10, 12345)
+        self.assertIsInstance(data, bytes)
+
+
+class TestGetMoreUncompressed(unittest.TestCase):
+    def test_returns_tuple(self):
+        rid, msg = _get_more_uncompressed("db.col", 10, 12345)
+        self.assertIsInstance(rid, int)
+        self.assertIsInstance(msg, bytes)
+
+    def test_op_code(self):
+        _rid, msg = _get_more_uncompressed("db.col", 0, 0)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2005)  # OP_GET_MORE
+
+
+class TestGetMoreCompressed(unittest.TestCase):
+    def test_returns_compressed(self):
+        ctx = _MockCtx()
+        rid, msg = _get_more_compressed("db.col", 0, 0, ctx)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2012)
+
+
+class TestGetMore(unittest.TestCase):
+    def test_uncompressed_path(self):
+        rid, msg = _get_more("db.col", 0, 0)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2005)
+
+    def test_compressed_path(self):
+        ctx = _MockCtx()
+        rid, msg = _get_more("db.col", 0, 0, ctx)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2012)
+
+
+# ---------------------------------------------------------------------------
+# _raise_document_too_large
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseDocumentTooLarge(unittest.TestCase):
+    def test_insert_includes_sizes(self):
+        with self.assertRaises(DocumentTooLarge) as ctx:
+            _raise_document_too_large("insert", 2_000_000, 1_000_000)
+        msg = str(ctx.exception)
+        self.assertIn("2000000", msg)
+        self.assertIn("1000000", msg)
+
+    def test_update_generic_message(self):
+        with self.assertRaises(DocumentTooLarge) as ctx:
+            _raise_document_too_large("update", 2_000_000, 1_000_000)
+        self.assertIn("update", str(ctx.exception))
+
+    def test_delete_generic_message(self):
+        with self.assertRaises(DocumentTooLarge) as ctx:
+            _raise_document_too_large("delete", 2_000_000, 1_000_000)
+        self.assertIn("delete", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# _gen_find_command
+# ---------------------------------------------------------------------------
+
+
+class TestGenFindCommand(unittest.TestCase):
+    def _read_concern(self, level=None):
+        from pymongo.read_concern import ReadConcern
+
+        return ReadConcern(level=level)
+
+    def test_basic(self):
+        cmd = _gen_find_command("col", {}, None, 0, 0, None, None, self._read_concern())
+        self.assertEqual(cmd["find"], "col")
+        self.assertEqual(cmd["filter"], {})
+
+    def test_with_projection(self):
+        cmd = _gen_find_command("col", {}, {"x": 1}, 0, 0, None, None, self._read_concern())
+        self.assertIn("projection", cmd)
+
+    def test_with_skip(self):
+        cmd = _gen_find_command("col", {}, None, 5, 0, None, None, self._read_concern())
+        self.assertEqual(cmd["skip"], 5)
+
+    def test_with_positive_limit(self):
+        cmd = _gen_find_command("col", {}, None, 0, 10, None, None, self._read_concern())
+        self.assertEqual(cmd["limit"], 10)
+        self.assertNotIn("singleBatch", cmd)
+
+    def test_with_negative_limit_sets_single_batch(self):
+        cmd = _gen_find_command("col", {}, None, 0, -5, None, None, self._read_concern())
+        self.assertEqual(cmd["limit"], 5)
+        self.assertTrue(cmd["singleBatch"])
+
+    def test_batch_size_adjusted_when_equal_to_limit(self):
+        cmd = _gen_find_command("col", {}, None, 0, 10, 10, None, self._read_concern())
+        self.assertEqual(cmd["batchSize"], 11)
+
+    def test_batch_size_not_adjusted_when_different(self):
+        cmd = _gen_find_command("col", {}, None, 0, 10, 5, None, self._read_concern())
+        self.assertEqual(cmd["batchSize"], 5)
+
+    def test_read_concern_level_included(self):
+        cmd = _gen_find_command("col", {}, None, 0, 0, None, None, self._read_concern("majority"))
+        self.assertIn("readConcern", cmd)
+
+    def test_query_with_dollar_query_modifier(self):
+        spec = {"$query": {"x": 1}, "$orderby": {"x": 1}}
+        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, self._read_concern())
+        self.assertIn("sort", cmd)
+        self.assertNotIn("$orderby", cmd)
+        self.assertNotIn("$query", cmd)
+
+    def test_allow_disk_use(self):
+        cmd = _gen_find_command(
+            "col", {}, None, 0, 0, None, None, self._read_concern(), allow_disk_use=True
+        )
+        self.assertTrue(cmd["allowDiskUse"])
+
+    def test_collation(self):
+        cmd = _gen_find_command(
+            "col", {}, None, 0, 0, None, None, self._read_concern(), collation={"locale": "en"}
+        )
+        self.assertEqual(cmd["collation"]["locale"], "en")
+
+    def test_options_tailable(self):
+        cmd = _gen_find_command("col", {}, None, 0, 0, None, 2, self._read_concern())
+        self.assertTrue(cmd.get("tailable"))
+
+    def test_dollar_query_with_explain_removed(self):
+        spec = {"$query": {"x": 1}, "$explain": 1}
+        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, self._read_concern())
+        # $explain should be stripped from the find command.
+        self.assertNotIn("$explain", cmd)
+
+    def test_dollar_query_with_read_preference_removed(self):
+        spec = {"$query": {"x": 1}, "$readPreference": {"mode": "secondary"}}
+        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, self._read_concern())
+        self.assertNotIn("$readPreference", cmd)
+
+
+# ---------------------------------------------------------------------------
+# _gen_get_more_command
+# ---------------------------------------------------------------------------
+
+
+class TestGenGetMoreCommand(unittest.TestCase):
+    def test_basic(self):
+        conn = _MockConn()
+        cmd = _gen_get_more_command(12345, "col", None, None, None, conn)
+        self.assertEqual(cmd["getMore"], 12345)
+        self.assertEqual(cmd["collection"], "col")
+
+    def test_with_batch_size(self):
+        conn = _MockConn()
+        cmd = _gen_get_more_command(1, "col", 100, None, None, conn)
+        self.assertEqual(cmd["batchSize"], 100)
+
+    def test_with_max_await_time_ms(self):
+        conn = _MockConn()
+        cmd = _gen_get_more_command(1, "col", None, 500, None, conn)
+        self.assertEqual(cmd["maxTimeMS"], 500)
+
+    def test_comment_added_on_high_wire_version(self):
+        conn = _MockConn()
+        conn.max_wire_version = 9
+        cmd = _gen_get_more_command(1, "col", None, None, "my comment", conn)
+        self.assertEqual(cmd["comment"], "my comment")
+
+    def test_comment_not_added_on_low_wire_version(self):
+        conn = _MockConn()
+        conn.max_wire_version = 8
+        cmd = _gen_get_more_command(1, "col", None, None, "my comment", conn)
+        self.assertNotIn("comment", cmd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -24,6 +24,7 @@ sys.path[0:0] = [""]
 from test import unittest
 
 from bson import CodecOptions
+from pymongo.compression_support import ZlibContext
 from pymongo.errors import DocumentTooLarge
 from pymongo.message import (
     MAX_INT32,
@@ -56,17 +57,7 @@ from pymongo.read_preferences import Primary, ReadPreference, Secondary, Seconda
 # ---------------------------------------------------------------------------
 
 _OPTS = CodecOptions()
-
-
-class _MockCtx:
-    """Minimal compression context for testing _compress."""
-
-    compressor_id = 2  # zlib id
-
-    def compress(self, data: bytes) -> bytes:
-        import zlib
-
-        return zlib.compress(data)
+_ZLIB_CTX = ZlibContext(-1)  # default zlib compression level
 
 
 class _MockConn:
@@ -242,14 +233,14 @@ class TestConvertWriteResult(unittest.TestCase):
 
 class TestCompress(unittest.TestCase):
     def test_returns_request_id_and_bytes(self):
-        ctx = _MockCtx()
+        ctx = _ZLIB_CTX
         data = b"hello world"
         request_id, msg = _compress(2013, data, ctx)
         self.assertIsInstance(request_id, int)
         self.assertIsInstance(msg, bytes)
 
     def test_compressed_message_has_op_compressed_header(self):
-        ctx = _MockCtx()
+        ctx = _ZLIB_CTX
         data = b"hello world"
         _request_id, msg = _compress(2013, data, ctx)
         # Header: 4 bytes msglen, 4 bytes requestId, 4 bytes responseTo, 4 bytes opCode
@@ -272,7 +263,7 @@ class TestOpMsgNoHeader(unittest.TestCase):
 
     def test_command_with_docs(self):
         cmd = {"insert": "col"}
-        docs = [{"_id": 1, "x": 2}, {"_id": 3, "x": 4}]
+        docs: list = [{"_id": 1, "x": 2}, {"_id": 3, "x": 4}]
         data, total_size, max_doc_size = _op_msg_no_header(0, cmd, "documents", docs, _OPTS)
         self.assertIsInstance(data, bytes)
         self.assertGreater(max_doc_size, 0)
@@ -331,7 +322,7 @@ class TestOpMsg(unittest.TestCase):
         self.assertNotIn("$readPreference", cmd)
 
     def test_with_compression_context(self):
-        ctx = _MockCtx()
+        ctx = _ZLIB_CTX
         cmd: dict = {"ping": 1}
         rid, msg, total_size, max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS, ctx)
         self.assertIsInstance(rid, int)
@@ -378,7 +369,7 @@ class TestQueryUncompressed(unittest.TestCase):
 
 class TestQueryCompressed(unittest.TestCase):
     def test_returns_compressed(self):
-        ctx = _MockCtx()
+        ctx = _ZLIB_CTX
         rid, msg, max_bson_size = _query_compressed(0, "db.col", 0, 0, {}, None, _OPTS, ctx)
         self.assertIsInstance(rid, int)
         op_code = struct.unpack("<i", msg[12:16])[0]
@@ -392,7 +383,7 @@ class TestQuery(unittest.TestCase):
         self.assertEqual(op_code, 2004)
 
     def test_compressed_path(self):
-        ctx = _MockCtx()
+        ctx = _ZLIB_CTX
         rid, msg, max_bson_size = _query(0, "db.col", 0, 0, {}, None, _OPTS, ctx)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)
@@ -423,7 +414,7 @@ class TestGetMoreUncompressed(unittest.TestCase):
 
 class TestGetMoreCompressed(unittest.TestCase):
     def test_returns_compressed(self):
-        ctx = _MockCtx()
+        ctx = _ZLIB_CTX
         rid, msg = _get_more_compressed("db.col", 0, 0, ctx)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)
@@ -436,7 +427,7 @@ class TestGetMore(unittest.TestCase):
         self.assertEqual(op_code, 2005)
 
     def test_compressed_path(self):
-        ctx = _MockCtx()
+        ctx = _ZLIB_CTX
         rid, msg = _get_more("db.col", 0, 0, ctx)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)
@@ -555,30 +546,30 @@ class TestGenFindCommand(unittest.TestCase):
 class TestGenGetMoreCommand(unittest.TestCase):
     def test_basic(self):
         conn = _MockConn()
-        cmd = _gen_get_more_command(12345, "col", None, None, None, conn)
+        cmd = _gen_get_more_command(12345, "col", None, None, None, conn)  # type: ignore[arg-type]
         self.assertEqual(cmd["getMore"], 12345)
         self.assertEqual(cmd["collection"], "col")
 
     def test_with_batch_size(self):
         conn = _MockConn()
-        cmd = _gen_get_more_command(1, "col", 100, None, None, conn)
+        cmd = _gen_get_more_command(1, "col", 100, None, None, conn)  # type: ignore[arg-type]
         self.assertEqual(cmd["batchSize"], 100)
 
     def test_with_max_await_time_ms(self):
         conn = _MockConn()
-        cmd = _gen_get_more_command(1, "col", None, 500, None, conn)
+        cmd = _gen_get_more_command(1, "col", None, 500, None, conn)  # type: ignore[arg-type]
         self.assertEqual(cmd["maxTimeMS"], 500)
 
     def test_comment_added_on_high_wire_version(self):
         conn = _MockConn()
         conn.max_wire_version = 9
-        cmd = _gen_get_more_command(1, "col", None, None, "my comment", conn)
+        cmd = _gen_get_more_command(1, "col", None, None, "my comment", conn)  # type: ignore[arg-type]
         self.assertEqual(cmd["comment"], "my comment")
 
     def test_comment_not_added_on_low_wire_version(self):
         conn = _MockConn()
         conn.max_wire_version = 8
-        cmd = _gen_get_more_command(1, "col", None, None, "my comment", conn)
+        cmd = _gen_get_more_command(1, "col", None, None, "my comment", conn)  # type: ignore[arg-type]
         self.assertNotIn("comment", cmd)
 
 

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import struct
 import sys
+from unittest.mock import MagicMock
 
 sys.path[0:0] = [""]
 
@@ -25,7 +26,7 @@ from test import unittest
 
 from bson import CodecOptions
 from pymongo.compression_support import ZlibContext
-from pymongo.errors import DocumentTooLarge
+from pymongo.errors import DocumentTooLarge, OperationFailure
 from pymongo.message import (
     MAX_INT32,
     MIN_INT32,
@@ -37,12 +38,9 @@ from pymongo.message import (
     _gen_get_more_command,
     _get_more,
     _get_more_compressed,
-    _get_more_impl,
     _get_more_uncompressed,
     _maybe_add_read_preference,
     _op_msg,
-    _op_msg_no_header,
-    _op_msg_uncompressed,
     _query,
     _query_compressed,
     _query_impl,
@@ -50,41 +48,19 @@ from pymongo.message import (
     _raise_document_too_large,
     _randint,
 )
-from pymongo.read_preferences import Primary, ReadPreference, Secondary, SecondaryPreferred
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+from pymongo.read_concern import ReadConcern
+from pymongo.read_preferences import ReadPreference, Secondary, SecondaryPreferred
 
 _OPTS = CodecOptions()
-_ZLIB_CTX = ZlibContext(-1)  # default zlib compression level
-
-
-class _MockConn:
-    """Mock connection for _gen_get_more_command."""
-
-    max_wire_version = 9
-
-
-# ---------------------------------------------------------------------------
-# _randint
-# ---------------------------------------------------------------------------
+_ZLIB_CTX = ZlibContext(-1)
 
 
 class TestRandint(unittest.TestCase):
-    def test_returns_int(self):
-        self.assertIsInstance(_randint(), int)
-
     def test_in_range(self):
         for _ in range(50):
             r = _randint()
             self.assertGreaterEqual(r, MIN_INT32)
             self.assertLessEqual(r, MAX_INT32)
-
-
-# ---------------------------------------------------------------------------
-# _maybe_add_read_preference
-# ---------------------------------------------------------------------------
 
 
 class TestMaybeAddReadPreference(unittest.TestCase):
@@ -110,7 +86,6 @@ class TestMaybeAddReadPreference(unittest.TestCase):
     def test_secondary_preferred_no_tags_does_not_add(self):
         spec: dict = {"find": "col"}
         result = _maybe_add_read_preference(spec, ReadPreference.SECONDARY_PREFERRED)
-        # SECONDARY_PREFERRED with no tags uses secondaryOk bit instead.
         self.assertNotIn("$readPreference", result)
 
     def test_secondary_preferred_with_tags_adds_read_preference(self):
@@ -122,14 +97,8 @@ class TestMaybeAddReadPreference(unittest.TestCase):
     def test_existing_query_wrapper_preserved(self):
         spec: dict = {"$query": {"x": 1}, "other": 2}
         result = _maybe_add_read_preference(spec, ReadPreference.SECONDARY)
-        # $query already present, $readPreference is added directly.
         self.assertIn("$readPreference", result)
         self.assertEqual(result["$query"], {"x": 1})
-
-
-# ---------------------------------------------------------------------------
-# _convert_exception
-# ---------------------------------------------------------------------------
 
 
 class TestConvertException(unittest.TestCase):
@@ -144,16 +113,7 @@ class TestConvertException(unittest.TestCase):
         doc = _convert_exception(exc)
         self.assertEqual(doc["errtype"], "RuntimeError")
 
-
-# ---------------------------------------------------------------------------
-# _convert_client_bulk_exception
-# ---------------------------------------------------------------------------
-
-
-class TestConvertClientBulkException(unittest.TestCase):
-    def test_includes_code(self):
-        from pymongo.errors import OperationFailure
-
+    def test_client_bulk_exception_includes_code(self):
         exc = OperationFailure("failed", code=11000)
         doc = _convert_client_bulk_exception(exc)
         self.assertEqual(doc["errmsg"], "failed")
@@ -161,17 +121,12 @@ class TestConvertClientBulkException(unittest.TestCase):
         self.assertEqual(doc["errtype"], "OperationFailure")
 
 
-# ---------------------------------------------------------------------------
-# _convert_write_result
-# ---------------------------------------------------------------------------
-
-
 class TestConvertWriteResult(unittest.TestCase):
     def test_insert_basic(self):
         cmd = {"documents": [{"_id": 1}, {"_id": 2}]}
         result = _convert_write_result("insert", cmd, {"n": 0})
         self.assertEqual(result["ok"], 1)
-        self.assertEqual(result["n"], 2)  # len(documents) overrides n
+        self.assertEqual(result["n"], 2)
 
     def test_update_basic(self):
         cmd = {"updates": [{"q": {}, "u": {"$set": {"x": 1}}}]}
@@ -190,7 +145,6 @@ class TestConvertWriteResult(unittest.TestCase):
         result = _convert_write_result(
             "update", cmd, {"n": 1, "updatedExisting": False, "upserted": None}
         )
-        # upserted is already in result, so it takes the fast path
         self.assertIn("upserted", result)
 
     def test_update_upsert_no_upserted_id_from_query(self):
@@ -226,80 +180,32 @@ class TestConvertWriteResult(unittest.TestCase):
         self.assertIn("errInfo", result["writeErrors"][0])
 
 
-# ---------------------------------------------------------------------------
-# _compress
-# ---------------------------------------------------------------------------
-
-
 class TestCompress(unittest.TestCase):
-    def test_returns_request_id_and_bytes(self):
-        ctx = _ZLIB_CTX
-        data = b"hello world"
-        request_id, msg = _compress(2013, data, ctx)
-        self.assertIsInstance(request_id, int)
-        self.assertIsInstance(msg, bytes)
-
     def test_compressed_message_has_op_compressed_header(self):
-        ctx = _ZLIB_CTX
-        data = b"hello world"
-        _request_id, msg = _compress(2013, data, ctx)
-        # Header: 4 bytes msglen, 4 bytes requestId, 4 bytes responseTo, 4 bytes opCode
+        _request_id, msg = _compress(2013, b"hello world", _ZLIB_CTX)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)  # OP_COMPRESSED
-
-
-# ---------------------------------------------------------------------------
-# _op_msg_no_header
-# ---------------------------------------------------------------------------
-
-
-class TestOpMsgNoHeader(unittest.TestCase):
-    def test_basic_command_no_docs(self):
-        cmd = {"ping": 1}
-        data, total_size, max_doc_size = _op_msg_no_header(0, cmd, "", None, _OPTS)
-        self.assertIsInstance(data, bytes)
-        self.assertGreater(total_size, 0)
-        self.assertEqual(max_doc_size, 0)
-
-    def test_command_with_docs(self):
-        cmd = {"insert": "col"}
-        docs: list = [{"_id": 1, "x": 2}, {"_id": 3, "x": 4}]
-        data, total_size, max_doc_size = _op_msg_no_header(0, cmd, "documents", docs, _OPTS)
-        self.assertIsInstance(data, bytes)
-        self.assertGreater(max_doc_size, 0)
-
-
-# ---------------------------------------------------------------------------
-# _op_msg_uncompressed / _op_msg_compressed
-# ---------------------------------------------------------------------------
-
-
-class TestOpMsgUncompressed(unittest.TestCase):
-    def test_returns_tuple(self):
-        cmd = {"ping": 1}
-        rid, msg, total_size, max_doc_size = _op_msg_uncompressed(0, cmd, "", None, _OPTS)
-        self.assertIsInstance(rid, int)
-        self.assertIsInstance(msg, bytes)
-
-    def test_msg_has_correct_op_code(self):
-        cmd = {"ping": 1}
-        _rid, msg, _ts, _mds = _op_msg_uncompressed(0, cmd, "", None, _OPTS)
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2013)  # OP_MSG
-
-
-# ---------------------------------------------------------------------------
-# _op_msg
-# ---------------------------------------------------------------------------
 
 
 class TestOpMsg(unittest.TestCase):
     def test_basic_uncompressed(self):
         cmd: dict = {"ping": 1}
-        rid, msg, total_size, max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS)
-        self.assertIsInstance(rid, int)
-        self.assertIsInstance(msg, bytes)
+        _op_msg(0, cmd, "testdb", None, _OPTS)
         self.assertEqual(cmd["$db"], "testdb")
+
+    def test_uncompressed_op_code(self):
+        _, msg, _, _ = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2013)  # OP_MSG
+
+    def test_max_doc_size_zero_without_docs(self):
+        _, _, _, max_doc_size = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)
+        self.assertEqual(max_doc_size, 0)
+
+    def test_max_doc_size_nonzero_with_docs(self):
+        cmd: dict = {"insert": "col", "documents": [{"_id": 1, "x": 2}, {"_id": 3, "x": 4}]}
+        _, _, _, max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS)
+        self.assertGreater(max_doc_size, 0)
 
     def test_read_preference_added_for_non_primary(self):
         cmd: dict = {"find": "col"}
@@ -322,120 +228,64 @@ class TestOpMsg(unittest.TestCase):
         self.assertNotIn("$readPreference", cmd)
 
     def test_with_compression_context(self):
-        ctx = _ZLIB_CTX
-        cmd: dict = {"ping": 1}
-        rid, msg, total_size, max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS, ctx)
-        self.assertIsInstance(rid, int)
-        # Compressed message uses OP_COMPRESSED (2012).
+        _, msg, _, _ = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS, _ZLIB_CTX)
         op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2012)
+        self.assertEqual(op_code, 2012)  # OP_COMPRESSED
 
     def test_command_with_documents_field_is_restored(self):
         docs = [{"_id": 1}]
         cmd: dict = {"insert": "col", "documents": docs}
         _op_msg(0, cmd, "testdb", None, _OPTS)
-        # The documents field should be restored after the call.
         self.assertIn("documents", cmd)
         self.assertEqual(cmd["documents"], docs)
 
 
-# ---------------------------------------------------------------------------
-# _query_impl / _query_uncompressed / _query_compressed / _query
-# ---------------------------------------------------------------------------
-
-
-class TestQueryImpl(unittest.TestCase):
-    def test_basic_query(self):
-        data, max_bson_size = _query_impl(0, "db.col", 0, 0, {"x": 1}, None, _OPTS)
-        self.assertIsInstance(data, bytes)
+class TestQuery(unittest.TestCase):
+    def test_basic(self):
+        _, max_bson_size = _query_impl(0, "db.col", 0, 0, {"x": 1}, None, _OPTS)
         self.assertGreater(max_bson_size, 0)
 
-    def test_with_field_selector(self):
-        data, max_bson_size = _query_impl(0, "db.col", 0, 0, {"x": 1}, {"_id": 0}, _OPTS)
-        self.assertIsInstance(data, bytes)
-
-
-class TestQueryUncompressed(unittest.TestCase):
-    def test_returns_tuple(self):
-        rid, msg, max_bson_size = _query_uncompressed(0, "db.col", 0, 0, {}, None, _OPTS)
-        self.assertIsInstance(rid, int)
-        self.assertIsInstance(msg, bytes)
-
-    def test_op_code(self):
+    def test_uncompressed_op_code(self):
         _rid, msg, _mbs = _query_uncompressed(0, "db.col", 0, 0, {}, None, _OPTS)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2004)  # OP_QUERY
 
-
-class TestQueryCompressed(unittest.TestCase):
-    def test_returns_compressed(self):
-        ctx = _ZLIB_CTX
-        rid, msg, max_bson_size = _query_compressed(0, "db.col", 0, 0, {}, None, _OPTS, ctx)
-        self.assertIsInstance(rid, int)
+    def test_compressed_op_code(self):
+        _rid, msg, _mbs = _query_compressed(0, "db.col", 0, 0, {}, None, _OPTS, _ZLIB_CTX)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)  # OP_COMPRESSED
 
-
-class TestQuery(unittest.TestCase):
     def test_uncompressed_path(self):
-        rid, msg, max_bson_size = _query(0, "db.col", 0, 0, {}, None, _OPTS)
+        _rid, msg, _mbs = _query(0, "db.col", 0, 0, {}, None, _OPTS)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2004)
 
     def test_compressed_path(self):
-        ctx = _ZLIB_CTX
-        rid, msg, max_bson_size = _query(0, "db.col", 0, 0, {}, None, _OPTS, ctx)
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2012)
-
-
-# ---------------------------------------------------------------------------
-# _get_more_impl / _get_more_uncompressed / _get_more_compressed / _get_more
-# ---------------------------------------------------------------------------
-
-
-class TestGetMoreImpl(unittest.TestCase):
-    def test_returns_bytes(self):
-        data = _get_more_impl("db.col", 10, 12345)
-        self.assertIsInstance(data, bytes)
-
-
-class TestGetMoreUncompressed(unittest.TestCase):
-    def test_returns_tuple(self):
-        rid, msg = _get_more_uncompressed("db.col", 10, 12345)
-        self.assertIsInstance(rid, int)
-        self.assertIsInstance(msg, bytes)
-
-    def test_op_code(self):
-        _rid, msg = _get_more_uncompressed("db.col", 0, 0)
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2005)  # OP_GET_MORE
-
-
-class TestGetMoreCompressed(unittest.TestCase):
-    def test_returns_compressed(self):
-        ctx = _ZLIB_CTX
-        rid, msg = _get_more_compressed("db.col", 0, 0, ctx)
+        _rid, msg, _mbs = _query(0, "db.col", 0, 0, {}, None, _OPTS, _ZLIB_CTX)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)
 
 
 class TestGetMore(unittest.TestCase):
+    def test_uncompressed_op_code(self):
+        _rid, msg = _get_more_uncompressed("db.col", 0, 0)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2005)  # OP_GET_MORE
+
+    def test_compressed_op_code(self):
+        _rid, msg = _get_more_compressed("db.col", 0, 0, _ZLIB_CTX)
+        op_code = struct.unpack("<i", msg[12:16])[0]
+        self.assertEqual(op_code, 2012)  # OP_COMPRESSED
+
     def test_uncompressed_path(self):
-        rid, msg = _get_more("db.col", 0, 0)
+        _rid, msg = _get_more("db.col", 0, 0)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2005)
 
     def test_compressed_path(self):
-        ctx = _ZLIB_CTX
-        rid, msg = _get_more("db.col", 0, 0, ctx)
+        _rid, msg = _get_more("db.col", 0, 0, _ZLIB_CTX)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)
-
-
-# ---------------------------------------------------------------------------
-# _raise_document_too_large
-# ---------------------------------------------------------------------------
 
 
 class TestRaiseDocumentTooLarge(unittest.TestCase):
@@ -457,119 +307,101 @@ class TestRaiseDocumentTooLarge(unittest.TestCase):
         self.assertIn("delete", str(ctx.exception))
 
 
-# ---------------------------------------------------------------------------
-# _gen_find_command
-# ---------------------------------------------------------------------------
-
-
 class TestGenFindCommand(unittest.TestCase):
-    def _read_concern(self, level=None):
-        from pymongo.read_concern import ReadConcern
-
-        return ReadConcern(level=level)
-
     def test_basic(self):
-        cmd = _gen_find_command("col", {}, None, 0, 0, None, None, self._read_concern())
+        cmd = _gen_find_command("col", {}, None, 0, 0, None, None, ReadConcern())
         self.assertEqual(cmd["find"], "col")
         self.assertEqual(cmd["filter"], {})
 
     def test_with_projection(self):
-        cmd = _gen_find_command("col", {}, {"x": 1}, 0, 0, None, None, self._read_concern())
+        cmd = _gen_find_command("col", {}, {"x": 1}, 0, 0, None, None, ReadConcern())
         self.assertIn("projection", cmd)
 
     def test_with_skip(self):
-        cmd = _gen_find_command("col", {}, None, 5, 0, None, None, self._read_concern())
+        cmd = _gen_find_command("col", {}, None, 5, 0, None, None, ReadConcern())
         self.assertEqual(cmd["skip"], 5)
 
     def test_with_positive_limit(self):
-        cmd = _gen_find_command("col", {}, None, 0, 10, None, None, self._read_concern())
+        cmd = _gen_find_command("col", {}, None, 0, 10, None, None, ReadConcern())
         self.assertEqual(cmd["limit"], 10)
         self.assertNotIn("singleBatch", cmd)
 
     def test_with_negative_limit_sets_single_batch(self):
-        cmd = _gen_find_command("col", {}, None, 0, -5, None, None, self._read_concern())
+        cmd = _gen_find_command("col", {}, None, 0, -5, None, None, ReadConcern())
         self.assertEqual(cmd["limit"], 5)
         self.assertTrue(cmd["singleBatch"])
 
     def test_batch_size_adjusted_when_equal_to_limit(self):
-        cmd = _gen_find_command("col", {}, None, 0, 10, 10, None, self._read_concern())
+        cmd = _gen_find_command("col", {}, None, 0, 10, 10, None, ReadConcern())
         self.assertEqual(cmd["batchSize"], 11)
 
     def test_batch_size_not_adjusted_when_different(self):
-        cmd = _gen_find_command("col", {}, None, 0, 10, 5, None, self._read_concern())
+        cmd = _gen_find_command("col", {}, None, 0, 10, 5, None, ReadConcern())
         self.assertEqual(cmd["batchSize"], 5)
 
     def test_read_concern_level_included(self):
-        cmd = _gen_find_command("col", {}, None, 0, 0, None, None, self._read_concern("majority"))
+        cmd = _gen_find_command("col", {}, None, 0, 0, None, None, ReadConcern("majority"))
         self.assertIn("readConcern", cmd)
 
     def test_query_with_dollar_query_modifier(self):
         spec = {"$query": {"x": 1}, "$orderby": {"x": 1}}
-        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, self._read_concern())
+        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
         self.assertIn("sort", cmd)
         self.assertNotIn("$orderby", cmd)
         self.assertNotIn("$query", cmd)
 
     def test_allow_disk_use(self):
         cmd = _gen_find_command(
-            "col", {}, None, 0, 0, None, None, self._read_concern(), allow_disk_use=True
+            "col", {}, None, 0, 0, None, None, ReadConcern(), allow_disk_use=True
         )
         self.assertTrue(cmd["allowDiskUse"])
 
     def test_collation(self):
         cmd = _gen_find_command(
-            "col", {}, None, 0, 0, None, None, self._read_concern(), collation={"locale": "en"}
+            "col", {}, None, 0, 0, None, None, ReadConcern(), collation={"locale": "en"}
         )
         self.assertEqual(cmd["collation"]["locale"], "en")
 
     def test_options_tailable(self):
-        cmd = _gen_find_command("col", {}, None, 0, 0, None, 2, self._read_concern())
+        cmd = _gen_find_command("col", {}, None, 0, 0, None, 2, ReadConcern())
         self.assertTrue(cmd.get("tailable"))
 
     def test_dollar_query_with_explain_removed(self):
         spec = {"$query": {"x": 1}, "$explain": 1}
-        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, self._read_concern())
-        # $explain should be stripped from the find command.
+        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
         self.assertNotIn("$explain", cmd)
 
     def test_dollar_query_with_read_preference_removed(self):
         spec = {"$query": {"x": 1}, "$readPreference": {"mode": "secondary"}}
-        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, self._read_concern())
+        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
         self.assertNotIn("$readPreference", cmd)
 
 
-# ---------------------------------------------------------------------------
-# _gen_get_more_command
-# ---------------------------------------------------------------------------
-
-
 class TestGenGetMoreCommand(unittest.TestCase):
+    def _make_conn(self, max_wire_version=9):
+        conn = MagicMock()
+        conn.max_wire_version = max_wire_version
+        return conn
+
     def test_basic(self):
-        conn = _MockConn()
-        cmd = _gen_get_more_command(12345, "col", None, None, None, conn)  # type: ignore[arg-type]
+        cmd = _gen_get_more_command(12345, "col", None, None, None, self._make_conn())
         self.assertEqual(cmd["getMore"], 12345)
         self.assertEqual(cmd["collection"], "col")
 
     def test_with_batch_size(self):
-        conn = _MockConn()
-        cmd = _gen_get_more_command(1, "col", 100, None, None, conn)  # type: ignore[arg-type]
+        cmd = _gen_get_more_command(1, "col", 100, None, None, self._make_conn())
         self.assertEqual(cmd["batchSize"], 100)
 
     def test_with_max_await_time_ms(self):
-        conn = _MockConn()
-        cmd = _gen_get_more_command(1, "col", None, 500, None, conn)  # type: ignore[arg-type]
+        cmd = _gen_get_more_command(1, "col", None, 500, None, self._make_conn())
         self.assertEqual(cmd["maxTimeMS"], 500)
 
     def test_comment_added_on_high_wire_version(self):
-        conn = _MockConn()
-        conn.max_wire_version = 9
-        cmd = _gen_get_more_command(1, "col", None, None, "my comment", conn)  # type: ignore[arg-type]
+        cmd = _gen_get_more_command(1, "col", None, None, "my comment", self._make_conn(9))
         self.assertEqual(cmd["comment"], "my comment")
 
     def test_comment_not_added_on_low_wire_version(self):
-        conn = _MockConn()
-        conn.max_wire_version = 8
-        cmd = _gen_get_more_command(1, "col", None, None, "my comment", conn)  # type: ignore[arg-type]
+        cmd = _gen_get_more_command(1, "col", None, None, "my comment", self._make_conn(8))
         self.assertNotIn("comment", cmd)
 
 

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -24,7 +24,7 @@ sys.path[0:0] = [""]
 
 from test import unittest
 
-from bson import CodecOptions
+from bson import CodecOptions, encode
 from pymongo.compression_support import ZlibContext
 from pymongo.errors import DocumentTooLarge, OperationFailure
 from pymongo.message import (
@@ -39,7 +39,6 @@ from pymongo.message import (
     _maybe_add_read_preference,
     _op_msg,
     _query_compressed,
-    _query_impl,
     _query_uncompressed,
     _raise_document_too_large,
 )
@@ -98,6 +97,11 @@ class TestConvertException(unittest.TestCase):
 
 
 class TestConvertWriteResult(unittest.TestCase):
+    """Tests for _convert_write_result.
+
+    In the update command spec, `q` is the query/filter and `u` is the update document.
+    """
+
     def test_insert_basic(self):
         cmd = {"documents": [{"_id": 1}, {"_id": 2}]}
         result = _convert_write_result("insert", cmd, {"n": 0})
@@ -116,12 +120,12 @@ class TestConvertWriteResult(unittest.TestCase):
         self.assertIn("upserted", result)
         self.assertEqual(result["upserted"][0]["_id"], 42)
 
-    def test_update_implicit_upsert_from_updatedExisting_false(self):
-        cmd = {"updates": [{"q": {"_id": 99}, "u": {"$set": {"x": 1}}}]}
-        result = _convert_write_result(
-            "update", cmd, {"n": 1, "updatedExisting": False, "upserted": None}
-        )
-        self.assertIn("upserted", result)
+    def test_update_upsert_id_precedence(self):
+        # When _id is in both the update document and the query spec,
+        # the update document's _id wins.
+        cmd = {"updates": [{"q": {"_id": 99}, "u": {"_id": 42}}]}
+        result = _convert_write_result("update", cmd, {"n": 1, "updatedExisting": False})
+        self.assertEqual(result["upserted"][0]["_id"], 42)
 
     def test_update_upsert_no_upserted_id_from_query(self):
         cmd = {"updates": [{"q": {"_id": 77}, "u": {"$set": {"x": 1}}}]}
@@ -159,25 +163,26 @@ class TestConvertWriteResult(unittest.TestCase):
 
 class TestCompress(unittest.TestCase):
     def test_compressed_message_has_op_compressed_header(self):
-        _request_id, msg = _compress(2013, b"hello world", _ZLIB_CTX)
+        msg = _compress(2013, b"hello world", _ZLIB_CTX)[1]
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)  # OP_COMPRESSED
 
 
 class TestOpMsg(unittest.TestCase):
     def test_uncompressed_op_code(self):
-        _, msg, _, _ = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)
+        msg = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)[1]
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2013)  # OP_MSG
 
     def test_max_doc_size_zero_without_docs(self):
-        _, _, _, max_doc_size = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)
+        max_doc_size = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)[3]
         self.assertEqual(max_doc_size, 0)
 
-    def test_max_doc_size_nonzero_with_docs(self):
-        cmd: dict = {"insert": "col", "documents": [{"_id": 1, "x": 2}, {"_id": 3, "x": 4}]}
-        _, _, _, max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS)
-        self.assertGreater(max_doc_size, 0)
+    def test_max_doc_size_matches_largest_encoded_doc(self):
+        docs = [{"_id": 1, "x": 2}, {"_id": 3, "x": 4}]
+        cmd: dict = {"insert": "col", "documents": docs}
+        max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS)[3]
+        self.assertEqual(max_doc_size, max(len(encode(d)) for d in docs))
 
     def test_read_preference_added_for_non_primary(self):
         cmd: dict = {"find": "col"}
@@ -190,7 +195,7 @@ class TestOpMsg(unittest.TestCase):
         self.assertEqual(cmd["$readPreference"]["mode"], "nearest")
 
     def test_with_compression_context(self):
-        _, msg, _, _ = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS, _ZLIB_CTX)
+        msg = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS, _ZLIB_CTX)[1]
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)  # OP_COMPRESSED
 
@@ -202,30 +207,26 @@ class TestOpMsg(unittest.TestCase):
         self.assertEqual(cmd["documents"], docs)
 
 
-class TestQuery(unittest.TestCase):
-    def test_basic(self):
-        _, max_bson_size = _query_impl(0, "db.col", 0, 0, {"x": 1}, None, _OPTS)
-        self.assertGreater(max_bson_size, 0)
+class TestLegacyWireOps(unittest.TestCase):
+    """Tests for pre-OP_MSG wire ops (OP_QUERY and OP_GET_MORE), compressed and uncompressed."""
 
-    def test_uncompressed_op_code(self):
-        _rid, msg, _mbs = _query_uncompressed(0, "db.col", 0, 0, {}, None, _OPTS)
+    def test_query_uncompressed_op_code(self):
+        msg = _query_uncompressed(0, "db.col", 0, 0, {}, None, _OPTS)[1]
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2004)  # OP_QUERY
 
-    def test_compressed_op_code(self):
-        _rid, msg, _mbs = _query_compressed(0, "db.col", 0, 0, {}, None, _OPTS, _ZLIB_CTX)
+    def test_query_compressed_op_code(self):
+        msg = _query_compressed(0, "db.col", 0, 0, {}, None, _OPTS, _ZLIB_CTX)[1]
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)  # OP_COMPRESSED
 
-
-class TestGetMore(unittest.TestCase):
-    def test_uncompressed_op_code(self):
-        _rid, msg = _get_more_uncompressed("db.col", 0, 0)
+    def test_get_more_uncompressed_op_code(self):
+        msg = _get_more_uncompressed("db.col", 0, 0)[1]
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2005)  # OP_GET_MORE
 
-    def test_compressed_op_code(self):
-        _rid, msg = _get_more_compressed("db.col", 0, 0, _ZLIB_CTX)
+    def test_get_more_compressed_op_code(self):
+        msg = _get_more_compressed("db.col", 0, 0, _ZLIB_CTX)[1]
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)  # OP_COMPRESSED
 
@@ -252,7 +253,7 @@ class TestGenFindCommand(unittest.TestCase):
 
     def test_with_projection(self):
         cmd = _gen_find_command("col", {}, {"x": 1}, 0, 0, None, None, ReadConcern())
-        self.assertIn("projection", cmd)
+        self.assertEqual(cmd["projection"], {"x": 1})
 
     def test_with_skip(self):
         cmd = _gen_find_command("col", {}, None, 5, 0, None, None, ReadConcern())
@@ -279,7 +280,7 @@ class TestGenFindCommand(unittest.TestCase):
 
     def test_read_concern_level_included(self):
         cmd = _gen_find_command("col", {}, None, 0, 0, None, None, ReadConcern("majority"))
-        self.assertIn("readConcern", cmd)
+        self.assertEqual(cmd["readConcern"], {"level": "majority"})
 
     def test_query_with_dollar_query_modifier(self):
         spec = {"$query": {"x": 1}, "$orderby": {"x": 1}}

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -28,39 +28,26 @@ from bson import CodecOptions
 from pymongo.compression_support import ZlibContext
 from pymongo.errors import DocumentTooLarge, OperationFailure
 from pymongo.message import (
-    MAX_INT32,
-    MIN_INT32,
     _compress,
     _convert_client_bulk_exception,
     _convert_exception,
     _convert_write_result,
     _gen_find_command,
     _gen_get_more_command,
-    _get_more,
     _get_more_compressed,
     _get_more_uncompressed,
     _maybe_add_read_preference,
     _op_msg,
-    _query,
     _query_compressed,
     _query_impl,
     _query_uncompressed,
     _raise_document_too_large,
-    _randint,
 )
 from pymongo.read_concern import ReadConcern
-from pymongo.read_preferences import ReadPreference, Secondary, SecondaryPreferred
+from pymongo.read_preferences import ReadPreference, SecondaryPreferred
 
 _OPTS = CodecOptions()
 _ZLIB_CTX = ZlibContext(-1)
-
-
-class TestRandint(unittest.TestCase):
-    def test_in_range(self):
-        for _ in range(50):
-            r = _randint()
-            self.assertGreaterEqual(r, MIN_INT32)
-            self.assertLessEqual(r, MAX_INT32)
 
 
 class TestMaybeAddReadPreference(unittest.TestCase):
@@ -76,12 +63,6 @@ class TestMaybeAddReadPreference(unittest.TestCase):
         self.assertIn("$readPreference", result)
         self.assertEqual(result["$readPreference"]["mode"], "secondary")
         self.assertIn("$query", result)
-
-    def test_nearest_adds_read_preference(self):
-        spec: dict = {"find": "col"}
-        result = _maybe_add_read_preference(spec, ReadPreference.NEAREST)
-        self.assertIn("$readPreference", result)
-        self.assertEqual(result["$readPreference"]["mode"], "nearest")
 
     def test_secondary_preferred_no_tags_does_not_add(self):
         spec: dict = {"find": "col"}
@@ -107,11 +88,6 @@ class TestConvertException(unittest.TestCase):
         doc = _convert_exception(exc)
         self.assertEqual(doc["errmsg"], "bad value")
         self.assertEqual(doc["errtype"], "ValueError")
-
-    def test_runtime_error(self):
-        exc = RuntimeError("oops")
-        doc = _convert_exception(exc)
-        self.assertEqual(doc["errtype"], "RuntimeError")
 
     def test_client_bulk_exception_includes_code(self):
         exc = OperationFailure("failed", code=11000)
@@ -174,6 +150,7 @@ class TestConvertWriteResult(unittest.TestCase):
         self.assertEqual(result["writeConcernError"]["code"], 64)
 
     def test_write_error_with_err_info(self):
+        # Covers the `if "errInfo" in result:` branch, which test_write_error does not enter.
         cmd = {"documents": [{"_id": 1}]}
         gle = {"n": 0, "err": "err", "code": 123, "errInfo": {"detail": "x"}}
         result = _convert_write_result("insert", cmd, gle)
@@ -188,11 +165,6 @@ class TestCompress(unittest.TestCase):
 
 
 class TestOpMsg(unittest.TestCase):
-    def test_basic_uncompressed(self):
-        cmd: dict = {"ping": 1}
-        _op_msg(0, cmd, "testdb", None, _OPTS)
-        self.assertEqual(cmd["$db"], "testdb")
-
     def test_uncompressed_op_code(self):
         _, msg, _, _ = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)
         op_code = struct.unpack("<i", msg[12:16])[0]
@@ -212,20 +184,10 @@ class TestOpMsg(unittest.TestCase):
         _op_msg(0, cmd, "testdb", ReadPreference.SECONDARY, _OPTS)
         self.assertIn("$readPreference", cmd)
 
-    def test_read_preference_not_added_for_primary(self):
-        cmd: dict = {"find": "col"}
-        _op_msg(0, cmd, "testdb", ReadPreference.PRIMARY, _OPTS)
-        self.assertNotIn("$readPreference", cmd)
-
     def test_read_preference_skipped_if_already_present(self):
         cmd: dict = {"find": "col", "$readPreference": {"mode": "nearest"}}
         _op_msg(0, cmd, "testdb", ReadPreference.SECONDARY, _OPTS)
         self.assertEqual(cmd["$readPreference"]["mode"], "nearest")
-
-    def test_none_read_preference_skipped(self):
-        cmd: dict = {"find": "col"}
-        _op_msg(0, cmd, "testdb", None, _OPTS)
-        self.assertNotIn("$readPreference", cmd)
 
     def test_with_compression_context(self):
         _, msg, _, _ = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS, _ZLIB_CTX)
@@ -255,16 +217,6 @@ class TestQuery(unittest.TestCase):
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)  # OP_COMPRESSED
 
-    def test_uncompressed_path(self):
-        _rid, msg, _mbs = _query(0, "db.col", 0, 0, {}, None, _OPTS)
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2004)
-
-    def test_compressed_path(self):
-        _rid, msg, _mbs = _query(0, "db.col", 0, 0, {}, None, _OPTS, _ZLIB_CTX)
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2012)
-
 
 class TestGetMore(unittest.TestCase):
     def test_uncompressed_op_code(self):
@@ -276,16 +228,6 @@ class TestGetMore(unittest.TestCase):
         _rid, msg = _get_more_compressed("db.col", 0, 0, _ZLIB_CTX)
         op_code = struct.unpack("<i", msg[12:16])[0]
         self.assertEqual(op_code, 2012)  # OP_COMPRESSED
-
-    def test_uncompressed_path(self):
-        _rid, msg = _get_more("db.col", 0, 0)
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2005)
-
-    def test_compressed_path(self):
-        _rid, msg = _get_more("db.col", 0, 0, _ZLIB_CTX)
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2012)
 
 
 class TestRaiseDocumentTooLarge(unittest.TestCase):
@@ -300,11 +242,6 @@ class TestRaiseDocumentTooLarge(unittest.TestCase):
         with self.assertRaises(DocumentTooLarge) as ctx:
             _raise_document_too_large("update", 2_000_000, 1_000_000)
         self.assertIn("update", str(ctx.exception))
-
-    def test_delete_generic_message(self):
-        with self.assertRaises(DocumentTooLarge) as ctx:
-            _raise_document_too_large("delete", 2_000_000, 1_000_000)
-        self.assertIn("delete", str(ctx.exception))
 
 
 class TestGenFindCommand(unittest.TestCase):
@@ -336,6 +273,7 @@ class TestGenFindCommand(unittest.TestCase):
         self.assertEqual(cmd["batchSize"], 11)
 
     def test_batch_size_not_adjusted_when_different(self):
+        # Covers the False branch of `if limit == batch_size:` — distinct from the True branch above.
         cmd = _gen_find_command("col", {}, None, 0, 10, 5, None, ReadConcern())
         self.assertEqual(cmd["batchSize"], 5)
 
@@ -372,6 +310,7 @@ class TestGenFindCommand(unittest.TestCase):
         self.assertNotIn("$explain", cmd)
 
     def test_dollar_query_with_read_preference_removed(self):
+        # Covers the separate `if "$readPreference" in cmd:` branch — not entered by test_dollar_query_with_explain_removed.
         spec = {"$query": {"x": 1}, "$readPreference": {"mode": "secondary"}}
         cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
         self.assertNotIn("$readPreference", cmd)

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import struct
 import sys
 from unittest.mock import MagicMock
 
@@ -24,6 +25,7 @@ sys.path[0:0] = [""]
 from test import unittest
 
 from bson import CodecOptions, encode
+from pymongo.compression_support import ZlibContext
 from pymongo.errors import DocumentTooLarge, OperationFailure
 from pymongo.message import (
     _convert_client_bulk_exception,
@@ -116,6 +118,21 @@ class TestMessage(unittest.TestCase):
         self.assertIn("upserted", result)
         self.assertEqual(result["upserted"][0]["_id"], 42)
 
+    def test_update_legacy_upsert_id_from_update_doc(self):
+        # Pre-2.6 servers omit "upserted"; _id is extracted from the update doc (takes
+        # precedence over the query doc when both contain _id).
+        cmd = {"updates": [{"q": {"_id": 10}, "u": {"_id": 42}}]}
+        result = _convert_write_result("update", cmd, {"n": 1, "updatedExisting": False})
+        self.assertIn("upserted", result)
+        self.assertEqual(result["upserted"][0]["_id"], 42)
+
+    def test_update_legacy_upsert_id_from_query_doc(self):
+        # When _id is absent from the update doc, fall back to the query doc's _id.
+        cmd = {"updates": [{"q": {"_id": 10}, "u": {"$set": {"x": 1}}}]}
+        result = _convert_write_result("update", cmd, {"n": 1, "updatedExisting": False})
+        self.assertIn("upserted", result)
+        self.assertEqual(result["upserted"][0]["_id"], 10)
+
     def test_delete_basic(self):
         cmd = {"deletes": [{"q": {}, "limit": 1}]}
         result = _convert_write_result("delete", cmd, {"n": 1})
@@ -171,6 +188,18 @@ class TestMessage(unittest.TestCase):
         _op_msg(0, cmd, "testdb", None, _OPTS)
         self.assertIn("documents", cmd)
         self.assertEqual(cmd["documents"], docs)
+
+    def test_op_msg_compressed_zlib_header(self):
+        # Verify the compressed path is taken and produces a valid OP_COMPRESSED frame.
+        # Header layout (little-endian): [msgLen(4), reqId(4), responseTo(4), opCode(4),
+        #   originalOpcode(4), uncompressedSize(4), compressorId(1)]
+        ctx = ZlibContext(6)
+        _, msg, _, _ = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS, ctx=ctx)
+        (opcode,) = struct.unpack_from("<i", msg, 12)
+        self.assertEqual(opcode, 2012)  # OP_COMPRESSED
+        (original_opcode,) = struct.unpack_from("<i", msg, 16)
+        self.assertEqual(original_opcode, 2013)  # OP_MSG
+        self.assertEqual(msg[24], ZlibContext.compressor_id)  # compressor_id == 2
 
     # _raise_document_too_large
 

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -25,7 +25,7 @@ sys.path[0:0] = [""]
 from test import unittest
 
 from bson import CodecOptions, encode
-from pymongo.compression_support import ZlibContext
+from pymongo.compression_support import ZlibContext, _have_zlib
 from pymongo.errors import DocumentTooLarge, OperationFailure
 from pymongo.message import (
     _convert_client_bulk_exception,
@@ -189,6 +189,7 @@ class TestMessage(unittest.TestCase):
         self.assertIn("documents", cmd)
         self.assertEqual(cmd["documents"], docs)
 
+    @unittest.skipUnless(_have_zlib(), "zlib not available")
     def test_op_msg_compressed_zlib_header(self):
         # Verify the compressed path is taken and produces a valid OP_COMPRESSED frame.
         # Header layout (little-endian): [msgLen(4), reqId(4), responseTo(4), opCode(4),

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -41,7 +41,15 @@ from pymongo.read_preferences import ReadPreference, SecondaryPreferred
 _OPTS = CodecOptions()
 
 
-class TestMaybeAddReadPreference(unittest.TestCase):
+class TestMessage(unittest.TestCase):
+    # _gen_get_more_command helper
+    def _make_conn(self, max_wire_version=9):
+        conn = MagicMock()
+        conn.max_wire_version = max_wire_version
+        return conn
+
+    # _maybe_add_read_preference
+
     def test_primary_no_read_preference_added(self):
         spec: dict = {"find": "col"}
         result = _maybe_add_read_preference(spec, ReadPreference.PRIMARY)
@@ -72,8 +80,8 @@ class TestMaybeAddReadPreference(unittest.TestCase):
         self.assertIn("$readPreference", result)
         self.assertEqual(result["$query"], {"x": 1})
 
+    # _convert_exception / _convert_client_bulk_exception
 
-class TestConvertException(unittest.TestCase):
     def test_basic_exception(self):
         exc = ValueError("bad value")
         doc = _convert_exception(exc)
@@ -87,12 +95,8 @@ class TestConvertException(unittest.TestCase):
         self.assertEqual(doc["code"], 11000)
         self.assertEqual(doc["errtype"], "OperationFailure")
 
-
-class TestConvertWriteResult(unittest.TestCase):
-    """Tests for _convert_write_result.
-
-    In the update command spec, `q` is the query/filter and `u` is the update document.
-    """
+    # _convert_write_result
+    # In the update command spec, `q` is the query/filter and `u` is the update document.
 
     def test_insert_basic(self):
         cmd = {"documents": [{"_id": 1}, {"_id": 2}]}
@@ -139,146 +143,141 @@ class TestConvertWriteResult(unittest.TestCase):
         result = _convert_write_result("insert", cmd, gle)
         self.assertIn("errInfo", result["writeErrors"][0])
 
+    # _op_msg
 
-class TestOpMsg(unittest.TestCase):
-    def test_max_doc_size_zero_without_docs(self):
+    def test_op_msg_max_doc_size_zero_without_docs(self):
         max_doc_size = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)[3]
         self.assertEqual(max_doc_size, 0)
 
-    def test_max_doc_size_matches_largest_encoded_doc(self):
+    def test_op_msg_max_doc_size_matches_largest_encoded_doc(self):
         docs = [{"_id": 1, "x": 2}, {"_id": 3, "x": 4}]
         cmd: dict = {"insert": "col", "documents": docs}
         max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS)[3]
         self.assertEqual(max_doc_size, max(len(encode(d)) for d in docs))
 
-    def test_read_preference_added_for_non_primary(self):
+    def test_op_msg_read_preference_added_for_non_primary(self):
         cmd: dict = {"find": "col"}
         _op_msg(0, cmd, "testdb", ReadPreference.SECONDARY, _OPTS)
         self.assertIn("$readPreference", cmd)
 
-    def test_read_preference_skipped_if_already_present(self):
+    def test_op_msg_read_preference_skipped_if_already_present(self):
         cmd: dict = {"find": "col", "$readPreference": {"mode": "nearest"}}
         _op_msg(0, cmd, "testdb", ReadPreference.SECONDARY, _OPTS)
         self.assertEqual(cmd["$readPreference"]["mode"], "nearest")
 
-    def test_command_with_documents_field_is_restored(self):
+    def test_op_msg_documents_field_is_restored(self):
         docs = [{"_id": 1}]
         cmd: dict = {"insert": "col", "documents": docs}
         _op_msg(0, cmd, "testdb", None, _OPTS)
         self.assertIn("documents", cmd)
         self.assertEqual(cmd["documents"], docs)
 
+    # _raise_document_too_large
 
-class TestRaiseDocumentTooLarge(unittest.TestCase):
-    def test_insert_includes_sizes(self):
+    def test_raise_document_too_large_insert_includes_sizes(self):
         with self.assertRaises(DocumentTooLarge) as ctx:
             _raise_document_too_large("insert", 2_000_000, 1_000_000)
         msg = str(ctx.exception)
         self.assertIn("2000000", msg)
         self.assertIn("1000000", msg)
 
-    def test_update_generic_message(self):
+    def test_raise_document_too_large_update_generic_message(self):
         with self.assertRaises(DocumentTooLarge) as ctx:
             _raise_document_too_large("update", 2_000_000, 1_000_000)
         self.assertIn("update", str(ctx.exception))
 
+    # _gen_find_command
 
-class TestGenFindCommand(unittest.TestCase):
-    def test_basic(self):
+    def test_find_basic(self):
         cmd = _gen_find_command("col", {}, None, 0, 0, None, None, ReadConcern())
         self.assertEqual(cmd["find"], "col")
         self.assertEqual(cmd["filter"], {})
 
-    def test_with_projection(self):
+    def test_find_with_projection(self):
         cmd = _gen_find_command("col", {}, {"x": 1}, 0, 0, None, None, ReadConcern())
         self.assertEqual(cmd["projection"], {"x": 1})
 
-    def test_with_skip(self):
+    def test_find_with_skip(self):
         cmd = _gen_find_command("col", {}, None, 5, 0, None, None, ReadConcern())
         self.assertEqual(cmd["skip"], 5)
 
-    def test_with_positive_limit(self):
+    def test_find_with_positive_limit(self):
         cmd = _gen_find_command("col", {}, None, 0, 10, None, None, ReadConcern())
         self.assertEqual(cmd["limit"], 10)
         self.assertNotIn("singleBatch", cmd)
 
-    def test_with_negative_limit_sets_single_batch(self):
+    def test_find_with_negative_limit_sets_single_batch(self):
         cmd = _gen_find_command("col", {}, None, 0, -5, None, None, ReadConcern())
         self.assertEqual(cmd["limit"], 5)
         self.assertTrue(cmd["singleBatch"])
 
-    def test_batch_size_adjusted_when_equal_to_limit(self):
+    def test_find_batch_size_adjusted_when_equal_to_limit(self):
         cmd = _gen_find_command("col", {}, None, 0, 10, 10, None, ReadConcern())
         self.assertEqual(cmd["batchSize"], 11)
 
-    def test_batch_size_not_adjusted_when_different(self):
+    def test_find_batch_size_not_adjusted_when_different(self):
         # Covers the False branch of `if limit == batch_size:` — distinct from the True branch above.
         cmd = _gen_find_command("col", {}, None, 0, 10, 5, None, ReadConcern())
         self.assertEqual(cmd["batchSize"], 5)
 
-    def test_read_concern_level_included(self):
+    def test_find_read_concern_level_included(self):
         cmd = _gen_find_command("col", {}, None, 0, 0, None, None, ReadConcern("majority"))
         self.assertEqual(cmd["readConcern"], {"level": "majority"})
 
-    def test_query_with_dollar_query_modifier(self):
+    def test_find_query_with_dollar_query_modifier(self):
         spec = {"$query": {"x": 1}, "$orderby": {"x": 1}}
         cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
         self.assertIn("sort", cmd)
         self.assertNotIn("$orderby", cmd)
         self.assertNotIn("$query", cmd)
 
-    def test_allow_disk_use(self):
+    def test_find_allow_disk_use(self):
         cmd = _gen_find_command(
             "col", {}, None, 0, 0, None, None, ReadConcern(), allow_disk_use=True
         )
         self.assertTrue(cmd["allowDiskUse"])
 
-    def test_collation(self):
+    def test_find_collation(self):
         cmd = _gen_find_command(
             "col", {}, None, 0, 0, None, None, ReadConcern(), collation={"locale": "en"}
         )
         self.assertEqual(cmd["collation"]["locale"], "en")
 
-    def test_options_tailable(self):
+    def test_find_options_tailable(self):
         cmd = _gen_find_command("col", {}, None, 0, 0, None, 2, ReadConcern())
         self.assertTrue(cmd.get("tailable"))
 
-    def test_dollar_query_with_explain_removed(self):
+    def test_find_dollar_query_with_explain_removed(self):
         spec = {"$query": {"x": 1}, "$explain": 1}
         cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
         self.assertNotIn("$explain", cmd)
 
-    def test_dollar_query_with_read_preference_removed(self):
+    def test_find_dollar_query_with_read_preference_removed(self):
         # Covers the separate `if "$readPreference" in cmd:` branch — not entered by test_dollar_query_with_explain_removed.
         spec = {"$query": {"x": 1}, "$readPreference": {"mode": "secondary"}}
         cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
         self.assertNotIn("$readPreference", cmd)
 
+    # _gen_get_more_command
 
-class TestGenGetMoreCommand(unittest.TestCase):
-    def _make_conn(self, max_wire_version=9):
-        conn = MagicMock()
-        conn.max_wire_version = max_wire_version
-        return conn
-
-    def test_basic(self):
+    def test_get_more_basic(self):
         cmd = _gen_get_more_command(12345, "col", None, None, None, self._make_conn())
         self.assertEqual(cmd["getMore"], 12345)
         self.assertEqual(cmd["collection"], "col")
 
-    def test_with_batch_size(self):
+    def test_get_more_with_batch_size(self):
         cmd = _gen_get_more_command(1, "col", 100, None, None, self._make_conn())
         self.assertEqual(cmd["batchSize"], 100)
 
-    def test_with_max_await_time_ms(self):
+    def test_get_more_with_max_await_time_ms(self):
         cmd = _gen_get_more_command(1, "col", None, 500, None, self._make_conn())
         self.assertEqual(cmd["maxTimeMS"], 500)
 
-    def test_comment_added_on_high_wire_version(self):
+    def test_get_more_comment_added_on_high_wire_version(self):
         cmd = _gen_get_more_command(1, "col", None, None, "my comment", self._make_conn(9))
         self.assertEqual(cmd["comment"], "my comment")
 
-    def test_comment_not_added_on_low_wire_version(self):
+    def test_get_more_comment_not_added_on_low_wire_version(self):
         cmd = _gen_get_more_command(1, "col", None, None, "my comment", self._make_conn(8))
         self.assertNotIn("comment", cmd)
 

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import struct
 import sys
+from typing import Any
 from unittest.mock import MagicMock
 
 sys.path[0:0] = [""]
@@ -154,7 +155,7 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(max_doc_size, 0)
 
     def test_op_msg_max_doc_size_matches_largest_encoded_doc(self):
-        docs = [{"_id": 1}, {"_id": 2, "data": "a" * 100}]
+        docs: list[dict[str, Any]] = [{"_id": 1}, {"_id": 2, "data": "a" * 100}]
         cmd: dict = {"insert": "col", "documents": docs}
         max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS)[3]
         self.assertEqual(max_doc_size, max(len(encode(d)) for d in docs))

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -154,7 +154,7 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(max_doc_size, 0)
 
     def test_op_msg_max_doc_size_matches_largest_encoded_doc(self):
-        docs = [{"_id": 1, "x": 2}, {"_id": 3, "x": 4}]
+        docs = [{"_id": 1}, {"_id": 2, "data": "a" * 100}]
         cmd: dict = {"insert": "col", "documents": docs}
         max_doc_size = _op_msg(0, cmd, "testdb", None, _OPTS)[3]
         self.assertEqual(max_doc_size, max(len(encode(d)) for d in docs))
@@ -199,103 +199,251 @@ class TestMessage(unittest.TestCase):
         self.assertIn("1000000", msg)
 
     def test_raise_document_too_large_update_generic_message(self):
-        with self.assertRaises(DocumentTooLarge) as ctx:
+        with self.assertRaisesRegex(DocumentTooLarge, "update command document too large"):
             _raise_document_too_large("update", 2_000_000, 1_000_000)
-        self.assertIn("update", str(ctx.exception))
 
     # _gen_find_command
 
     def test_find_basic(self):
-        cmd = _gen_find_command("col", {}, None, 0, 0, None, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            {},
+            projection=None,
+            skip=0,
+            limit=0,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertEqual(cmd["find"], "col")
         self.assertEqual(cmd["filter"], {})
 
     def test_find_with_projection(self):
-        cmd = _gen_find_command("col", {}, {"x": 1}, 0, 0, None, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            {},
+            projection={"x": 1},
+            skip=0,
+            limit=0,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertEqual(cmd["projection"], {"x": 1})
 
     def test_find_with_skip(self):
-        cmd = _gen_find_command("col", {}, None, 5, 0, None, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            {},
+            projection=None,
+            skip=5,
+            limit=0,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertEqual(cmd["skip"], 5)
 
     def test_find_with_positive_limit(self):
-        cmd = _gen_find_command("col", {}, None, 0, 10, None, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            {},
+            projection=None,
+            skip=0,
+            limit=10,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertEqual(cmd["limit"], 10)
         self.assertNotIn("singleBatch", cmd)
 
     def test_find_with_negative_limit_sets_single_batch(self):
-        cmd = _gen_find_command("col", {}, None, 0, -5, None, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            {},
+            projection=None,
+            skip=0,
+            limit=-5,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertEqual(cmd["limit"], 5)
         self.assertTrue(cmd["singleBatch"])
 
     def test_find_batch_size_adjusted_when_equal_to_limit(self):
-        cmd = _gen_find_command("col", {}, None, 0, 10, 10, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            {},
+            projection=None,
+            skip=0,
+            limit=10,
+            batch_size=10,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertEqual(cmd["batchSize"], 11)
 
     def test_find_batch_size_not_adjusted_when_different(self):
         # Covers the False branch of `if limit == batch_size:` — distinct from the True branch above.
-        cmd = _gen_find_command("col", {}, None, 0, 10, 5, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            {},
+            projection=None,
+            skip=0,
+            limit=10,
+            batch_size=5,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertEqual(cmd["batchSize"], 5)
 
     def test_find_read_concern_level_included(self):
-        cmd = _gen_find_command("col", {}, None, 0, 0, None, None, ReadConcern("majority"))
+        cmd = _gen_find_command(
+            "col",
+            {},
+            projection=None,
+            skip=0,
+            limit=0,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern("majority"),
+        )
         self.assertEqual(cmd["readConcern"], {"level": "majority"})
 
     def test_find_query_with_dollar_query_modifier(self):
         spec = {"$query": {"x": 1}, "$orderby": {"x": 1}}
-        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            spec,
+            projection=None,
+            skip=0,
+            limit=0,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertIn("sort", cmd)
         self.assertNotIn("$orderby", cmd)
         self.assertNotIn("$query", cmd)
 
     def test_find_allow_disk_use(self):
         cmd = _gen_find_command(
-            "col", {}, None, 0, 0, None, None, ReadConcern(), allow_disk_use=True
+            "col",
+            {},
+            projection=None,
+            skip=0,
+            limit=0,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+            allow_disk_use=True,
         )
         self.assertTrue(cmd["allowDiskUse"])
 
     def test_find_collation(self):
         cmd = _gen_find_command(
-            "col", {}, None, 0, 0, None, None, ReadConcern(), collation={"locale": "en"}
+            "col",
+            {},
+            projection=None,
+            skip=0,
+            limit=0,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+            collation={"locale": "en"},
         )
         self.assertEqual(cmd["collation"]["locale"], "en")
 
     def test_find_options_tailable(self):
-        cmd = _gen_find_command("col", {}, None, 0, 0, None, 2, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            {},
+            projection=None,
+            skip=0,
+            limit=0,
+            batch_size=None,
+            options=2,
+            read_concern=ReadConcern(),
+        )
         self.assertTrue(cmd.get("tailable"))
 
     def test_find_dollar_query_with_explain_removed(self):
         spec = {"$query": {"x": 1}, "$explain": 1}
-        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            spec,
+            projection=None,
+            skip=0,
+            limit=0,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertNotIn("$explain", cmd)
 
     def test_find_dollar_query_with_read_preference_removed(self):
         # Covers the separate `if "$readPreference" in cmd:` branch — not entered by test_dollar_query_with_explain_removed.
         spec = {"$query": {"x": 1}, "$readPreference": {"mode": "secondary"}}
-        cmd = _gen_find_command("col", spec, None, 0, 0, None, None, ReadConcern())
+        cmd = _gen_find_command(
+            "col",
+            spec,
+            projection=None,
+            skip=0,
+            limit=0,
+            batch_size=None,
+            options=None,
+            read_concern=ReadConcern(),
+        )
         self.assertNotIn("$readPreference", cmd)
 
     # _gen_get_more_command
 
     def test_get_more_basic(self):
-        cmd = _gen_get_more_command(12345, "col", None, None, None, self._make_conn())
+        cmd = _gen_get_more_command(
+            12345,
+            "col",
+            batch_size=None,
+            max_await_time_ms=None,
+            comment=None,
+            conn=self._make_conn(),
+        )
         self.assertEqual(cmd["getMore"], 12345)
         self.assertEqual(cmd["collection"], "col")
 
     def test_get_more_with_batch_size(self):
-        cmd = _gen_get_more_command(1, "col", 100, None, None, self._make_conn())
+        cmd = _gen_get_more_command(
+            1, "col", batch_size=100, max_await_time_ms=None, comment=None, conn=self._make_conn()
+        )
         self.assertEqual(cmd["batchSize"], 100)
 
     def test_get_more_with_max_await_time_ms(self):
-        cmd = _gen_get_more_command(1, "col", None, 500, None, self._make_conn())
+        cmd = _gen_get_more_command(
+            1, "col", batch_size=None, max_await_time_ms=500, comment=None, conn=self._make_conn()
+        )
         self.assertEqual(cmd["maxTimeMS"], 500)
 
     def test_get_more_comment_added_on_high_wire_version(self):
-        cmd = _gen_get_more_command(1, "col", None, None, "my comment", self._make_conn(9))
+        cmd = _gen_get_more_command(
+            1,
+            "col",
+            batch_size=None,
+            max_await_time_ms=None,
+            comment="my comment",
+            conn=self._make_conn(9),
+        )
         self.assertEqual(cmd["comment"], "my comment")
 
     def test_get_more_comment_not_added_on_low_wire_version(self):
-        cmd = _gen_get_more_command(1, "col", None, None, "my comment", self._make_conn(8))
+        cmd = _gen_get_more_command(
+            1,
+            "col",
+            batch_size=None,
+            max_await_time_ms=None,
+            comment="my comment",
+            conn=self._make_conn(8),
+        )
         self.assertNotIn("comment", cmd)
 
 

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -75,6 +75,8 @@ class TestMessage(unittest.TestCase):
         spec: dict = {"find": "col"}
         result = _maybe_add_read_preference(spec, pref)
         self.assertIn("$readPreference", result)
+        self.assertEqual(result["$readPreference"]["mode"], "secondaryPreferred")
+        self.assertIn("$query", result)
 
     def test_existing_query_wrapper_preserved(self):
         spec: dict = {"$query": {"x": 1}, "other": 2}
@@ -117,21 +119,6 @@ class TestMessage(unittest.TestCase):
         result = _convert_write_result("update", cmd, {"n": 1, "upserted": 42})
         self.assertIn("upserted", result)
         self.assertEqual(result["upserted"][0]["_id"], 42)
-
-    def test_update_legacy_upsert_id_from_update_doc(self):
-        # Pre-2.6 servers omit "upserted"; _id is extracted from the update doc (takes
-        # precedence over the query doc when both contain _id).
-        cmd = {"updates": [{"q": {"_id": 10}, "u": {"_id": 42}}]}
-        result = _convert_write_result("update", cmd, {"n": 1, "updatedExisting": False})
-        self.assertIn("upserted", result)
-        self.assertEqual(result["upserted"][0]["_id"], 42)
-
-    def test_update_legacy_upsert_id_from_query_doc(self):
-        # When _id is absent from the update doc, fall back to the query doc's _id.
-        cmd = {"updates": [{"q": {"_id": 10}, "u": {"$set": {"x": 1}}}]}
-        result = _convert_write_result("update", cmd, {"n": 1, "updatedExisting": False})
-        self.assertIn("upserted", result)
-        self.assertEqual(result["upserted"][0]["_id"], 10)
 
     def test_delete_basic(self):
         cmd = {"deletes": [{"q": {}, "limit": 1}]}

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import struct
 import sys
 from unittest.mock import MagicMock
 
@@ -25,28 +24,21 @@ sys.path[0:0] = [""]
 from test import unittest
 
 from bson import CodecOptions, encode
-from pymongo.compression_support import ZlibContext
 from pymongo.errors import DocumentTooLarge, OperationFailure
 from pymongo.message import (
-    _compress,
     _convert_client_bulk_exception,
     _convert_exception,
     _convert_write_result,
     _gen_find_command,
     _gen_get_more_command,
-    _get_more_compressed,
-    _get_more_uncompressed,
     _maybe_add_read_preference,
     _op_msg,
-    _query_compressed,
-    _query_uncompressed,
     _raise_document_too_large,
 )
 from pymongo.read_concern import ReadConcern
 from pymongo.read_preferences import ReadPreference, SecondaryPreferred
 
 _OPTS = CodecOptions()
-_ZLIB_CTX = ZlibContext(-1)
 
 
 class TestMaybeAddReadPreference(unittest.TestCase):
@@ -120,19 +112,6 @@ class TestConvertWriteResult(unittest.TestCase):
         self.assertIn("upserted", result)
         self.assertEqual(result["upserted"][0]["_id"], 42)
 
-    def test_update_upsert_id_precedence(self):
-        # When _id is in both the update document and the query spec,
-        # the update document's _id wins.
-        cmd = {"updates": [{"q": {"_id": 99}, "u": {"_id": 42}}]}
-        result = _convert_write_result("update", cmd, {"n": 1, "updatedExisting": False})
-        self.assertEqual(result["upserted"][0]["_id"], 42)
-
-    def test_update_upsert_no_upserted_id_from_query(self):
-        cmd = {"updates": [{"q": {"_id": 77}, "u": {"$set": {"x": 1}}}]}
-        result = _convert_write_result("update", cmd, {"n": 1, "updatedExisting": False})
-        self.assertIn("upserted", result)
-        self.assertEqual(result["upserted"][0]["_id"], 77)
-
     def test_delete_basic(self):
         cmd = {"deletes": [{"q": {}, "limit": 1}]}
         result = _convert_write_result("delete", cmd, {"n": 1})
@@ -161,19 +140,7 @@ class TestConvertWriteResult(unittest.TestCase):
         self.assertIn("errInfo", result["writeErrors"][0])
 
 
-class TestCompress(unittest.TestCase):
-    def test_compressed_message_has_op_compressed_header(self):
-        msg = _compress(2013, b"hello world", _ZLIB_CTX)[1]
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2012)  # OP_COMPRESSED
-
-
 class TestOpMsg(unittest.TestCase):
-    def test_uncompressed_op_code(self):
-        msg = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)[1]
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2013)  # OP_MSG
-
     def test_max_doc_size_zero_without_docs(self):
         max_doc_size = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS)[3]
         self.assertEqual(max_doc_size, 0)
@@ -194,41 +161,12 @@ class TestOpMsg(unittest.TestCase):
         _op_msg(0, cmd, "testdb", ReadPreference.SECONDARY, _OPTS)
         self.assertEqual(cmd["$readPreference"]["mode"], "nearest")
 
-    def test_with_compression_context(self):
-        msg = _op_msg(0, {"ping": 1}, "testdb", None, _OPTS, _ZLIB_CTX)[1]
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2012)  # OP_COMPRESSED
-
     def test_command_with_documents_field_is_restored(self):
         docs = [{"_id": 1}]
         cmd: dict = {"insert": "col", "documents": docs}
         _op_msg(0, cmd, "testdb", None, _OPTS)
         self.assertIn("documents", cmd)
         self.assertEqual(cmd["documents"], docs)
-
-
-class TestLegacyWireOps(unittest.TestCase):
-    """Tests for pre-OP_MSG wire ops (OP_QUERY and OP_GET_MORE), compressed and uncompressed."""
-
-    def test_query_uncompressed_op_code(self):
-        msg = _query_uncompressed(0, "db.col", 0, 0, {}, None, _OPTS)[1]
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2004)  # OP_QUERY
-
-    def test_query_compressed_op_code(self):
-        msg = _query_compressed(0, "db.col", 0, 0, {}, None, _OPTS, _ZLIB_CTX)[1]
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2012)  # OP_COMPRESSED
-
-    def test_get_more_uncompressed_op_code(self):
-        msg = _get_more_uncompressed("db.col", 0, 0)[1]
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2005)  # OP_GET_MORE
-
-    def test_get_more_compressed_op_code(self):
-        msg = _get_more_compressed("db.col", 0, 0, _ZLIB_CTX)[1]
-        op_code = struct.unpack("<i", msg[12:16])[0]
-        self.assertEqual(op_code, 2012)  # OP_COMPRESSED
 
 
 class TestRaiseDocumentTooLarge(unittest.TestCase):


### PR DESCRIPTION
PYTHON-5782

## Changes in this PR
Adds `test/test_message.py` with unit tests for `pymongo/message.py`.

Also removes a dead code branch in `_convert_write_result()` — a legacy compatibility shim for MongoDB < 2.6 that manually reconstructed the upserted `_id` when it wasn't an ObjectId. MongoDB 2.6+ always returns the `upserted` field directly, so this branch was unreachable.

Also fixes a bug in `_raise_document_too_large()` where the error message used `{operation!r}` (repr formatting), producing `'update' command document too large` instead of `update command document too large`. This mismatched the C extension's `%s`-formatted equivalent and broke the new test.

Tests cover:

**Result / error conversion**
- `_convert_exception()` — converts an `Exception` into an `errmsg`/`errtype` failure document for event publishing
- `_convert_client_bulk_exception()` — same as above but also captures the error `code`, used by the client-level bulk write API
- `_convert_write_result()` — converts a legacy GLE (Get Last Error) write result into write-command format, handling insert/update/delete/upsert, wtimeout, and errInfo branches
- `_raise_document_too_large()` — raises `DocumentTooLarge` with a size-aware message for inserts or a generic message for other operations

**Wire-format message construction**
- `_op_msg()` — builds an OP_MSG wire message, injecting `$db` and `$readPreference`, and temporarily popping document-sequence fields before encoding

**Command builders**
- `_gen_find_command()` — builds a `find` command document from a query spec, applying projections, skip/limit, batch size, read concern, collation, and cursor options
- `_gen_get_more_command()` — builds a `getMore` command document, conditionally including batch size, `maxTimeMS`, and `comment` (gated on wire version ≥ 9)

**Read preference**
- `_maybe_add_read_preference()` — injects `$readPreference` into a query spec for non-primary modes, skipping plain `secondaryPreferred` when no tags or maxStalenessSeconds are set

## Test Plan
Added unit tests using a real `ZlibContext` for compression paths and a `MagicMock` connection for `_gen_get_more_command`. Focuses on the pure-Python code paths without requiring a live MongoDB server.

```
hatch run test:test test/test_message.py -v
```

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?