### PR TITLE
PYTHON-5952 Update contributor docs and CI triggers to use main branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", "v*"]
+    branches: [ "main", "v*"]
     tags: ['*']
   pull_request:
   workflow_call:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -8,7 +8,7 @@ name: Generate SBOM
 on:
   workflow_dispatch: {}
   push:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'requirements.txt'
       - 'requirements/**.txt'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -2,7 +2,7 @@ name: Python Tests
 
 on:
   push:
-    branches: ["master", "v**"]
+    branches: ["main", "v**"]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
     branches: ["**"]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ just run lint-manual
 
 To contribute to the [API documentation](https://pymongo.readthedocs.io/en/stable/) just make your
 changes to the inline documentation of the appropriate [source code](https://github.com/mongodb/mongo-python-driver) or
-[rst file](https://github.com/mongodb/mongo-python-driver/tree/master/doc) in
+[rst file](https://github.com/mongodb/mongo-python-driver/tree/main/doc) in
 a branch and submit a [pull request](https://help.github.com/articles/using-pull-requests). You
 might also use the GitHub
 [Edit](https://github.com/blog/844-forking-with-the-edit-button) button.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python Versions](https://img.shields.io/pypi/pyversions/pymongo)](https://pypi.org/project/pymongo)
 [![Monthly Downloads](https://static.pepy.tech/badge/pymongo/month)](https://pepy.tech/project/pymongo)
 [![API Documentation Status](https://readthedocs.org/projects/pymongo/badge/?version=stable)](http://pymongo.readthedocs.io/en/stable/api?badge=stable)
-[![codecov](https://codecov.io/gh/mongodb/mongo-python-driver/graph/badge.svg?branch=master)](https://codecov.io/gh/mongodb/mongo-python-driver)
+[![codecov](https://codecov.io/gh/mongodb/mongo-python-driver/graph/badge.svg?branch=main)](https://codecov.io/gh/mongodb/mongo-python-driver)
 
 ## About
 
@@ -216,4 +216,4 @@ pip install -e ".[test]"
 pytest
 ```
 
-For more advanced testing scenarios, see the [contributing guide](https://github.com/mongodb/mongo-python-driver/blob/master/CONTRIBUTING.md#running-tests-locally).
+For more advanced testing scenarios, see the [contributing guide](https://github.com/mongodb/mongo-python-driver/blob/main/CONTRIBUTING.md#running-tests-locally).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,8 +53,8 @@ About This Documentation
 This documentation is generated using the `Sphinx
 <https://www.sphinx-doc.org/en/master/>`_ documentation generator. The source files
 for the documentation are located in the *doc/* directory of the
-**PyMongo** distribution. See the PyMongo `contributing guide  <https://github.com/mongodb/mongo-python-driver/blob/main/CONTRIBUTING.md>`_
-for instructions on the building the docs from source.
+**PyMongo** distribution. See the PyMongo `contributing guide <https://github.com/mongodb/mongo-python-driver/blob/main/CONTRIBUTING.md>`_
+for instructions on building the docs from source.
 
 Indices and tables
 ------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,7 +53,7 @@ About This Documentation
 This documentation is generated using the `Sphinx
 <https://www.sphinx-doc.org/en/master/>`_ documentation generator. The source files
 for the documentation are located in the *doc/* directory of the
-**PyMongo** distribution. See the PyMongo `contributing guide  <https://github.com/mongodb/mongo-python-driver/blob/master/CONTRIBUTING.md>`_
+**PyMongo** distribution. See the PyMongo `contributing guide  <https://github.com/mongodb/mongo-python-driver/blob/main/CONTRIBUTING.md>`_
 for instructions on the building the docs from source.
 
 Indices and tables


### PR DESCRIPTION
[PYTHON-5952](https://jira.mongodb.org/browse/PYTHON-5952)

## Changes in this PR
After renaming the default branch `master` -> `main` several self-referencing links and CI branch triggers still pointed at `master`. This PR updates:

- `README.md`: codecov badge `?branch=main`; contributing-guide link `/blob/main/`.
- `CONTRIBUTING.md`: `/tree/main/doc` link.
- `doc/index.rst`: contributing-guide link `/blob/main/`.
- `.github/workflows/{test-python,codeql,zizmor,sbom}.yml`: `push` branch triggers changed from `master` to `main`.

## Test Plan
CI-trigger behavior is exercised when pushes land on `main`.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)? N/A — docs / CI config, no user-facing behavior.
- [ ] Is there test coverage? N/A — see Test Plan.
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s). Related script fix: [PYTHON-5950](https://jira.mongodb.org/browse/PYTHON-5950) (#2951).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
