### PR TITLE
PYTHON-5950 Fix spec resync scripts to use main branch

### DIFF
--- a/.evergreen/resync-specs.sh
+++ b/.evergreen/resync-specs.sh
@@ -65,7 +65,7 @@ cpjson () {
     sed -e '/^[0-9]/d' | sed -e 's|< ./||g' )"
     printf "%s\n" $IGNORED_FILES
     cd "$PYMONGO"/test/$2
-    printf "%s\n" $IGNORED_FILES | xargs git checkout master
+    printf "%s\n" $IGNORED_FILES | xargs git checkout main
 
 }
 

--- a/.evergreen/scripts/create-spec-pr.sh
+++ b/.evergreen/scripts/create-spec-pr.sh
@@ -31,7 +31,7 @@ echo "Creating the git checkout..."
 branch="spec-resync-"$(date '+%m-%d-%Y')
 
 git remote set-url origin https://x-access-token:${token}@github.com/$owner/$repo.git
-git checkout -b $branch "origin/master"
+git checkout -b $branch "origin/main"
 git add ./test
 git commit -am "resyncing specs $(date '+%m-%d-%Y')"
 echo "Creating the git checkout... done."
@@ -42,7 +42,7 @@ resp=$(curl -L \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer $token" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    -d "{\"title\":\"[Spec Resync] $(date '+%m-%d-%Y')\",\"body\":\"$(cat "$1")\",\"head\":\"${branch}\",\"base\":\"master\"}" \
+    -d "{\"title\":\"[Spec Resync] $(date '+%m-%d-%Y')\",\"body\":\"$(cat "$1")\",\"head\":\"${branch}\",\"base\":\"main\"}" \
     --url https://api.github.com/repos/$owner/$repo/pulls)
 echo $resp | jq '.html_url'
 echo "Creating the PR... done."


### PR DESCRIPTION
[PYTHON-5950](https://jira.mongodb.org/browse/PYTHON-5950)

After switching the default branch from `master` to `main` the spec resync scripts still referenced `master` and failed to check out the repo (see PYTHON-5950).

## Changes in this PR

- In `.evergreen/scripts/create-spec-pr.sh` check out the new branch from `origin/main` and set the PR `base` to `main`.
- In `.evergreen/resync-specs.sh` restore blocklisted/ignored files via `git checkout main`.

## Test Plan
Full validation happens when the spec-resync Evergreen task next runs against `main`.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)? N/A — CI tooling change, no user-facing behavior.
- [ ] Is there test coverage? N/A — CI shell scripts; see Test Plan.
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s). Contributor-doc / CI-trigger `master` references tracked in [PYTHON-5952](https://jira.mongodb.org/browse/PYTHON-5952).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
