### PR TITLE
PYTHON-5847 Fix intermittent linkcheck failures due to rate-limiting

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -172,6 +172,8 @@ jobs:
         run: just install
       - name: Build docs
         run: just docs-linkcheck
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   typing:
     name: Typing Tests

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,6 +98,10 @@ linkcheck_ignore = [
 
 # Allow for flaky links.
 linkcheck_retries = 3
+# Serialize requests to dochub.mongodb.org to avoid rate-limiting (PYTHON-5847).
+linkcheck_workers = 1
+# Give slow redirects more time before retrying.
+linkcheck_timeout = 60
 
 # -- Options for extensions ----------------------------------------------------
 autoclass_content = "init"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -100,7 +100,7 @@ linkcheck_workers = 1
 linkcheck_timeout = 60
 
 # Ignore anchors in links since they may not be added to the page right away.
-linkcheck_anchors_ignore = True
+linkcheck_anchors_ignore_for_url = [r"https://github.com/.*"]
 
 # Pass GitHub token to avoid rate-limiting on GitHub links.
 if github_token := os.environ.get("GITHUB_TOKEN"):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,6 +4,7 @@
 # This file is execfile()d with the current directory set to its containing dir.
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -86,11 +87,6 @@ pygments_style = "sphinx"
 # sourceforge.net is giving a 403 error, but is still accessible from the browser.
 # Links to release notes in jira give 401 error: unauthorized. PYTHON-5585
 linkcheck_ignore = [
-    "https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-monitoring.md#requesting-an-immediate-check",
-    "https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.md#handling-errors-inside-the-callback",
-    "https://github.com/mongodb/specifications/blob/master/source/uri-options/uri-options.md",
-    "https://github.com/mongodb/specifications/blob/master/source/uri-options/uri-options.md",
-    "https://github.com/mongodb/libmongocrypt/blob/master/bindings/python/README.rst#installing-from-source",
     r"https://wiki.centos.org/[\w/]*",
     r"https://sourceforge.net/",
     r"https://jira\.mongodb\.org/secure/ReleaseNote\.jspa.*",
@@ -102,6 +98,17 @@ linkcheck_retries = 3
 linkcheck_workers = 1
 # Give slow redirects more time before retrying.
 linkcheck_timeout = 60
+
+# Ignore anchors in links since they may not be added to the page right away.
+linkcheck_anchors_ignore = True
+
+# Pass GitHub token to avoid rate-limiting on GitHub links.
+if github_token := os.environ.get("GITHUB_TOKEN"):
+    linkcheck_request_headers = {
+        "https://github.com/": {"Authorization": f"token {github_token}"},
+        "https://api.github.com/": {"Authorization": f"token {github_token}"},
+    }
+
 
 # -- Options for extensions ----------------------------------------------------
 autoclass_content = "init"

--- a/uv.lock
+++ b/uv.lock
@@ -1601,7 +1601,7 @@ requires-dist = [
     { name = "python-snappy", marker = "extra == 'snappy'", specifier = ">=0.7.3" },
     { name = "readthedocs-sphinx-search", marker = "extra == 'docs'", specifier = "~=0.3" },
     { name = "requests", marker = "extra == 'ocsp'", specifier = ">=2.23.0,<3.0" },
-    { name = "service-identity", marker = "extra == 'ocsp'", specifier = ">=23.1.0" },
+    { name = "service-identity", marker = "extra == 'ocsp'", specifier = ">=24.2.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=5.3,<9" },
     { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = ">=2024.10.3" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=3.1.0,<4" },


### PR DESCRIPTION
[PYTHON-5847](https://jira.mongodb.org/browse/PYTHON-5847)

## Changes in this PR
Updates `doc/conf.py` and the linkcheck CI job to reduce intermittent linkcheck failures:

- Set `linkcheck_workers = 1` to serialize requests to dochub.mongodb.org and avoid rate-limiting
- Set `linkcheck_timeout = 60` to give slow redirects more time before retrying
- Remove GitHub links from `linkcheck_ignore` — they are now checked properly instead of skipped
- Add `linkcheck_anchors_ignore_for_url` to skip anchor validation on GitHub URLs (anchors are rendered client-side and are unreliable to check)
- Add `linkcheck_request_headers` to pass a GitHub token when checking GitHub links, avoiding rate-limiting
- Pass `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the linkcheck workflow step so the token is available

## Test Plan
Run the `docs-linkcheck` CI job a few times to confirm no more timeout or rate-limit failures on dochub or GitHub links.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?