### PR TITLE
PYTHON-5929 Add coding agent env var to handshake metadata

### DIFF
--- a/pymongo/pool_options.py
+++ b/pymongo/pool_options.py
@@ -249,6 +249,16 @@ def _truncate_metadata(metadata: MutableMapping[str, Any]) -> None:
         metadata["os"] = {"type": os_type}
     if len(bson.encode(metadata)) <= _MAX_METADATA_SIZE:
         return
+    # 2b. Drop env.agent (which may hold an arbitrarily large AI_AGENT/AGENT
+    # value) before sacrificing env.name by dropping the env document entirely.
+    if "agent" in trimmed_env:
+        del trimmed_env["agent"]
+        if trimmed_env:
+            metadata["env"] = trimmed_env
+        else:
+            metadata.pop("env", None)
+    if len(bson.encode(metadata)) <= _MAX_METADATA_SIZE:
+        return
     # 3. Omit the env document entirely.
     metadata.pop("env", None)
     encoded_size = len(bson.encode(metadata))

--- a/pymongo/pool_options.py
+++ b/pymongo/pool_options.py
@@ -151,7 +151,7 @@ def _is_faas() -> bool:
 
 # Environment variables that indicate a coding agent, checked in order. The
 # first match determines the value of the client.env.agent metadata field.
-# See DRIVERS-3529.
+# See DRIVERS-3529 and PYTHON-5929.
 _AGENT_ENV_VARS = [
     ("CLAUDECODE", "CLAUDECODE"),
     ("CURSOR_AGENT", "CURSOR"),

--- a/pymongo/pool_options.py
+++ b/pymongo/pool_options.py
@@ -241,22 +241,25 @@ def _truncate_metadata(metadata: MutableMapping[str, Any]) -> None:
     trimmed_env = {k: env[k] for k in ("name", "agent") if k in env}
     if trimmed_env:
         metadata["env"] = trimmed_env
+    else:
+        metadata.pop("env", None)
     if len(bson.encode(metadata)) <= _MAX_METADATA_SIZE:
         return
-    # 2. Omit fields from os except os.type.
-    os_type = metadata.get("os", {}).get("type")
-    if os_type:
-        metadata["os"] = {"type": os_type}
-    if len(bson.encode(metadata)) <= _MAX_METADATA_SIZE:
-        return
-    # 2b. Drop env.agent (which may hold an arbitrarily large AI_AGENT/AGENT
-    # value) before sacrificing env.name by dropping the env document entirely.
+    # 1b. Drop env.agent (which may hold an arbitrarily large AI_AGENT/AGENT
+    # value) before trimming os and before sacrificing env.name, so the more
+    # valuable os and env.name fields are preserved as long as possible.
     if "agent" in trimmed_env:
         del trimmed_env["agent"]
         if trimmed_env:
             metadata["env"] = trimmed_env
         else:
             metadata.pop("env", None)
+    if len(bson.encode(metadata)) <= _MAX_METADATA_SIZE:
+        return
+    # 2. Omit fields from os except os.type.
+    os_type = metadata.get("os", {}).get("type")
+    if os_type:
+        metadata["os"] = {"type": os_type}
     if len(bson.encode(metadata)) <= _MAX_METADATA_SIZE:
         return
     # 3. Omit the env document entirely.

--- a/pymongo/pool_options.py
+++ b/pymongo/pool_options.py
@@ -149,6 +149,34 @@ def _is_faas() -> bool:
     return _is_lambda() or _is_azure_func() or _is_gcp_func() or _is_vercel()
 
 
+# Environment variables that indicate a coding agent, checked in order. The
+# first match determines the value of the client.env.agent metadata field.
+# See DRIVERS-3529.
+_AGENT_ENV_VARS = [
+    ("CLAUDECODE", "CLAUDECODE"),
+    ("CURSOR_AGENT", "CURSOR"),
+    ("GEMINI_CLI", "GEMINI_CLI"),
+    ("CODEX_SANDBOX", "CODEX_SANDBOX"),
+    ("AUGMENT_AGENT", "AUGMENT"),
+    ("OPENCODE_CLIENT", "OPENCODE"),
+]
+
+
+def _metadata_agent() -> Optional[str]:
+    """Detect a coding agent from the environment for client.env.agent.
+
+    A generic AI_AGENT or AGENT environment variable takes precedence and its
+    value is used verbatim. Otherwise the first matching known agent variable
+    determines the value."""
+    agent = os.getenv("AI_AGENT") or os.getenv("AGENT")
+    if agent:
+        return agent
+    for var, name in _AGENT_ENV_VARS:
+        if os.getenv(var):
+            return name
+    return None
+
+
 def _getenv_int(key: str) -> Optional[int]:
     """Like os.getenv but returns an int, or None if the value is missing/malformed."""
     val = os.getenv(key)
@@ -165,6 +193,9 @@ def _metadata_env() -> dict[str, Any]:
     container = get_container_env_info()
     if container:
         env["container"] = container
+    agent = _metadata_agent()
+    if agent:
+        env["agent"] = agent
     # Skip if multiple (or no) envs are matched.
     if (_is_lambda(), _is_azure_func(), _is_gcp_func(), _is_vercel()).count(True) != 1:
         return env
@@ -205,10 +236,11 @@ def _truncate_metadata(metadata: MutableMapping[str, Any]) -> None:
     """Perform metadata truncation."""
     if len(bson.encode(metadata)) <= _MAX_METADATA_SIZE:
         return
-    # 1. Omit fields from env except env.name.
-    env_name = metadata.get("env", {}).get("name")
-    if env_name:
-        metadata["env"] = {"name": env_name}
+    # 1. Omit fields from env except env.name and env.agent.
+    env = metadata.get("env", {})
+    trimmed_env = {k: env[k] for k in ("name", "agent") if k in env}
+    if trimmed_env:
+        metadata["env"] = trimmed_env
     if len(bson.encode(metadata)) <= _MAX_METADATA_SIZE:
         return
     # 2. Omit fields from os except os.type.

--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -87,7 +87,13 @@ from pymongo.errors import (
     WriteConcernError,
 )
 from pymongo.monitoring import ServerHeartbeatListener, ServerHeartbeatStartedEvent
-from pymongo.pool_options import _MAX_METADATA_SIZE, _METADATA, ENV_VAR_K8S, PoolOptions
+from pymongo.pool_options import (
+    _AGENT_ENV_VARS,
+    _MAX_METADATA_SIZE,
+    _METADATA,
+    ENV_VAR_K8S,
+    PoolOptions,
+)
 from pymongo.read_preferences import ReadPreference
 from pymongo.server_description import ServerDescription
 from pymongo.server_selectors import readable_server_selector, writable_server_selector
@@ -2099,7 +2105,11 @@ class TestClient(AsyncIntegrationTest):
         self.assertNotIn("ServerHeartbeatFailedEvent", log_output)
 
     async def _test_handshake(self, env_vars, expected_env):
-        with patch.dict("os.environ", env_vars):
+        # Clear any ambient agent-detection vars (e.g. AI_AGENT/AGENT set by the
+        # CI runner) so detection is deterministic and only reflects env_vars.
+        agent_vars = ["AI_AGENT", "AGENT", *(var for var, _ in _AGENT_ENV_VARS)]
+        cleared = {var: "" for var in agent_vars if var not in env_vars}
+        with patch.dict("os.environ", {**cleared, **env_vars}):
             metadata = copy.deepcopy(_METADATA)
             if has_c():
                 metadata["driver"]["name"] = "PyMongo|c|async"

--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -2204,6 +2204,25 @@ class TestClient(AsyncIntegrationTest):
             },
         )
 
+    async def test_handshake_10_agent_known(self):
+        # A known coding-agent env var maps to its metadata value.
+        await self._test_handshake({"CLAUDECODE": "1"}, {"agent": "CLAUDECODE"})
+        await self._test_handshake({"CURSOR_AGENT": "1"}, {"agent": "CURSOR"})
+        await self._test_handshake({"OPENCODE_CLIENT": "1"}, {"agent": "OPENCODE"})
+
+    async def test_handshake_11_agent_generic(self):
+        # Generic AI_AGENT/AGENT vars are used verbatim and take precedence.
+        await self._test_handshake({"AI_AGENT": "myagent"}, {"agent": "myagent"})
+        await self._test_handshake({"AGENT": "myagent"}, {"agent": "myagent"})
+        await self._test_handshake({"AI_AGENT": "myagent", "CLAUDECODE": "1"}, {"agent": "myagent"})
+
+    async def test_handshake_12_agent_with_provider(self):
+        # agent is reported alongside a FaaS provider.
+        await self._test_handshake(
+            {"FUNCTIONS_WORKER_RUNTIME": "python", "CLAUDECODE": "1"},
+            {"name": "azure.func", "agent": "CLAUDECODE"},
+        )
+
     def test_dict_hints(self):
         self.db.t.find(hint={"x": 1})
 

--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -2220,6 +2220,13 @@ class TestClient(AsyncIntegrationTest):
         await self._test_handshake({"CURSOR_AGENT": "1"}, {"agent": "CURSOR"})
         await self._test_handshake({"OPENCODE_CLIENT": "1"}, {"agent": "OPENCODE"})
 
+    async def test_handshake_10b_agent_known_precedence(self):
+        # When multiple known agent vars are set, the first in _AGENT_ENV_VARS
+        # order wins, regardless of which comes first in the environment dict.
+        first_var, first_name = _AGENT_ENV_VARS[0]
+        last_var, _ = _AGENT_ENV_VARS[-1]
+        await self._test_handshake({last_var: "1", first_var: "1"}, {"agent": first_name})
+
     async def test_handshake_11_agent_generic(self):
         # Generic AI_AGENT/AGENT vars are used verbatim and take precedence.
         await self._test_handshake({"AI_AGENT": "myagent"}, {"agent": "myagent"})

--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -2223,6 +2223,13 @@ class TestClient(AsyncIntegrationTest):
             {"name": "azure.func", "agent": "CLAUDECODE"},
         )
 
+    async def test_handshake_13_agent_too_long(self):
+        # A too-long agent value is dropped during truncation before env.name.
+        await self._test_handshake(
+            {"FUNCTIONS_WORKER_RUNTIME": "python", "AI_AGENT": "a" * 512},
+            {"name": "azure.func"},
+        )
+
     def test_dict_hints(self):
         self.db.t.find(hint={"x": 1})
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -2161,6 +2161,25 @@ class TestClient(IntegrationTest):
             },
         )
 
+    def test_handshake_10_agent_known(self):
+        # A known coding-agent env var maps to its metadata value.
+        self._test_handshake({"CLAUDECODE": "1"}, {"agent": "CLAUDECODE"})
+        self._test_handshake({"CURSOR_AGENT": "1"}, {"agent": "CURSOR"})
+        self._test_handshake({"OPENCODE_CLIENT": "1"}, {"agent": "OPENCODE"})
+
+    def test_handshake_11_agent_generic(self):
+        # Generic AI_AGENT/AGENT vars are used verbatim and take precedence.
+        self._test_handshake({"AI_AGENT": "myagent"}, {"agent": "myagent"})
+        self._test_handshake({"AGENT": "myagent"}, {"agent": "myagent"})
+        self._test_handshake({"AI_AGENT": "myagent", "CLAUDECODE": "1"}, {"agent": "myagent"})
+
+    def test_handshake_12_agent_with_provider(self):
+        # agent is reported alongside a FaaS provider.
+        self._test_handshake(
+            {"FUNCTIONS_WORKER_RUNTIME": "python", "CLAUDECODE": "1"},
+            {"name": "azure.func", "agent": "CLAUDECODE"},
+        )
+
     def test_dict_hints(self):
         self.db.t.find(hint={"x": 1})
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -76,7 +76,13 @@ from pymongo.errors import (
     WriteConcernError,
 )
 from pymongo.monitoring import ServerHeartbeatListener, ServerHeartbeatStartedEvent
-from pymongo.pool_options import _MAX_METADATA_SIZE, _METADATA, ENV_VAR_K8S, PoolOptions
+from pymongo.pool_options import (
+    _AGENT_ENV_VARS,
+    _MAX_METADATA_SIZE,
+    _METADATA,
+    ENV_VAR_K8S,
+    PoolOptions,
+)
 from pymongo.read_preferences import ReadPreference
 from pymongo.server_description import ServerDescription
 from pymongo.server_selectors import readable_server_selector, writable_server_selector
@@ -2056,7 +2062,11 @@ class TestClient(IntegrationTest):
         self.assertNotIn("ServerHeartbeatFailedEvent", log_output)
 
     def _test_handshake(self, env_vars, expected_env):
-        with patch.dict("os.environ", env_vars):
+        # Clear any ambient agent-detection vars (e.g. AI_AGENT/AGENT set by the
+        # CI runner) so detection is deterministic and only reflects env_vars.
+        agent_vars = ["AI_AGENT", "AGENT", *(var for var, _ in _AGENT_ENV_VARS)]
+        cleared = {var: "" for var in agent_vars if var not in env_vars}
+        with patch.dict("os.environ", {**cleared, **env_vars}):
             metadata = copy.deepcopy(_METADATA)
             if has_c():
                 metadata["driver"]["name"] = "PyMongo|c"

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -2180,6 +2180,13 @@ class TestClient(IntegrationTest):
             {"name": "azure.func", "agent": "CLAUDECODE"},
         )
 
+    def test_handshake_13_agent_too_long(self):
+        # A too-long agent value is dropped during truncation before env.name.
+        self._test_handshake(
+            {"FUNCTIONS_WORKER_RUNTIME": "python", "AI_AGENT": "a" * 512},
+            {"name": "azure.func"},
+        )
+
     def test_dict_hints(self):
         self.db.t.find(hint={"x": 1})
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -2177,6 +2177,13 @@ class TestClient(IntegrationTest):
         self._test_handshake({"CURSOR_AGENT": "1"}, {"agent": "CURSOR"})
         self._test_handshake({"OPENCODE_CLIENT": "1"}, {"agent": "OPENCODE"})
 
+    def test_handshake_10b_agent_known_precedence(self):
+        # When multiple known agent vars are set, the first in _AGENT_ENV_VARS
+        # order wins, regardless of which comes first in the environment dict.
+        first_var, first_name = _AGENT_ENV_VARS[0]
+        last_var, _ = _AGENT_ENV_VARS[-1]
+        self._test_handshake({last_var: "1", first_var: "1"}, {"agent": first_name})
+
     def test_handshake_11_agent_generic(self):
         # Generic AI_AGENT/AGENT vars are used verbatim and take precedence.
         self._test_handshake({"AI_AGENT": "myagent"}, {"agent": "myagent"})


### PR DESCRIPTION
PYTHON-5929

[DRIVERS-3529](https://jira.mongodb.org/browse/DRIVERS-3529)

## Changes in this PR
Report coding-agent environment variables in the client handshake metadata so that agentic usage of MongoDB/Atlas can be quantified.

- Added `_metadata_agent()` and the ordered `_AGENT_ENV_VARS` list in `pymongo/pool_options.py` with detection precedence:
  1. `AI_AGENT`, then `AGENT`
  2. First matching known agent variable maps to fixed value: `CLAUDECODE`→`CLAUDECODE`, `CURSOR_AGENT`→`CURSOR`, `GEMINI_CLI`→`GEMINI_CLI`, `CODEX_SANDBOX`→`CODEX_SANDBOX`, `AUGMENT_AGENT`→`AUGMENT`, `OPENCODE_CLIENT`→`OPENCODE`.
- `_metadata_env()` now sets `client.env.agent` when detected and coexists with `env.name` (the [serverless / Function-as-a-Service provider](https://www.mongodb.com/docs/atlas/manage-connections-aws-lambda/), e.g. AWS Lambda) and `env.container`.
- `_truncate_metadata()` preserves both `env.name` and `env.agent` in its first truncation step

> [!NOTE]
> The handshake spec is not yet updated for this field. Field name/values follow the DRIVERS-3529 Jira design and may need to be reconciled with the final spec and the Node driver implementation.

## Test Plan
Added tests in `test/asynchronous/test_client.py` covering known-agent detection, generic `AI_AGENT`/`AGENT` precedence, and agent reported alongside a serverless provider (e.g. AWS Lambda).

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s). (Spec finalization tracked under DRIVERS-3529.)

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?

