### PR TITLE
PYTHON-5776 Add documentation comments to justfile recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,64 +16,78 @@ default:
 resync:
  @uv sync --quiet
 
+# Set up the development environment
 install:
    bash .evergreen/scripts/setup-dev-env.sh
 
+# Build the HTML documentation
 [group('docs')]
 docs: && resync
     {{docs_run}} sphinx-build -W -b html doc {{doc_build}}/html
 
+# Serve the docs locally with live-reload
 [group('docs')]
 docs-serve: && resync
     {{docs_run}} sphinx-autobuild -W -b html doc --watch ./pymongo --watch ./bson --watch ./gridfs {{doc_build}}/serve
 
+# Check documentation hyperlinks for broken URLs
 [group('docs')]
 docs-linkcheck: && resync
     {{docs_run}} sphinx-build -E -b linkcheck doc {{doc_build}}/linkcheck
 
+# Run mypy and pyright
 [group('typing')]
 typing: && resync
     just typing-mypy
     just typing-pyright
 
+# Run mypy against the library source and test suite
 [group('typing')]
 typing-mypy: && resync
     {{typing_run}} python -m mypy {{mypy_args}} bson gridfs tools pymongo
     {{typing_run}} python -m mypy {{mypy_args}} --config-file mypy_test.ini test
     {{typing_run}} python -m mypy {{mypy_args}} test/test_typing.py test/test_typing_strict.py
 
+# Run pyright against the typing test files
 [group('typing')]
 typing-pyright: && resync
     {{typing_run}} python -m pyright test/test_typing.py test/test_typing_strict.py
     {{typing_run}} python -m pyright -p strict_pyrightconfig.json test/test_typing_strict.py
 
+# Run all pre-commit hooks across the repository
 [group('lint')]
 lint *args="": && resync
     uvx pre-commit run --all-files {{args}}
 
+# Run shellcheck, doc8, and slotscheck
 [group('lint')]
 lint-manual *args="": && resync
     uvx pre-commit run --all-files --hook-stage manual {{args}}
 
+# Run pytest (e.g. just test test/test_uri_parser.py)
 [group('test')]
 test *args="-v --durations=5 --maxfail=10": && resync
     #!/usr/bin/env bash
     set -euo pipefail
     uv run ${USE_ACTIVE_VENV:+--active} --extra test python -m pytest {{args}}
 
+# Run the BSON test suite with numpy
 [group('test')]
 test-numpy *args="": && resync
     just setup-tests numpy {{args}}
     just run-tests test/test_bson.py
 
+# Run tests via the Evergreen test runner script
 [group('test')]
 run-tests *args: && resync
     bash ./.evergreen/run-tests.sh {{args}}
 
+# Set up the test environment (auth, TLS, etc.)
 [group('test')]
 setup-tests *args="":
     bash .evergreen/scripts/setup-tests.sh {{args}}
 
+# Tear down resources created by setup-tests
 [group('test')]
 teardown-tests:
     bash .evergreen/scripts/teardown-tests.sh
@@ -82,25 +96,30 @@ teardown-tests:
 integration-tests:
     bash integration_tests/run.sh
 
+# Run the full test suite with coverage
 [group('test')]
 test-coverage *args="":
     just setup-tests --cov
     just run-tests {{args}}
 
+# Print the coverage summary to the terminal
 [group('coverage')]
 coverage-report:
     uv tool run --with "coverage[toml]" coverage report
 
+# Generate an HTML coverage report in htmlcov/
 [group('coverage')]
 coverage-html:
     uv tool run --with "coverage[toml]" coverage html
     @echo "Coverage report generated in htmlcov/index.html"
 
+# Generate an XML coverage report at coverage.xml
 [group('coverage')]
 coverage-xml:
     uv tool run --with "coverage[toml]" coverage xml
     @echo "Coverage report generated in coverage.xml"
 
+# Start a MongoDB server via drivers-evergreen-tools
 [group('server')]
 run-server *args="":
     bash .evergreen/scripts/run-server.sh {{args}}


### PR DESCRIPTION
[PYTHON-5776](https://jira.mongodb.org/browse/PYTHON-5776)

## Changes in this PR

Adds `just` [documentation comments](https://just.systems/man/en/documentation-comments.html) to all justfile recipes so that `just -l` shows a brief description next to each recipe.

## Test Plan

Run `just -l` and verify descriptions appear next to each recipe.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [ ] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?