### PR TITLE
PYTHON-5792: Bump maxWireVersion to 29

### DIFF
--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -69,8 +69,8 @@ MAX_WRITE_BATCH_SIZE = 100000
 # What this version of PyMongo supports.
 MIN_SUPPORTED_SERVER_VERSION = "4.2"
 MIN_SUPPORTED_WIRE_VERSION = 8
-# MongoDB 8.0
-MAX_SUPPORTED_WIRE_VERSION = 25
+# MongoDB 9.0
+MAX_SUPPORTED_WIRE_VERSION = 29
 
 # Frequency to call hello on servers, in seconds.
 HEARTBEAT_FREQUENCY = 10

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -593,8 +593,8 @@ class TestMultiServerTopology(TopologyTest):
                 HelloCompat.LEGACY_CMD: True,
                 "setName": "rs",
                 "hosts": ["a"],
-                "minWireVersion": 26,
-                "maxWireVersion": 29,
+                "minWireVersion": common.MAX_SUPPORTED_WIRE_VERSION + 1,
+                "maxWireVersion": common.MAX_SUPPORTED_WIRE_VERSION + 2,
             },
         )
 
@@ -604,8 +604,9 @@ class TestMultiServerTopology(TopologyTest):
             # Error message should say which server failed and why.
             self.assertEqual(
                 str(e),
-                "Server at a:27017 requires wire version 26, but this version "
-                "of PyMongo only supports up to %d." % (common.MAX_SUPPORTED_WIRE_VERSION,),
+                "Server at a:27017 requires wire version %d, but this version "
+                "of PyMongo only supports up to %d."
+                % (common.MAX_SUPPORTED_WIRE_VERSION + 1, common.MAX_SUPPORTED_WIRE_VERSION),
             )
         else:
             self.fail("No error with incompatible wire version")

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -594,7 +594,7 @@ class TestMultiServerTopology(TopologyTest):
                 "setName": "rs",
                 "hosts": ["a"],
                 "minWireVersion": 26,
-                "maxWireVersion": 27,
+                "maxWireVersion": 29,
             },
         )
 


### PR DESCRIPTION
[PYTHON-5792](https://jira.mongodb.org/browse/PYTHON-5792)

## Changes in this PR
Bumped maxWireVersion referencing https://github.com/mongodb/mongo-python-driver/commit/f7225fda55df81265c3284b2b159a610eb390539

## Test Plan
N/A

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [ ] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
