### PR TITLE
PYTHON-5853 Dependabot improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,10 @@ updates:
       actions:
         patterns:
           - "*"
-  # Python
-  - package-ecosystem: "pip"
+  # Python (uv)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
       stages: [manual]
 
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.29.0
+  rev: 0.37.2
   hooks:
     - id: check-github-workflows
     - id: check-github-actions


### PR DESCRIPTION
[PYTHON-5853](https://jira.mongodb.org/browse/PYTHON-5853)

## Changes in this PR
- Replaced the `pip` Dependabot ecosystem entry with `uv`, since GitHub Dependabot now has native `uv` support.
- Added `cooldown: default-days: 7` to the `uv` ecosystem entry (matching the existing `github-actions` entry).
- Bumped `check-jsonschema` pre-commit hook from `0.29.0` to `0.37.2` to pick up the updated SchemaStore Dependabot schema that recognises `uv` as a valid ecosystem.

## Test Plan
The pre-commit `check-dependabot` hook validates the updated config and passes with `check-jsonschema` 0.37.2.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?