### PR TITLE
PYTHON-5858 fix flipped conditional

### DIFF
--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -2922,7 +2922,7 @@ class TestRangeQueryProse(AsyncEncryptionIntegrationTest):
                 EncryptionError, "expected matching 'min' and value type. Got range option"
             ):
                 await self.client_encryption.encrypt(
-                    6 if cast_func is int else float(6),
+                    6 if cast_func is not int else float(6),
                     key_id=self.key1_id,
                     algorithm=Algorithm.RANGE,
                     contention_factor=0,


### PR DESCRIPTION

<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
PYTHON-5858: Issue Title

If you are an external contributor and there is no JIRA ticket associated with your change, then use your best judgement
for the PR title. A MongoDB employee will create a JIRA ticket and edit the name and links as appropriate.

Note on AI Contributions:
We only accept pull requests that are authored and submitted by human contributors who fully understand the changes they are proposing.
All contributions must be written and understood by human contributors. Please read about our policy in our contributing guide.
-->
PYTHON-5858

## Changes in this PR
This is a follow-up to d88aaa6cfdb05599a79f60a2cbea5513f3788f6c. "!=" was accidentally changed to "is". This commit fixes it to "is not".

## Test Plan
The change caused failures in the test-python-integ task on libmongocrypt ([failed task](https://spruce.corp.mongodb.com/task/libmongocrypt_rhel_80_64_bit_test_python_integ_6a329349f638f200088f7c08_26_06_17_12_30_01/logs?execution=0)). Testing this branch resulted in success ([successful patch](https://spruce.corp.mongodb.com/version/6a329bd3a3c0d000072192e9)).

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- ~~[ ] Did you update the changelog (if necessary)?~~
- [x] Is there test coverage?
- ~~[ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).~~

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
