### PR TITLE
PYTHON-5756 - Fix BSON Binary type length bug

### DIFF
--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2155,7 +2155,7 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
             }
             memcpy(&length, buffer + *position, 4);
             length = BSON_UINT32_FROM_LE(length);
-            if (max < length) {
+            if (max < length + 5) { // Account for 5 byte header
                 goto invalid;
             }
 

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2155,7 +2155,7 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
             }
             memcpy(&length, buffer + *position, 4);
             length = BSON_UINT32_FROM_LE(length);
-            if (max < length + 5) { // Account for 5 byte header
+            if (length > max - 5) { // Account for 5-byte header. max >= 5 guaranteed above
                 goto invalid;
             }
 

--- a/bson/_cbsonmodule.c
+++ b/bson/_cbsonmodule.c
@@ -2155,7 +2155,7 @@ static PyObject* get_value(PyObject* self, PyObject* name, const char* buffer,
             }
             memcpy(&length, buffer + *position, 4);
             length = BSON_UINT32_FROM_LE(length);
-            if (length > max - 5) { // Account for 5-byte header. max >= 5 guaranteed above
+            if (max - 5 < length) { // Account for 5-byte header. max >= 5 guaranteed above
                 goto invalid;
             }
 

--- a/test/test_bson.py
+++ b/test/test_bson.py
@@ -1269,6 +1269,22 @@ class TestBSON(unittest.TestCase):
             encode(doc)
         self.assertEqual(cm.exception.document, doc)
 
+    def test_binary_length_accounts_for_header(self):
+        size = 20
+        binary_length = 12  # 5 more than the actual 7 bytes
+
+        payload = b""
+        payload += struct.pack("<i", size)  # document size
+        payload += b"\x05"  # type = Binary
+        payload += b"a\x00"  # key "a"
+        payload += struct.pack("<I", binary_length)  # Binary length (inflated)
+        payload += b"\x00"  # subtype 0
+        payload += b"\x41" * 7  # value
+        payload += b"\x00"  # EOO
+
+        with self.assertRaises(InvalidBSON):
+            decode(payload)
+
 
 class TestCodecOptions(unittest.TestCase):
     def test_document_class(self):


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
[JIRA TICKET]: Issue Title

If you are an external contributor and there is no JIRA ticket associated with your change, then use your best judgement
for the PR title. A MongoDB employee will create a JIRA ticket and edit the name and links as appropriate.

Note on AI Contributions:
We only accept pull requests that are authored and submitted by human contributors who fully understand the changes they are proposing.
All contributions must be written and understood by human contributors. Please read about our policy in our contributing guide.
-->
[PYTHON-5756](https://jira.mongodb.org/browse/PYTHON-5756)

## Changes in this PR
<!-- What changes did you make to the code? What new APIs (public or private) were added, removed, or edited to generate
the desired outcome explained in the above summary? -->
Fixes a bug in the C extension where BSON Binary fields did not correctly account for the header when calculating value length.

## Test Plan
<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why.
All code should be tested in some way – so please list what your validation strategy was. -->
Added a new unit test `test_binary_length_accounts_for_header`.

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- [X] Did you update the changelog (if necessary)?
- [X] Is there test coverage?
- [X] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
