### PR TITLE
PYTHON-5928 Redact AWS session token from client repr

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,10 @@ Changes in Version 4.18.0
   to the same server, avoiding a full handshake on each new connection.
   Session resumption is supported on all Python versions for synchronous clients
   and on Python 3.11+ for async clients.
+- Redacted potentially sensitive authentication mechanism properties, including
+  AWS session tokens, from the representations of
+  :class:`~pymongo.synchronous.mongo_client.MongoClient` and
+  :class:`~pymongo.asynchronous.mongo_client.AsyncMongoClient`.
 
 Changes in Version 4.17.0 (2026/04/20)
 --------------------------------------

--- a/pymongo/asynchronous/mongo_client.py
+++ b/pymongo/asynchronous/mongo_client.py
@@ -1305,6 +1305,8 @@ class AsyncMongoClient(common.BaseObject, Generic[_DocumentType]):
                     return "document_class=dict"
                 else:
                     return f"document_class={value.__module__}.{value.__name__}"
+            if option == "authmechanismproperties":
+                value = common.redact_auth_mechanism_properties_for_repr(value)
             if option in common.TIMEOUT_OPTIONS and value is not None:
                 return f"{option}={int(value * 1000)}"
 

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -423,6 +423,31 @@ _MECHANISM_PROPS = frozenset(
 )
 
 
+_SAFE_AUTH_MECHANISM_PROPS_FOR_REPR = frozenset(
+    [
+        "ALLOWED_HOSTS",
+        "CANONICALIZE_HOST_NAME",
+        "ENVIRONMENT",
+        "SERVICE_HOST",
+        "SERVICE_NAME",
+        "SERVICE_REALM",
+        "TOKEN_RESOURCE",
+    ]
+)
+
+
+def redact_auth_mechanism_properties_for_repr(value: Any) -> Any:
+    """Redact sensitive auth mechanism properties before including them in repr."""
+    if not isinstance(value, dict):
+        return value
+
+    redacted = value.copy()
+    for key in redacted:
+        if str(key).upper() not in _SAFE_AUTH_MECHANISM_PROPS_FOR_REPR:
+            redacted[key] = "<redacted>"
+    return redacted
+
+
 def validate_auth_mechanism_properties(option: str, value: Any) -> dict[str, Union[bool, str]]:
     """Validate authMechanismProperties."""
     props: dict[str, Any] = {}

--- a/pymongo/synchronous/mongo_client.py
+++ b/pymongo/synchronous/mongo_client.py
@@ -1306,6 +1306,8 @@ class MongoClient(common.BaseObject, Generic[_DocumentType]):
                     return "document_class=dict"
                 else:
                     return f"document_class={value.__module__}.{value.__name__}"
+            if option == "authmechanismproperties":
+                value = common.redact_auth_mechanism_properties_for_repr(value)
             if option in common.TIMEOUT_OPTIONS and value is not None:
                 return f"{option}={int(value * 1000)}"
 

--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -196,6 +196,41 @@ class AsyncClientUnitTest(AsyncUnitTest):
 
         self.assertRaises(ConfigurationError, AsyncMongoClient, [])
 
+    async def test_repr_redacts_aws_session_token(self):
+        token = "SECRET_AWS_SESSION_TOKEN"
+        client = AsyncMongoClient(
+            "mongodb://AKIA:SECRET@localhost:27017/"
+            f"?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:{token}",
+            connect=False,
+        )
+
+        the_repr = repr(client)
+
+        self.assertNotIn(token, the_repr)
+        self.assertIn("'AWS_SESSION_TOKEN': '<redacted>'", the_repr)
+
+    async def test_repr_redacts_secret_auth_mechanism_properties(self):
+        token = "SECRET_AWS_SESSION_TOKEN"
+        api_key = "SECRET_API_KEY"
+        client = AsyncMongoClient(
+            "mongodb://AKIA:SECRET@localhost:27017/",
+            authMechanism="MONGODB-AWS",
+            authMechanismProperties={
+                "aws_session_token": token,
+                "CUSTOM_API_KEY": api_key,
+                "TOKEN_RESOURCE": "mongodb://cluster.example",
+            },
+            connect=False,
+        )
+
+        the_repr = repr(client)
+
+        self.assertNotIn(token, the_repr)
+        self.assertNotIn(api_key, the_repr)
+        self.assertIn("'aws_session_token': '<redacted>'", the_repr)
+        self.assertIn("'CUSTOM_API_KEY': '<redacted>'", the_repr)
+        self.assertIn("'TOKEN_RESOURCE': 'mongodb://cluster.example'", the_repr)
+
     async def test_max_pool_size_zero(self):
         self.simple_client(maxPoolSize=0)
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -193,6 +193,41 @@ class ClientUnitTest(UnitTest):
 
         self.assertRaises(ConfigurationError, MongoClient, [])
 
+    def test_repr_redacts_aws_session_token(self):
+        token = "SECRET_AWS_SESSION_TOKEN"
+        client = MongoClient(
+            "mongodb://AKIA:SECRET@localhost:27017/"
+            f"?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:{token}",
+            connect=False,
+        )
+
+        the_repr = repr(client)
+
+        self.assertNotIn(token, the_repr)
+        self.assertIn("'AWS_SESSION_TOKEN': '<redacted>'", the_repr)
+
+    def test_repr_redacts_secret_auth_mechanism_properties(self):
+        token = "SECRET_AWS_SESSION_TOKEN"
+        api_key = "SECRET_API_KEY"
+        client = MongoClient(
+            "mongodb://AKIA:SECRET@localhost:27017/",
+            authMechanism="MONGODB-AWS",
+            authMechanismProperties={
+                "aws_session_token": token,
+                "CUSTOM_API_KEY": api_key,
+                "TOKEN_RESOURCE": "mongodb://cluster.example",
+            },
+            connect=False,
+        )
+
+        the_repr = repr(client)
+
+        self.assertNotIn(token, the_repr)
+        self.assertNotIn(api_key, the_repr)
+        self.assertIn("'aws_session_token': '<redacted>'", the_repr)
+        self.assertIn("'CUSTOM_API_KEY': '<redacted>'", the_repr)
+        self.assertIn("'TOKEN_RESOURCE': 'mongodb://cluster.example'", the_repr)
+
     def test_max_pool_size_zero(self):
         self.simple_client(maxPoolSize=0)
 


### PR DESCRIPTION
[PYTHON-5928](https://jira.mongodb.org/browse/PYTHON-5928)

AWS session tokens passed via `authMechanismProperties` (for example, `AWS_SESSION_TOKEN`) were rendered in plain text inside `MongoClient.__repr__`, leaking short-lived AWS credentials into logs and error messages. The existing username/password redaction did not cover authentication mechanism properties.

## Changes in this PR

- Add the shared helper `pymongo.common.redact_auth_mechanism_properties_for_repr`, which redacts every authentication mechanism property whose upper-cased name is not in the safe allowlist (`ALLOWED_HOSTS`, `CANONICALIZE_HOST_NAME`, `ENVIRONMENT`, `SERVICE_HOST`, `SERVICE_NAME`, `SERVICE_REALM`, `TOKEN_RESOURCE`).
- Apply the helper to the repr path in both `pymongo/asynchronous/mongo_client.py` and `pymongo/synchronous/mongo_client.py`.
- Add sync and async regression coverage for:
  - `AWS_SESSION_TOKEN` supplied through the connection URI.
  - Lower-case `aws_session_token` and a custom `CUSTOM_API_KEY` supplied through `authMechanismProperties` kwargs.
  - Safe `TOKEN_RESOURCE` values remaining visible.

The allowlist approach, rather than a single-key denylist, also prevents other custom token-, password-, secret-, or key-bearing properties from leaking through the client repr.

## Test Plan

```text
python -m pytest test/test_client.py::ClientUnitTest::test_repr_redacts_aws_session_token test/test_client.py::ClientUnitTest::test_repr_redacts_secret_auth_mechanism_properties test/asynchronous/test_client.py::AsyncClientUnitTest::test_repr_redacts_aws_session_token test/asynchronous/test_client.py::AsyncClientUnitTest::test_repr_redacts_secret_auth_mechanism_properties -q
```

Local result: `4 passed`.

Manual verification:

```python
from pymongo import MongoClient

client = MongoClient(
    "mongodb://AKIA:SECRET@localhost:27017/"
    "?authMechanism=MONGODB-AWS"
    "&authMechanismProperties=AWS_SESSION_TOKEN:SECRET-TOKEN",
    connect=False,
)
print(repr(client))  # 'AWS_SESSION_TOKEN': '<redacted>'
```

## Checklist

### Checklist for Author

- [x] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [x] Is any followup work tracked in a JIRA ticket? PYTHON-5928

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation?
- [ ] Is all relevant documentation (README or docstring) updated?
