### PR TITLE
PYTHON-5879 Skip coverage on macOS/Win64 encryption tests

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4844,7 +4844,7 @@ tasks:
           VERSION: latest
           TOOLCHAIN_VERSION: 3.14t
     tags:
-      - test-non-standard
+      - test-non-standard-no-cov
       - server-latest
       - python-3.14t
       - replica_set-noauth-ssl
@@ -4914,7 +4914,7 @@ tasks:
           VERSION: latest
           TOOLCHAIN_VERSION: "3.14"
     tags:
-      - test-non-standard
+      - test-non-standard-no-cov
       - server-latest
       - python-3.14
       - sharded_cluster-auth-ssl
@@ -4961,7 +4961,7 @@ tasks:
           VERSION: latest
           TOOLCHAIN_VERSION: "3.13"
     tags:
-      - test-non-standard
+      - test-non-standard-no-cov
       - server-latest
       - python-3.13
       - standalone-noauth-nossl

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4827,6 +4827,7 @@ tasks:
       - noauth
       - free-threaded
       - pr
+      - cov
   - name: test-non-standard-latest-pypy3.11-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -4873,6 +4874,7 @@ tasks:
       - sharded_cluster-auth-ssl
       - auth
       - pr
+      - cov
   - name: test-non-standard-latest-python3.13-noauth-nossl-standalone-cov
     commands:
       - func: run server
@@ -4897,6 +4899,7 @@ tasks:
       - standalone-noauth-nossl
       - noauth
       - pr
+      - cov
   - name: test-non-standard-rapid-python3.11-noauth-ssl-replica-set
     commands:
       - func: run server

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4802,32 +4802,6 @@ tasks:
       - python-3.13
       - standalone-noauth-nossl
       - noauth
-  - name: test-non-standard-latest-python3.14t-noauth-ssl-replica-set-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          COVERAGE: "1"
-          TOOLCHAIN_VERSION: 3.14t
-    tags:
-      - test-non-standard
-      - server-latest
-      - python-3.14t
-      - replica_set-noauth-ssl
-      - noauth
-      - free-threaded
-      - pr
-      - cov
   - name: test-non-standard-latest-python3.14t-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -4844,13 +4818,12 @@ tasks:
           VERSION: latest
           TOOLCHAIN_VERSION: 3.14t
     tags:
-      - test-non-standard-no-cov
+      - test-non-standard
       - server-latest
       - python-3.14t
       - replica_set-noauth-ssl
       - noauth
       - free-threaded
-      - pr
   - name: test-non-standard-latest-pypy3.11-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -4920,31 +4893,6 @@ tasks:
       - sharded_cluster-auth-ssl
       - auth
       - pr
-  - name: test-non-standard-latest-python3.13-noauth-nossl-standalone-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          COVERAGE: "1"
-          TOOLCHAIN_VERSION: "3.13"
-    tags:
-      - test-non-standard
-      - server-latest
-      - python-3.13
-      - standalone-noauth-nossl
-      - noauth
-      - pr
-      - cov
   - name: test-non-standard-latest-python3.13-noauth-nossl-standalone
     commands:
       - func: run server
@@ -4961,12 +4909,11 @@ tasks:
           VERSION: latest
           TOOLCHAIN_VERSION: "3.13"
     tags:
-      - test-non-standard-no-cov
+      - test-non-standard
       - server-latest
       - python-3.13
       - standalone-noauth-nossl
       - noauth
-      - pr
   - name: test-non-standard-rapid-python3.11-noauth-ssl-replica-set
     commands:
       - func: run server

--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -4828,6 +4828,29 @@ tasks:
       - free-threaded
       - pr
       - cov
+  - name: test-non-standard-latest-python3.14t-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          TOOLCHAIN_VERSION: 3.14t
+    tags:
+      - test-non-standard
+      - server-latest
+      - python-3.14t
+      - replica_set-noauth-ssl
+      - noauth
+      - free-threaded
+      - pr
   - name: test-non-standard-latest-pypy3.11-noauth-ssl-replica-set
     commands:
       - func: run server
@@ -4875,6 +4898,28 @@ tasks:
       - auth
       - pr
       - cov
+  - name: test-non-standard-latest-python3.14-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          TOOLCHAIN_VERSION: "3.14"
+    tags:
+      - test-non-standard
+      - server-latest
+      - python-3.14
+      - sharded_cluster-auth-ssl
+      - auth
+      - pr
   - name: test-non-standard-latest-python3.13-noauth-nossl-standalone-cov
     commands:
       - func: run server
@@ -4900,6 +4945,28 @@ tasks:
       - noauth
       - pr
       - cov
+  - name: test-non-standard-latest-python3.13-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          TOOLCHAIN_VERSION: "3.13"
+    tags:
+      - test-non-standard
+      - server-latest
+      - python-3.13
+      - standalone-noauth-nossl
+      - noauth
+      - pr
   - name: test-non-standard-rapid-python3.11-noauth-ssl-replica-set
     commands:
       - func: run server

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -194,6 +194,7 @@ buildvariants:
   - name: encryption-macos
     tasks:
       - name: .test-non-standard !.pypy !.cov
+      - name: .test-non-standard-no-cov !.pypy
     display_name: Encryption macOS
     run_on:
       - macos-14
@@ -204,6 +205,7 @@ buildvariants:
   - name: encryption-win64
     tasks:
       - name: .test-non-standard !.pypy !.cov
+      - name: .test-non-standard-no-cov !.pypy
     display_name: Encryption Win64
     run_on:
       - windows-2022-latest-small
@@ -225,6 +227,7 @@ buildvariants:
   - name: encryption-crypt_shared-macos
     tasks:
       - name: .test-non-standard !.pypy !.cov
+      - name: .test-non-standard-no-cov !.pypy
     display_name: Encryption crypt_shared macOS
     run_on:
       - macos-14
@@ -236,6 +239,7 @@ buildvariants:
   - name: encryption-crypt_shared-win64
     tasks:
       - name: .test-non-standard !.pypy !.cov
+      - name: .test-non-standard-no-cov !.pypy
     display_name: Encryption crypt_shared Win64
     run_on:
       - windows-2022-latest-small

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -193,7 +193,7 @@ buildvariants:
     tags: [encryption_tag]
   - name: encryption-macos
     tasks:
-      - name: .test-non-standard !.pypy
+      - name: .test-non-standard !.pypy !.cov
     display_name: Encryption macOS
     run_on:
       - macos-14
@@ -203,7 +203,7 @@ buildvariants:
     tags: [encryption_tag]
   - name: encryption-win64
     tasks:
-      - name: .test-non-standard !.pypy
+      - name: .test-non-standard !.pypy !.cov
     display_name: Encryption Win64
     run_on:
       - windows-2022-latest-small
@@ -224,7 +224,7 @@ buildvariants:
     tags: [encryption_tag]
   - name: encryption-crypt_shared-macos
     tasks:
-      - name: .test-non-standard !.pypy
+      - name: .test-non-standard !.pypy !.cov
     display_name: Encryption crypt_shared macOS
     run_on:
       - macos-14
@@ -235,7 +235,7 @@ buildvariants:
     tags: [encryption_tag]
   - name: encryption-crypt_shared-win64
     tasks:
-      - name: .test-non-standard !.pypy
+      - name: .test-non-standard !.pypy !.cov
     display_name: Encryption crypt_shared Win64
     run_on:
       - windows-2022-latest-small

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -648,8 +648,9 @@ def create_test_non_standard_tasks():
     tasks = []
     task_combos = set()
     # For each version and topology, rotate through the CPythons.
+    # Only the sharded_cluster topology runs on PRs to keep patch build size manageable.
     for (version, topology), python in zip_cycle(list(product(ALL_VERSIONS, TOPOLOGIES)), CPYTHONS):
-        pr = version == "latest"
+        pr = version == "latest" and topology == "sharded_cluster"
         task_combos.add((version, topology, python, pr))
     # For each PyPy and topology, rotate through the MongoDB versions.
     for (python, topology), version in zip_cycle(list(product(PYPYS, TOPOLOGIES)), ALL_VERSIONS):

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -132,7 +132,8 @@ def create_encryption_variants() -> list[BuildVariant]:
         display_name = get_variant_name(encryption, host, **expansions)
         tasks = [".test-non-standard"]
         if host != "rhel8":
-            tasks = [".test-non-standard !.pypy"]
+            # Exclude PyPy (not supported on non-linux) and coverage tasks (too slow on macOS/win64).
+            tasks = [".test-non-standard !.pypy !.cov"]
         variant = create_variant(
             tasks,
             display_name,
@@ -670,6 +671,7 @@ def create_test_non_standard_tasks():
             expansions["TEST_MIN_DEPS"] = "1"
         elif pr:
             expansions["COVERAGE"] = "1"
+            tags.append("cov")
         name = get_task_name("test-non-standard", python=python, **expansions)
         server_func = FunctionCall(func="run server", vars=expansions)
         test_vars = expansions.copy()

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -134,7 +134,9 @@ def create_encryption_variants() -> list[BuildVariant]:
         if host != "rhel8":
             # Exclude PyPy (no Evergreen toolchain on macOS/win64) and coverage tasks
             # (encryption suites exceed the 60-min timeout with coverage overhead on macOS/win64).
-            tasks = [".test-non-standard !.pypy !.cov"]
+            # Also include the non-coverage companion tasks (test-non-standard-no-cov) which
+            # carry the "latest" server tasks without COVERAGE=1.
+            tasks = [".test-non-standard !.pypy !.cov", ".test-non-standard-no-cov !.pypy"]
         variant = create_variant(
             tasks,
             display_name,
@@ -684,7 +686,13 @@ def create_test_non_standard_tasks():
         # constraints) still have a "latest" task to activate in patch builds.
         if pr and "cov" in tags:
             nc_expansions = {k: v for k, v in expansions.items() if k != "COVERAGE"}
-            nc_tags = [t for t in tags if t != "cov"]
+            # Use a distinct primary tag so companions are not selected by existing
+            # ".test-non-standard" selectors (e.g. load-balancer, PyOpenSSL variants).
+            nc_tags = [
+                "test-non-standard-no-cov" if t == "test-non-standard" else t
+                for t in tags
+                if t != "cov"
+            ]
             nc_name = get_task_name("test-non-standard", python=python, **nc_expansions)
             nc_server_func = FunctionCall(func="run server", vars=nc_expansions)
             nc_test_vars = nc_expansions.copy()

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -132,7 +132,8 @@ def create_encryption_variants() -> list[BuildVariant]:
         display_name = get_variant_name(encryption, host, **expansions)
         tasks = [".test-non-standard"]
         if host != "rhel8":
-            # Exclude PyPy (not supported on non-linux) and coverage tasks (too slow on macOS/win64).
+            # Exclude PyPy (no Evergreen toolchain on macOS/win64) and coverage tasks
+            # (encryption suites exceed the 60-min timeout with coverage overhead on macOS/win64).
             tasks = [".test-non-standard !.pypy !.cov"]
         variant = create_variant(
             tasks,

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -132,7 +132,7 @@ def create_encryption_variants() -> list[BuildVariant]:
         display_name = get_variant_name(encryption, host, **expansions)
         tasks = [".test-non-standard"]
         if host != "rhel8":
-            # Exclude PyPy (no Evergreen toolchain on macOS/win64) and coverage tasks
+            # Exclude PyPy (not tested with encryption on macOS/win64) and coverage tasks
             # (encryption suites exceed the 60-min timeout with coverage overhead on macOS/win64).
             # Also include the non-coverage companion tasks (test-non-standard-no-cov) which
             # carry the "latest" server tasks without COVERAGE=1.

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -679,6 +679,20 @@ def create_test_non_standard_tasks():
         test_vars["TOOLCHAIN_VERSION"] = python
         test_func = FunctionCall(func="run tests", vars=test_vars)
         tasks.append(EvgTask(name=name, tags=tags, commands=[server_func, test_func]))
+        # For each coverage task, also emit a non-coverage companion so that
+        # macOS/Win64 encryption variants (which filter out .cov due to timeout
+        # constraints) still have a "latest" task to activate in patch builds.
+        if pr and "cov" in tags:
+            nc_expansions = {k: v for k, v in expansions.items() if k != "COVERAGE"}
+            nc_tags = [t for t in tags if t != "cov"]
+            nc_name = get_task_name("test-non-standard", python=python, **nc_expansions)
+            nc_server_func = FunctionCall(func="run server", vars=nc_expansions)
+            nc_test_vars = nc_expansions.copy()
+            nc_test_vars["TOOLCHAIN_VERSION"] = python
+            nc_test_func = FunctionCall(func="run tests", vars=nc_test_vars)
+            tasks.append(
+                EvgTask(name=nc_name, tags=nc_tags, commands=[nc_server_func, nc_test_func])
+            )
     return tasks
 
 


### PR DESCRIPTION
PYTHON-5879

## Changes in this PR

Adds a `cov` tag to non-standard Evergreen tasks that enable coverage (`COVERAGE=1`), then excludes those tasks from the macOS and Win64 encryption variants using `!.cov`.

Both sync and async encryption test suites each take >30 min on macOS/Win64 with coverage enabled, which combined exceeds the 60-minute task timeout. Linux (RHEL8) encryption variants still run the coverage tasks, so encryption code paths remain covered in the combined Codecov report.

### Companion non-coverage tasks

The cycling algorithm in `create_test_non_standard_tasks()` happens to assign python 3.13/3.14t/3.14 to all three `latest` topology slots. Since none of those is `ALL_PYTHONS[0]` ("3.10"), every "latest" non-standard task was getting `COVERAGE=1` and the `cov` tag — meaning `!.cov` removed **all** latest tasks from macOS/Win64, leaving nothing to activate in patch builds.

Fix: for each coverage task emitted, also emit a non-coverage companion with the same python/topology/version but no `COVERAGE` expansion and no `cov` tag. This gives macOS/Win64 encryption variants three "latest" tasks to run without coverage overhead:

- `test-non-standard-latest-python3.13-noauth-nossl-standalone`
- `test-non-standard-latest-python3.14t-noauth-ssl-replica-set`
- `test-non-standard-latest-python3.14-auth-ssl-sharded-cluster`

## Test Plan

Config change only — verified the generated `tasks.yml` and `variants.yml` reflect the new tags, selectors, and companion tasks correctly.

## Checklist
### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?