### PR TITLE
PYTHON-5925 Fix flaky SRV polling monitor tests

### DIFF
--- a/test/asynchronous/test_srv_polling.py
+++ b/test/asynchronous/test_srv_polling.py
@@ -21,7 +21,6 @@ import sys
 import time
 from typing import Any
 
-from test.asynchronous.utils import flaky
 from test.utils_shared import FunctionCallRecorder
 
 sys.path[0:0] = [""]
@@ -226,7 +225,6 @@ class TestSrvPolling(AsyncPyMongoTestCase):
 
             await self.run_scenario(response_callback, False)
 
-    @flaky(reason="PYTHON-5500", max_runs=3)
     async def test_dns_failures_logging(self):
         from dns import exception
 
@@ -237,8 +235,13 @@ class TestSrvPolling(AsyncPyMongoTestCase):
 
             await self.run_scenario(response_callback, False)
 
+            await async_wait_until(
+                lambda: any("SRV monitor check failed" in r.getMessage() for r in cm.records),
+                "log the SRV monitor check failure",
+            )
+
         srv_failure_logs = [r for r in cm.records if "SRV monitor check failed" in r.getMessage()]
-        self.assertEqual(len(srv_failure_logs), 1)
+        self.assertGreaterEqual(len(srv_failure_logs), 1)
 
     async def test_dns_record_lookup_empty(self):
         response: list = []
@@ -270,14 +273,12 @@ class TestSrvPolling(AsyncPyMongoTestCase):
             # Nodelist should reflect new valid DNS resolver response.
             await self.assert_nodelist_change(response_final, client)
 
-    @flaky(reason="PYTHON-5315")
     async def test_recover_from_initially_empty_seedlist(self):
         def empty_seedlist():
             return []
 
         await self._test_recover_from_initial(empty_seedlist)
 
-    @flaky(reason="PYTHON-5315")
     async def test_recover_from_initially_erroring_seedlist(self):
         def erroring_seedlist():
             raise ConfigurationError

--- a/test/asynchronous/test_srv_polling.py
+++ b/test/asynchronous/test_srv_polling.py
@@ -240,9 +240,6 @@ class TestSrvPolling(AsyncPyMongoTestCase):
                 "log the SRV monitor check failure",
             )
 
-        srv_failure_logs = [r for r in cm.records if "SRV monitor check failed" in r.getMessage()]
-        self.assertGreaterEqual(len(srv_failure_logs), 1)
-
     async def test_dns_record_lookup_empty(self):
         response: list = []
         await self.run_scenario(response, False)

--- a/test/test_srv_polling.py
+++ b/test/test_srv_polling.py
@@ -240,9 +240,6 @@ class TestSrvPolling(PyMongoTestCase):
                 "log the SRV monitor check failure",
             )
 
-        srv_failure_logs = [r for r in cm.records if "SRV monitor check failed" in r.getMessage()]
-        self.assertGreaterEqual(len(srv_failure_logs), 1)
-
     def test_dns_record_lookup_empty(self):
         response: list = []
         self.run_scenario(response, False)

--- a/test/test_srv_polling.py
+++ b/test/test_srv_polling.py
@@ -21,7 +21,6 @@ import sys
 import time
 from typing import Any
 
-from test.utils import flaky
 from test.utils_shared import FunctionCallRecorder
 
 sys.path[0:0] = [""]
@@ -226,7 +225,6 @@ class TestSrvPolling(PyMongoTestCase):
 
             self.run_scenario(response_callback, False)
 
-    @flaky(reason="PYTHON-5500", max_runs=3)
     def test_dns_failures_logging(self):
         from dns import exception
 
@@ -237,8 +235,13 @@ class TestSrvPolling(PyMongoTestCase):
 
             self.run_scenario(response_callback, False)
 
+            wait_until(
+                lambda: any("SRV monitor check failed" in r.getMessage() for r in cm.records),
+                "log the SRV monitor check failure",
+            )
+
         srv_failure_logs = [r for r in cm.records if "SRV monitor check failed" in r.getMessage()]
-        self.assertEqual(len(srv_failure_logs), 1)
+        self.assertGreaterEqual(len(srv_failure_logs), 1)
 
     def test_dns_record_lookup_empty(self):
         response: list = []
@@ -270,14 +273,12 @@ class TestSrvPolling(PyMongoTestCase):
             # Nodelist should reflect new valid DNS resolver response.
             self.assert_nodelist_change(response_final, client)
 
-    @flaky(reason="PYTHON-5315")
     def test_recover_from_initially_empty_seedlist(self):
         def empty_seedlist():
             return []
 
         self._test_recover_from_initial(empty_seedlist)
 
-    @flaky(reason="PYTHON-5315")
     def test_recover_from_initially_erroring_seedlist(self):
         def erroring_seedlist():
             raise ConfigurationError

--- a/test/utils_shared.py
+++ b/test/utils_shared.py
@@ -338,7 +338,14 @@ class CompareType:
 
 
 class FunctionCallRecorder:
-    """Utility class to wrap a callable and record its invocations."""
+    """Utility class to wrap a callable and record its invocations.
+
+    A synchronous callable is recorded immediately, before it runs. A
+    coroutine function is recorded only once the returned coroutine
+    finishes running, whether it returns, raises, or is cancelled, so
+    callers can rely on a recorded call meaning the wrapped coroutine
+    actually ran rather than merely having been scheduled.
+    """
 
     def __init__(self, function):
         self._function = function

--- a/test/utils_shared.py
+++ b/test/utils_shared.py
@@ -345,11 +345,23 @@ class FunctionCallRecorder:
         self._call_list = []
 
     def __call__(self, *args, **kwargs):
-        self._call_list.append((args, kwargs))
         if iscoroutinefunction(self._function):
-            return self._function(*args, **kwargs)
+
+            async def _run_and_record():
+                try:
+                    return await self._function(*args, **kwargs)
+                finally:
+                    self._call_list.append((args, kwargs))
+
+            return _run_and_record()
         else:
+            self._call_list.append((args, kwargs))
             return self._function(*args, **kwargs)
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return functools.partial(self, obj)
 
     def reset(self):
         """Wipes the call list."""


### PR DESCRIPTION
[PYTHON-5925](https://jira.mongodb.org/browse/PYTHON-5925)

## Changes in this PR
Fixes the flakiness in `test_dns_failures_logging`. Also removes the now-unnecessary `@flaky` markers for [PYTHON-5315](https://jira.mongodb.org/browse/PYTHON-5315) on the SRV seedlist recovery tests, since the underlying test-harness race conditions are resolved.

## Test Plan
Verified locally (repeated runs) and Evergreen patch builds, including a [full-matrix confirmation run](https://spruce.corp.mongodb.com/version/6a50014b5439b20007a5c7c7) targeting the previously-failing variants (win32/win64/pyopenssl-win64/etc.). The remaining failures there are pre-existing and unrelated to this change.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?