### PR TITLE
PYTHON-3011 Fix flaky test_connections_are_only_returned_once on PyPy

### DIFF
--- a/test/asynchronous/test_load_balancer.py
+++ b/test/asynchronous/test_load_balancer.py
@@ -50,14 +50,17 @@ class TestLB(AsyncIntegrationTest):
     RUN_ON_LOAD_BALANCER = True
 
     async def test_connections_are_only_returned_once(self):
-        if "PyPy" in sys.version:
-            # Tracked in PYTHON-3011
-            self.skipTest("Test is flaky on PyPy")
         pool = await async_get_pool(self.client)
         n_conns = len(pool.conns)
         await self.db.test.find_one({})
+        # On PyPy it can take a few rounds to collect the cursor.
+        for _ in range(3):
+            gc.collect()
         self.assertEqual(len(pool.conns), n_conns)
         await (await self.db.test.aggregate([{"$limit": 1}])).to_list()
+        # On PyPy it can take a few rounds to collect the cursor.
+        for _ in range(3):
+            gc.collect()
         self.assertEqual(len(pool.conns), n_conns)
 
     @async_client_context.require_load_balancer

--- a/test/test_load_balancer.py
+++ b/test/test_load_balancer.py
@@ -50,14 +50,17 @@ class TestLB(IntegrationTest):
     RUN_ON_LOAD_BALANCER = True
 
     def test_connections_are_only_returned_once(self):
-        if "PyPy" in sys.version:
-            # Tracked in PYTHON-3011
-            self.skipTest("Test is flaky on PyPy")
         pool = get_pool(self.client)
         n_conns = len(pool.conns)
         self.db.test.find_one({})
+        # On PyPy it can take a few rounds to collect the cursor.
+        for _ in range(3):
+            gc.collect()
         self.assertEqual(len(pool.conns), n_conns)
         (self.db.test.aggregate([{"$limit": 1}])).to_list()
+        # On PyPy it can take a few rounds to collect the cursor.
+        for _ in range(3):
+            gc.collect()
         self.assertEqual(len(pool.conns), n_conns)
 
     @client_context.require_load_balancer


### PR DESCRIPTION
[PYTHON-3011](https://jira.mongodb.org/browse/PYTHON-3011)

## Changes in this PR

Removes the PyPy skip from `test_connections_are_only_returned_once` and fixes the underlying flakiness so the test runs on PyPy.

## Test Plan

- Pre-commit hooks pass (ruff, synchro, etc.)
- The test now runs on PyPy without the skip.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage? *(this PR fixes the test itself)*
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?