### PR TITLE
PYTHON-5917 Fix document_class generic alias check on PyPy

### DIFF
--- a/bson/codec_options.py
+++ b/bson/codec_options.py
@@ -377,14 +377,16 @@ else:
             datetime_conversion: Optional[DatetimeConversion] = DatetimeConversion.DATETIME,
         ) -> CodecOptions:
             doc_class = document_class or dict
-            # issubclass can raise TypeError for generic aliases like SON[str, Any].
-            # In that case we can use the base class for the comparison.
-            is_mapping = False
+            # Generic aliases like SON[str, Any] or dict[str, Any] aren't classes, so
+            # resolve to their origin before the subclass check. Whether issubclass()
+            # raises TypeError or just returns False for such aliases is inconsistent
+            # across Python implementations (e.g. PyPy vs CPython), so check the
+            # origin proactively instead of relying on catching the error.
+            check_class = getattr(doc_class, "__origin__", doc_class)
             try:
-                is_mapping = issubclass(doc_class, _MutableMapping)
+                is_mapping = issubclass(check_class, _MutableMapping)
             except TypeError:
-                if hasattr(doc_class, "__origin__"):
-                    is_mapping = issubclass(doc_class.__origin__, _MutableMapping)
+                is_mapping = False
             if not (is_mapping or _raw_document_class(doc_class)):
                 raise TypeError(
                     "document_class must be dict, bson.son.SON, "

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -482,14 +482,16 @@ def validate_document_class(
     option: str, value: Any
 ) -> Union[type[MutableMapping[str, Any]], type[RawBSONDocument]]:
     """Validate the document_class option."""
-    # issubclass can raise TypeError for generic aliases like SON[str, Any].
-    # In that case we can use the base class for the comparison.
-    is_mapping = False
+    # Generic aliases like SON[str, Any] or dict[str, Any] aren't classes, so
+    # resolve to their origin before the subclass check. Whether issubclass()
+    # raises TypeError or just returns False for such aliases is inconsistent
+    # across Python implementations (e.g. PyPy vs CPython), so check the
+    # origin proactively instead of relying on catching the error.
+    check_class = getattr(value, "__origin__", value)
     try:
-        is_mapping = issubclass(value, abc.MutableMapping)
+        is_mapping = issubclass(check_class, abc.MutableMapping)
     except TypeError:
-        if hasattr(value, "__origin__"):
-            is_mapping = issubclass(value.__origin__, abc.MutableMapping)
+        is_mapping = False
     if not is_mapping and not issubclass(value, RawBSONDocument):
         raise TypeError(
             f"{option} must be dict, bson.son.SON, "


### PR DESCRIPTION
[PYTHON-5917](https://jira.mongodb.org/browse/PYTHON-5917)

## Changes in this PR
Fixes a PyPy-only failure when validating a parameterized generic `document_class` (e.g. `dict[str, Any]`, `SON[str, Any]`).

Passing build: https://spruce.corp.mongodb.com/version/6a4bd47a30181800078c2ed7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

## Test Plan
Covered by existing unit tests exercising generic `document_class` values; verified passing on PyPy via the Evergreen patch linked above.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?