### PR TITLE
PYTHON-5911 - Mark test.test_server_selection_in_window.TestProse.tes…

### DIFF
--- a/test/asynchronous/test_server_selection_in_window.py
+++ b/test/asynchronous/test_server_selection_in_window.py
@@ -29,6 +29,7 @@ from pymongo.operations import _Op
 from pymongo.read_preferences import ReadPreference
 from test.asynchronous import AsyncIntegrationTest, async_client_context, unittest
 from test.asynchronous.helpers import ConcurrentRunner
+from test.asynchronous.utils import flaky
 from test.asynchronous.utils_selection_tests import create_topology
 from test.asynchronous.utils_spec_runner import AsyncSpecTestCreator
 from test.utils_shared import (
@@ -144,6 +145,7 @@ class TestProse(AsyncIntegrationTest):
         sys.platform == "darwin" and platform.machine() == "arm64" and "CI" in os.environ,
         "PYTHON-5861: Load balancing frequency assertion is timing-sensitive on macOS ARM64 CI",
     )
+    @flaky(reason="PYTHON-5911", affects_cpython_linux=True)
     async def test_load_balancing(self):
         listener = OvertCommandListener()
         cmap_listener = CMAPListener()

--- a/test/test_server_selection_in_window.py
+++ b/test/test_server_selection_in_window.py
@@ -29,6 +29,7 @@ from pymongo.operations import _Op
 from pymongo.read_preferences import ReadPreference
 from test import IntegrationTest, client_context, unittest
 from test.helpers import ConcurrentRunner
+from test.utils import flaky
 from test.utils_selection_tests import create_topology
 from test.utils_shared import (
     CMAPListener,
@@ -144,6 +145,7 @@ class TestProse(IntegrationTest):
         sys.platform == "darwin" and platform.machine() == "arm64" and "CI" in os.environ,
         "PYTHON-5861: Load balancing frequency assertion is timing-sensitive on macOS ARM64 CI",
     )
+    @flaky(reason="PYTHON-5911", affects_cpython_linux=True)
     def test_load_balancing(self):
         listener = OvertCommandListener()
         cmap_listener = CMAPListener()


### PR DESCRIPTION
…t_load_balancing as flaky again

<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
[JIRA TICKET]: Issue Title

If you are an external contributor and there is no JIRA ticket associated with your change, then use your best judgement
for the PR title. A MongoDB employee will create a JIRA ticket and edit the name and links as appropriate.

Note on AI Contributions:
We only accept pull requests that are authored and submitted by human contributors who fully understand the changes they are proposing.
All contributions must be written and understood by human contributors. Please read about our policy in our contributing guide.
-->
[PYTHON-5911](https://jira.mongodb.org/browse/PYTHON-5911)

## Changes in this PR
<!-- What changes did you make to the code? What new APIs (public or private) were added, removed, or edited to generate
the desired outcome explained in the above summary? -->
The fixes in [PYTHON-3689](https://jira.mongodb.org/browse/PYTHON-3689) did not make the test completely deterministic. Re-adds the `@flaky` decorator to the test in question.

## Test Plan
<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why.
All code should be tested in some way – so please list what your validation strategy was. -->
Test change only.

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- ~[ ] Did you update the changelog (if necessary)?~
- [X] Is there test coverage?
- ~[ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).~

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
