### PR TITLE
PYTHON-5890 Remove automatic synchro for local testing

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,10 +16,6 @@ default:
 resync:
  @uv sync --quiet
 
-[private]
-run-synchro:
-    uv run --group unasync ./tools/synchro.py
-
 # Set up the development environment
 install:
    bash .evergreen/scripts/setup-dev-env.sh
@@ -70,7 +66,7 @@ lint-manual *args="": && resync
 
 # Run pytest (e.g. just test test/test_uri_parser.py)
 [group('test')]
-test *args="-v --durations=5 --maxfail=10": run-synchro && resync
+test *args="-v --durations=5 --maxfail=10": && resync
     #!/usr/bin/env bash
     set -euo pipefail
     uv run ${USE_ACTIVE_VENV:+--active} --extra test python -m pytest {{args}}
@@ -83,7 +79,7 @@ test-numpy *args="": && resync
 
 # Run tests via the Evergreen test runner script
 [group('test')]
-run-tests *args: run-synchro && resync
+run-tests *args: && resync
     bash ./.evergreen/run-tests.sh {{args}}
 
 # Set up the test environment (auth, TLS, etc.)


### PR DESCRIPTION
[PYTHON-5890](https://jira.mongodb.org/browse/PYTHON-5890)

## Changes in this PR

Removes the `run-synchro` recipe from the `justfile` (introduced in #2887) and its use as a pre-dependency on `just test` and `just run-tests`. When invoked this way, synchro runs on all async files unconditionally — if any of those files have linting issues or are in a partially-edited state, the run fails before tests even start. Synchro already runs automatically via the pre-commit hook on commit, scoped to only the files being staged.

## Test Plan

CI passes. Locally, `just test` and `just run-tests` no longer trigger synchro.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s).  [PYTHON-5895 - Run synchro on changed async files when running tests](https://jira.mongodb.org/browse/PYTHON-5895)

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?