### PR TITLE
PYTHON-5727 Add tests for __main__ blocks

### DIFF
--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -706,8 +706,9 @@ class TestMainBlock(unittest.TestCase):
             timeout=15,
         )
         self.assertEqual(0, result.returncode)
-        self.assertIn("localhost", result.stdout)
-        self.assertIn("mydb", result.stdout)
+        # Assert on the pretty-printed dict structure, not bare substrings.
+        self.assertRegex(result.stdout, r"'database': 'mydb'")
+        self.assertRegex(result.stdout, r"'nodelist': \[\('localhost', 27017\)\]")
 
     def test_invalid_uri_prints_error(self):
         # An invalid URI is caught and its message printed, still exiting 0.

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import copy
+import subprocess
 import sys
 import warnings
 from typing import Any
@@ -693,6 +694,31 @@ class TestURI(unittest.TestCase):
                 parse_uri,
                 "mongodb+srv://host1.example.com",
             )
+
+
+class TestMainBlock(unittest.TestCase):
+    def test_valid_uri_prints_parsed_dict(self):
+        # Run uri_parser.py as a script; a valid URI is pretty-printed.
+        result = subprocess.run(
+            [sys.executable, "-m", "pymongo.uri_parser", "mongodb://localhost:27017/mydb"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        self.assertEqual(0, result.returncode)
+        self.assertIn("localhost", result.stdout)
+        self.assertIn("mydb", result.stdout)
+
+    def test_invalid_uri_prints_error(self):
+        # An invalid URI is caught and its message printed, still exiting 0.
+        result = subprocess.run(
+            [sys.executable, "-m", "pymongo.uri_parser", "not-a-valid-uri"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        self.assertEqual(0, result.returncode)
+        self.assertIn("Invalid URI scheme", result.stdout)
 
 
 if __name__ == "__main__":

--- a/test/test_uri_parser.py
+++ b/test/test_uri_parser.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import ast
 import copy
 import subprocess
 import sys
@@ -706,9 +707,11 @@ class TestMainBlock(unittest.TestCase):
             timeout=15,
         )
         self.assertEqual(0, result.returncode)
-        # Assert on the pretty-printed dict structure, not bare substrings.
-        self.assertRegex(result.stdout, r"'database': 'mydb'")
-        self.assertRegex(result.stdout, r"'nodelist': \[\('localhost', 27017\)\]")
+        # The output is a valid Python literal; parse it and assert on values
+        # rather than the formatting of the pretty-printed text.
+        parsed = ast.literal_eval(result.stdout)
+        self.assertEqual("mydb", parsed["database"])
+        self.assertEqual([("localhost", 27017)], parsed["nodelist"])
 
     def test_invalid_uri_prints_error(self):
         # An invalid URI is caught and its message printed, still exiting 0.


### PR DESCRIPTION
[PYTHON-5727](https://jira.mongodb.org/browse/PYTHON-5727)

## Changes in this PR
Adds test coverage for the previously untested `__main__` block in `pymongo/uri_parser.py`.

A new `TestMainBlock` class in `test/test_uri_parser.py` launches the module as a script via `subprocess` (`python -m pymongo.uri_parser <uri>`) and covers both branches:
- a valid URI is parsed and pretty-printed to stdout
- an invalid URI is caught and its error message printed


## Test Plan
- `python -m pytest test/test_uri_parser.py::TestMainBlock test/test_daemon.py::TestMainBlock -v` passes.
- Both cases assert a clean (`0`) exit code.
- The new tests exercise the `__main__` block end-to-end through a real subprocess so `coverage.py` subprocess measurement will capture it.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)? N/A — test-only change.
- [x] Is there test coverage?
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s). N/A

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
