### PR TITLE
PYTHON-5851 Run setup-uv-python.sh before install-dependencies.sh

### DIFF
--- a/.evergreen/scripts/setup-dev-env.sh
+++ b/.evergreen/scripts/setup-dev-env.sh
@@ -16,11 +16,11 @@ if [ -f $HERE/test-env.sh ]; then
   . $HERE/test-env.sh
 fi
 
-# Ensure dependencies are installed.
-bash $HERE/install-dependencies.sh
-
 # Handle the value for UV_PYTHON.
 . $HERE/setup-uv-python.sh
+
+# Ensure dependencies are installed.
+bash $HERE/install-dependencies.sh
 
 # Only run the next part if not running on CI.
 if [ -z "${CI:-}" ]; then


### PR DESCRIPTION
[PYTHON-5851](https://jira.mongodb.org/browse/PYTHON-5851)

## Changes in this PR
Reorder script execution in `setup-dev-env.sh` so that `setup-uv-python.sh` (which configures `UV_PYTHON`) runs before `install-dependencies.sh` (which uses `uv` to install dependencies). Previously the ordering caused `install-dependencies.sh` to run without the correct Python version set.

## Test Plan
Verified via Evergreen patch on `other-hosts-rhel8-arm64-latest` / `test-no-toolchain-sync-noauth-nossl-standalone` (patch [6a2055295e7fc100078cc5c3](https://evergreen.mongodb.com/patch/6a2055295e7fc100078cc5c3)) — task that was previously failing now passes.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?