### PR TITLE
PYTHON-5852 Fix inverted polling condition in TestSearchIndexProse test_case_3

### DIFF
--- a/.evergreen/scripts/setup-dev-env.sh
+++ b/.evergreen/scripts/setup-dev-env.sh
@@ -16,11 +16,11 @@ if [ -f $HERE/test-env.sh ]; then
   . $HERE/test-env.sh
 fi
 
-# Ensure dependencies are installed.
-bash $HERE/install-dependencies.sh
-
 # Handle the value for UV_PYTHON.
 . $HERE/setup-uv-python.sh
+
+# Ensure dependencies are installed.
+bash $HERE/install-dependencies.sh
 
 # Only run the next part if not running on CI.
 if [ -z "${CI:-}" ]; then

--- a/test/asynchronous/test_index_management.py
+++ b/test/asynchronous/test_index_management.py
@@ -223,7 +223,7 @@ class TestSearchIndexProse(SearchIndexIntegrationBase):
         t0 = time.time()
         while True:
             indices = await (await coll0.list_search_indexes()).to_list()
-            if indices:
+            if not indices:
                 break
             if (time.time() - t0) / 60 > 5:
                 raise TimeoutError("Timed out waiting for index deletion")

--- a/test/test_index_management.py
+++ b/test/test_index_management.py
@@ -223,7 +223,7 @@ class TestSearchIndexProse(SearchIndexIntegrationBase):
         t0 = time.time()
         while True:
             indices = (coll0.list_search_indexes()).to_list()
-            if indices:
+            if not indices:
                 break
             if (time.time() - t0) / 60 > 5:
                 raise TimeoutError("Timed out waiting for index deletion")


### PR DESCRIPTION
[PYTHON-5852](https://jira.mongodb.org/browse/PYTHON-5852)

## Changes in this PR

Fix a bug in the `test_case_3` prose test ("Driver can successfully drop search indexes") that caused it to always time out waiting for index deletion.

## Test Plan

- Evergreen patch [6a2094be](https://evergreen.mongodb.com/patch/6a2094be14fb5900070b3598) running `test-search-index-helpers` passed successfully.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?