### PR TITLE
PYTHON-5924 Remove TestPyPI upload from release

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -79,12 +79,6 @@ jobs:
         with:
           name: all-dist-${{ github.run_id }}
           path: dist/
-      - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-          attestations: ${{ env.DRY_RUN }}
       - name: Publish package distributions to PyPI
         if: startsWith(env.DRY_RUN, 'false')
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -58,7 +58,7 @@ jobs:
           uvx --from 'validate-pyproject[all]' validate-pyproject pyproject.toml
       - name: Check package metadata
         run: |
-          uv build --sdist
+          uv build
           uvx twine check --strict dist/*
       - run: |
           sudo apt-get install -y cppcheck

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -53,6 +53,13 @@ jobs:
       - name: Run synchro smoke test
         run: |
           uv run --extra test --with unasync pytest tools/test_synchro.py -v --override-ini="addopts="
+      - name: Validate pyproject.toml
+        run: |
+          uvx validate-pyproject pyproject.toml
+      - name: Check package metadata
+        run: |
+          uv build --sdist
+          uvx twine check --strict dist/*
       - run: |
           sudo apt-get install -y cppcheck
       - run: |

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -55,7 +55,7 @@ jobs:
           uv run --extra test --with unasync pytest tools/test_synchro.py -v --override-ini="addopts="
       - name: Validate pyproject.toml
         run: |
-          uvx validate-pyproject pyproject.toml
+          uvx --from 'validate-pyproject[all]' validate-pyproject pyproject.toml
       - name: Check package metadata
         run: |
           uv build --sdist


### PR DESCRIPTION
[PYTHON-5924](https://jira.mongodb.org/browse/PYTHON-5924)

## Changes in this PR
Removes the TestPyPI upload step from the release workflow, which has started failing due to a PyPI policy change. Adds package metadata validation to the static CI job to help cover the gap.

## Test Plan
Verified the new checks pass locally; relying on CI for the workflow changes themselves.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?