### PR TITLE
PYTHON-5931 PYTHON-5935 Fix auth-aws-ecs and kms test failures

### DIFF
--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -25,6 +25,9 @@ apt-get -q install -y build-essential
 
 export SET_XTRACE_ON=1
 export CI=true
+# Install from the uv.lock generated on the host (which has git); this
+# container doesn't, so it must not try to resolve mockupdb itself.
+export UV_FROZEN=1
 cd src
 rm -rf .venv
 rm -f .evergreen/scripts/test-env.sh || true

--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -25,9 +25,9 @@ apt-get -q install -y build-essential
 
 export SET_XTRACE_ON=1
 export CI=true
-# Install from the uv.lock generated on the host (which has git); this
-# container doesn't, so it must not try to resolve mockupdb itself.
-export UV_FROZEN=1
+# This container has no git, so uv must never try to resolve the mockupdb
+# git dependency; UV_NO_LOCK makes uv ignore any lock file entirely.
+export UV_NO_LOCK=1
 cd src
 rm -rf .venv
 rm -f .evergreen/scripts/test-env.sh || true

--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -21,7 +21,7 @@ set -o xtrace
 
 # Install a c compiler.
 apt-get -qq update  < /dev/null > /dev/null
-apt-get -q install -y build-essential
+apt-get -q install -y build-essential git
 
 export SET_XTRACE_ON=1
 cd src

--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -21,9 +21,10 @@ set -o xtrace
 
 # Install a c compiler.
 apt-get -qq update  < /dev/null > /dev/null
-apt-get -q install -y build-essential git
+apt-get -q install -y build-essential
 
 export SET_XTRACE_ON=1
+export CI=true
 cd src
 rm -rf .venv
 rm -f .evergreen/scripts/test-env.sh || true

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -27,7 +27,11 @@ else
 fi
 
 # Start the test runner.
-export UV_NO_LOCK=1
+# UV_FROZEN means a uv.lock was already generated where git is available
+# (e.g. for the ecs remote host); don't fight it by disabling lock usage.
+if [ -z "${UV_FROZEN:-}" ]; then
+  export UV_NO_LOCK=1
+fi
 echo "Running tests with UV_PYTHON=${UV_PYTHON:-}..."
 echo "UV_ARGS=${UV_ARGS}"
 uv run ${UV_ARGS} --reinstall-package pymongo .evergreen/scripts/run_tests.py "$@"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -28,8 +28,6 @@ fi
 
 # Start the test runner.
 export UV_NO_LOCK=1
-# GNU date on Linux and Windows, BSD date on macOS.
-export UV_EXCLUDE_NEWER="${UV_EXCLUDE_NEWER:-$(date -u -d '7 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-7d +%Y-%m-%d)}"
 echo "Running tests with UV_PYTHON=${UV_PYTHON:-}..."
 echo "UV_ARGS=${UV_ARGS}"
 uv run ${UV_ARGS} --reinstall-package pymongo .evergreen/scripts/run_tests.py "$@"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -27,11 +27,8 @@ else
 fi
 
 # Start the test runner.
-# UV_FROZEN means a uv.lock was already generated where git is available
-# (e.g. for the ecs remote host); don't fight it by disabling lock usage.
-if [ -z "${UV_FROZEN:-}" ]; then
-  export UV_NO_LOCK=1
-fi
+# Never create or read a uv.lock; hosts without git can't resolve mockupdb.
+export UV_NO_LOCK=1
 echo "Running tests with UV_PYTHON=${UV_PYTHON:-}..."
 echo "UV_ARGS=${UV_ARGS}"
 uv run ${UV_ARGS} --reinstall-package pymongo .evergreen/scripts/run_tests.py "$@"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -27,6 +27,9 @@ else
 fi
 
 # Start the test runner.
+export UV_NO_LOCK=1
+# GNU date on Linux and Windows, BSD date on macOS.
+export UV_EXCLUDE_NEWER="${UV_EXCLUDE_NEWER:-$(date -u -d '7 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-7d +%Y-%m-%d)}"
 echo "Running tests with UV_PYTHON=${UV_PYTHON:-}..."
 echo "UV_ARGS=${UV_ARGS}"
 uv run ${UV_ARGS} --reinstall-package pymongo .evergreen/scripts/run_tests.py "$@"

--- a/.evergreen/scripts/configure-env.sh
+++ b/.evergreen/scripts/configure-env.sh
@@ -18,12 +18,6 @@ UV_TOOL_DIR=$PROJECT_DIRECTORY/.local/uv/tools
 UV_CACHE_DIR=$PROJECT_DIRECTORY/.local/uv/cache
 DRIVERS_TOOLS_BINARIES="$DRIVERS_TOOLS/.bin"
 MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"
-# GNU date on Linux and Windows, BSD date on macOS.
-UV_EXCLUDE_NEWER="$(date -u -d '7 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-7d +%Y-%m-%d)"
-if [ -z "$UV_EXCLUDE_NEWER" ]; then
-  echo "Failed to compute UV_EXCLUDE_NEWER" >&2
-  exit 1
-fi
 
 # On Evergreen jobs, "CI" will be set, and we don't want to write to $HOME.
 if [ "${CI:-}" == "true" ]; then
@@ -72,7 +66,6 @@ export UV_TOOL_DIR="$UV_TOOL_DIR"
 export UV_CACHE_DIR="$UV_CACHE_DIR"
 export UV_TOOL_BIN_DIR="$DRIVERS_TOOLS_BINARIES"
 export UV_NO_LOCK=1
-export UV_EXCLUDE_NEWER="$UV_EXCLUDE_NEWER"
 export PYMONGO_BIN_DIR="$PYMONGO_BIN_DIR"
 export PATH="$PATH_EXT"
 # shellcheck disable=SC2154

--- a/.evergreen/scripts/kms_tester.py
+++ b/.evergreen/scripts/kms_tester.py
@@ -33,7 +33,7 @@ def _setup_azure_vm(base_env: dict[str, str]) -> None:
     env["AZUREKMS_CMD"] = "sudo apt-get install -y python3-dev build-essential"
     run_command(f"{azure_dir}/run-command.sh", env=env)
 
-    env["AZUREKMS_CMD"] = "bash .evergreen/just.sh setup-tests kms azure-remote"
+    env["AZUREKMS_CMD"] = "CI=true bash .evergreen/just.sh setup-tests kms azure-remote"
     run_command(f"{azure_dir}/run-command.sh", env=env)
     LOGGER.info("Setting up Azure VM... done.")
 
@@ -53,7 +53,7 @@ def _setup_gcp_vm(base_env: dict[str, str]) -> None:
     env["GCPKMS_CMD"] = "sudo apt-get install -y python3-dev build-essential"
     run_command(f"{gcp_dir}/run-command.sh", env=env)
 
-    env["GCPKMS_CMD"] = "bash ./.evergreen/just.sh setup-tests kms gcp-remote"
+    env["GCPKMS_CMD"] = "CI=true bash ./.evergreen/just.sh setup-tests kms gcp-remote"
     run_command(f"{gcp_dir}/run-command.sh", env=env)
     LOGGER.info("Setting up GCP VM...")
 
@@ -128,10 +128,10 @@ def test_kms_send_to_remote(sub_test_name: str) -> None:
         key_name = os.environ["KEY_NAME"]
         key_vault_endpoint = os.environ["KEY_VAULT_ENDPOINT"]
         env["AZUREKMS_CMD"] = (
-            f'KEY_NAME="{key_name}" KEY_VAULT_ENDPOINT="{key_vault_endpoint}" bash ./.evergreen/just.sh run-tests'
+            f'KEY_NAME="{key_name}" KEY_VAULT_ENDPOINT="{key_vault_endpoint}" CI=true bash ./.evergreen/just.sh run-tests'
         )
     else:
-        env["GCPKMS_CMD"] = "./.evergreen/just.sh run-tests"
+        env["GCPKMS_CMD"] = "CI=true ./.evergreen/just.sh run-tests"
     cmd = f"{DIRS[sub_test_name]}/run-command.sh"
     run_command(cmd, env=env)
 

--- a/.evergreen/scripts/kms_tester.py
+++ b/.evergreen/scripts/kms_tester.py
@@ -33,7 +33,9 @@ def _setup_azure_vm(base_env: dict[str, str]) -> None:
     env["AZUREKMS_CMD"] = "sudo apt-get install -y python3-dev build-essential"
     run_command(f"{azure_dir}/run-command.sh", env=env)
 
-    env["AZUREKMS_CMD"] = "CI=true bash .evergreen/just.sh setup-tests kms azure-remote"
+    env["AZUREKMS_CMD"] = (
+        "CI=true UV_NO_LOCK=1 bash .evergreen/just.sh setup-tests kms azure-remote"
+    )
     run_command(f"{azure_dir}/run-command.sh", env=env)
     LOGGER.info("Setting up Azure VM... done.")
 
@@ -53,7 +55,7 @@ def _setup_gcp_vm(base_env: dict[str, str]) -> None:
     env["GCPKMS_CMD"] = "sudo apt-get install -y python3-dev build-essential"
     run_command(f"{gcp_dir}/run-command.sh", env=env)
 
-    env["GCPKMS_CMD"] = "CI=true bash ./.evergreen/just.sh setup-tests kms gcp-remote"
+    env["GCPKMS_CMD"] = "CI=true UV_NO_LOCK=1 bash ./.evergreen/just.sh setup-tests kms gcp-remote"
     run_command(f"{gcp_dir}/run-command.sh", env=env)
     LOGGER.info("Setting up GCP VM...")
 
@@ -128,10 +130,10 @@ def test_kms_send_to_remote(sub_test_name: str) -> None:
         key_name = os.environ["KEY_NAME"]
         key_vault_endpoint = os.environ["KEY_VAULT_ENDPOINT"]
         env["AZUREKMS_CMD"] = (
-            f'KEY_NAME="{key_name}" KEY_VAULT_ENDPOINT="{key_vault_endpoint}" CI=true bash ./.evergreen/just.sh run-tests'
+            f'KEY_NAME="{key_name}" KEY_VAULT_ENDPOINT="{key_vault_endpoint}" CI=true UV_NO_LOCK=1 bash ./.evergreen/just.sh run-tests'
         )
     else:
-        env["GCPKMS_CMD"] = "CI=true ./.evergreen/just.sh run-tests"
+        env["GCPKMS_CMD"] = "CI=true UV_NO_LOCK=1 ./.evergreen/just.sh run-tests"
     cmd = f"{DIRS[sub_test_name]}/run-command.sh"
     run_command(cmd, env=env)
 

--- a/.evergreen/scripts/run_tests.py
+++ b/.evergreen/scripts/run_tests.py
@@ -182,6 +182,10 @@ def run() -> None:
 
     # Send ecs tests to run remotely.
     if TEST_NAME == "auth_aws" and SUB_TEST_NAME == "ecs":
+        # Lock dependencies here, where git is available, so the ecs
+        # container (which has no git) can install from the lock frozen,
+        # without needing to resolve mockupdb's git dependency itself.
+        run_command("uv lock", cwd=ROOT)
         run_command(f"{DRIVERS_TOOLS}/.evergreen/auth_aws/aws_setup.sh ecs")
         return
 

--- a/.evergreen/scripts/run_tests.py
+++ b/.evergreen/scripts/run_tests.py
@@ -182,10 +182,6 @@ def run() -> None:
 
     # Send ecs tests to run remotely.
     if TEST_NAME == "auth_aws" and SUB_TEST_NAME == "ecs":
-        # Lock dependencies here, where git is available, so the ecs
-        # container (which has no git) can install from the lock frozen,
-        # without needing to resolve mockupdb's git dependency itself.
-        run_command("uv lock", cwd=ROOT)
         run_command(f"{DRIVERS_TOOLS}/.evergreen/auth_aws/aws_setup.sh ecs")
         return
 

--- a/.evergreen/scripts/setup-dev-env.sh
+++ b/.evergreen/scripts/setup-dev-env.sh
@@ -22,13 +22,13 @@ fi
 # Ensure dependencies are installed.
 bash $HERE/install-dependencies.sh
 
+# Add the default install path to the path if needed.
+if [ -z "${PYMONGO_BIN_DIR:-}" ]; then
+  export PATH="$PATH:$HOME/.local/bin"
+fi
+
 # Only run the next part if not running on CI.
 if [ -z "${CI:-}" ]; then
-  # Add the default install path to the path if needed.
-  if [ -z "${PYMONGO_BIN_DIR:-}" ]; then
-    export PATH="$PATH:$HOME/.local/bin"
-  fi
-
   # Set up venv, making sure c extensions build unless disabled.
   if [ -z "${NO_EXT:-}" ]; then
     export PYMONGO_C_EXT_MUST_BUILD=1

--- a/.evergreen/scripts/setup-tests.sh
+++ b/.evergreen/scripts/setup-tests.sh
@@ -21,11 +21,8 @@ if [ -f $SCRIPT_DIR/env.sh ]; then
   source $SCRIPT_DIR/env.sh
 fi
 
-# UV_FROZEN means a uv.lock was already generated where git is available
-# (e.g. for the ecs remote host); don't fight it by disabling lock usage.
-if [ -z "${UV_FROZEN:-}" ]; then
-  export UV_NO_LOCK=1
-fi
+# Never create or read a uv.lock; hosts without git can't resolve mockupdb.
+export UV_NO_LOCK=1
 
 echo "Setting up tests with args \"$*\"..."
 uv run ${USE_ACTIVE_VENV:+--active} "$SCRIPT_DIR/setup_tests.py" "$@"

--- a/.evergreen/scripts/setup-tests.sh
+++ b/.evergreen/scripts/setup-tests.sh
@@ -22,8 +22,6 @@ if [ -f $SCRIPT_DIR/env.sh ]; then
 fi
 
 export UV_NO_LOCK=1
-# GNU date on Linux and Windows, BSD date on macOS.
-export UV_EXCLUDE_NEWER="${UV_EXCLUDE_NEWER:-$(date -u -d '7 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-7d +%Y-%m-%d)}"
 
 echo "Setting up tests with args \"$*\"..."
 uv run ${USE_ACTIVE_VENV:+--active} "$SCRIPT_DIR/setup_tests.py" "$@"

--- a/.evergreen/scripts/setup-tests.sh
+++ b/.evergreen/scripts/setup-tests.sh
@@ -21,7 +21,11 @@ if [ -f $SCRIPT_DIR/env.sh ]; then
   source $SCRIPT_DIR/env.sh
 fi
 
-export UV_NO_LOCK=1
+# UV_FROZEN means a uv.lock was already generated where git is available
+# (e.g. for the ecs remote host); don't fight it by disabling lock usage.
+if [ -z "${UV_FROZEN:-}" ]; then
+  export UV_NO_LOCK=1
+fi
 
 echo "Setting up tests with args \"$*\"..."
 uv run ${USE_ACTIVE_VENV:+--active} "$SCRIPT_DIR/setup_tests.py" "$@"

--- a/.evergreen/scripts/setup-tests.sh
+++ b/.evergreen/scripts/setup-tests.sh
@@ -21,6 +21,10 @@ if [ -f $SCRIPT_DIR/env.sh ]; then
   source $SCRIPT_DIR/env.sh
 fi
 
+export UV_NO_LOCK=1
+# GNU date on Linux and Windows, BSD date on macOS.
+export UV_EXCLUDE_NEWER="${UV_EXCLUDE_NEWER:-$(date -u -d '7 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-7d +%Y-%m-%d)}"
+
 echo "Setting up tests with args \"$*\"..."
 uv run ${USE_ACTIVE_VENV:+--active} "$SCRIPT_DIR/setup_tests.py" "$@"
 echo "Setting up tests with args \"$*\"... done."

--- a/justfile
+++ b/justfile
@@ -3,9 +3,6 @@ set shell := ["bash", "-c"]
 
 # Don't let `uv` create or read uv.lock.
 export UV_NO_LOCK := "1"
-# Match CI's resolution window so local installs agree.
-# GNU date on Linux and Windows, BSD date on macOS.
-export UV_EXCLUDE_NEWER := `date -u -d '7 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-7d +%Y-%m-%d`
 
 # Commonly used command segments.
 typing_run := "uv run --group typing --extra aws --extra encryption --with numpy --extra ocsp --extra snappy --extra test --extra zstd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ Tracker = "https://jira.mongodb.org/projects/PYTHON/issues"
 # Only sync the (empty) dev group by default; groups like mockupdb require
 # an explicit --group flag so hosts without git aren't forced to resolve it.
 default-groups = ["dev"]
+# Wait 7 days before resolving newly published package versions.
+exclude-newer = "7 days"
 
 [dependency-groups]
 dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ Documentation = "https://www.mongodb.com/docs/languages/python/pymongo-driver/cu
 Source = "https://github.com/mongodb/mongo-python-driver"
 Tracker = "https://jira.mongodb.org/projects/PYTHON/issues"
 
+[tool.uv]
+# Only sync the (empty) dev group by default; groups like mockupdb require
+# an explicit --group flag so hosts without git aren't forced to resolve it.
+default-groups = ["dev"]
+
 [dependency-groups]
 dev = []
 lint = [


### PR DESCRIPTION
[PYTHON-5931](https://jira.mongodb.org/browse/PYTHON-5931) / [PYTHON-5935](https://jira.mongodb.org/browse/PYTHON-5935)

## Changes in this PR
Fixes the auth-aws-ecs and kms (Azure/GCP) Evergreen tests, which were both failing on their remote/ephemeral test hosts.

## Test Plan
Verified with a passing Evergreen patch covering all affected tasks (test-auth-aws-ecs, test-gcpkms, test-azurekms, and the auth_oidc remote variants): https://spruce.corp.mongodb.com/patch/6a518b361480fd00075f1a1d

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?