### PR TITLE
PYTHON-5906 Raise ProtocolError for malformed OP_COMPRESSED messages in sync receive_message

### DIFF
--- a/pymongo/network_layer.py
+++ b/pymongo/network_layer.py
@@ -775,6 +775,10 @@ def receive_message(
         )
     data: memoryview | bytes
     if op_code == 2012:
+        if length <= 25:
+            raise ProtocolError(
+                f"Message length ({length!r}) not longer than standard OP_COMPRESSED message header size (25)"
+            )
         op_code, _, compressor_id = _UNPACK_COMPRESSION_HEADER(receive_data(conn, 9, deadline))
         data = decompress(receive_data(conn, length - 25, deadline), compressor_id)
     else:

--- a/test/test_network_layer.py
+++ b/test/test_network_layer.py
@@ -80,6 +80,21 @@ class TestReceiveMessage(UnitTest):
         with self.assertRaisesRegex(ProtocolError, "larger than server max"):
             network_layer.receive_message(conn, request_id=None)
 
+    def test_compressed_length_too_small_raises(self):
+        # An OP_COMPRESSED frame with 16 < length <= 25 is malformed: it lacks
+        # room for the 9-byte compression sub-header plus payload. It must raise
+        # ProtocolError (not ValueError from a negative receive_data count).
+        for length in (17, 24, 25):
+            conn = _make_conn()
+            _mock_recv_into(
+                conn,
+                pack_msg_header(length=length, request_id=0, response_to=0, op_code=2012),
+            )
+            with self.assertRaisesRegex(
+                ProtocolError, "not longer than standard OP_COMPRESSED message header"
+            ):
+                network_layer.receive_message(conn, request_id=None)
+
     def test_unknown_opcode_raises(self):
         conn = _make_conn()
         _mock_recv_into(


### PR DESCRIPTION
[PYTHON-5906](https://jira.mongodb.org/browse/PYTHON-5906)

## Changes in this PR
The sync `receive_message` in `pymongo/network_layer.py` was missing the OP_COMPRESSED minimum-length guard that exists in the async `PyMongoProtocol.process_header`. For a malformed OP_COMPRESSED frame with `16 < length <= 24`, `length - 25` is negative, so `receive_data` calls `bytearray(negative)` and raises `ValueError` instead of `ProtocolError`; for `length == 25`, `decompress` was called on 0 bytes.

Added the same guard before entering the `op_code == 2012` branch so the sync path raises `ProtocolError`, matching async parity. No public API changes.

## Test Plan
Added `test_compressed_length_too_small_raises` to `test/test_network_layer.py`, covering lengths 17, 24, and 25 and asserting `ProtocolError`. All tests in the file pass.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?