### PR TITLE
PYTHON-5968 Reject extra fields in Extended JSON timestamps

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -788,7 +788,11 @@ def _parse_binary(doc: Any, json_options: JSONOptions) -> Union[Binary, uuid.UUI
 
 
 def _parse_timestamp(doc: Any, dummy0: Any) -> Timestamp:
+    if len(doc) != 1:
+        raise TypeError(f"Bad $timestamp, extra field(s): {doc}")
     tsp = doc["$timestamp"]
+    if not isinstance(tsp, Mapping):
+        raise TypeError(f'$timestamp value must be a document with "t" and "i" components: {doc}')
     if set(tsp) != {"t", "i"}:
         raise TypeError(f'$timestamp must include exactly "t" and "i" components: {doc}')
     return Timestamp(tsp["t"], tsp["i"])

--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -789,6 +789,8 @@ def _parse_binary(doc: Any, json_options: JSONOptions) -> Union[Binary, uuid.UUI
 
 def _parse_timestamp(doc: Any, dummy0: Any) -> Timestamp:
     tsp = doc["$timestamp"]
+    if set(tsp) != {"t", "i"}:
+        raise TypeError(f'$timestamp must include exactly "t" and "i" components: {doc}')
     return Timestamp(tsp["t"], tsp["i"])
 
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -25,6 +25,8 @@ PyMongo 4.18 brings a number of changes including:
   the bytes remaining in the array now raises
   :class:`~bson.errors.InvalidBSON` instead of reading past the end of the
   buffer.
+- Fixed :func:`bson.json_util.loads` to reject ``$timestamp`` values containing
+  fields other than ``t`` and ``i``.
 
 Changes in Version 4.17.0 (2026/04/20)
 --------------------------------------

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -109,3 +109,4 @@ The following is a list of people who have contributed to
 - Noah Stapp (NoahStapp)
 - Cal Jacobson (cj81499)
 - Sophia Yang (sophiayangDB)
+- Madan Kumar (winklemad)

--- a/test/test_json_util.py
+++ b/test/test_json_util.py
@@ -405,6 +405,18 @@ class TestJsonUtil(unittest.TestCase):
         self.assertEqual(dct, rtdct)
         self.assertEqual('{"ts": {"$timestamp": {"t": 4, "i": 13}}}', res)
 
+    def test_timestamp_with_invalid_fields(self):
+        invalid_values = [
+            '{"t": 4, "i": 13, "extra": 1}',
+            '{"t": 4, "unexpected": 13}',
+        ]
+        for value in invalid_values:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    TypeError, r'\$timestamp must include exactly "t" and "i" components'
+                ):
+                    json_util.loads(f'{{"ts": {{"$timestamp": {value}}}}}')
+
     def test_uuid_default(self):
         # Cannot directly encode native UUIDs with the default
         # uuid_representation.

--- a/test/test_json_util.py
+++ b/test/test_json_util.py
@@ -424,9 +424,7 @@ class TestJsonUtil(unittest.TestCase):
     def test_timestamp_with_non_document_value(self):
         for value in ('["t", "i"]', '"ti"', "5"):
             with self.subTest(value=value):
-                with self.assertRaisesRegex(
-                    TypeError, r"\$timestamp value must be a document"
-                ):
+                with self.assertRaisesRegex(TypeError, r"\$timestamp value must be a document"):
                     json_util.loads(f'{{"ts": {{"$timestamp": {value}}}}}')
 
     def test_uuid_default(self):

--- a/test/test_json_util.py
+++ b/test/test_json_util.py
@@ -417,6 +417,18 @@ class TestJsonUtil(unittest.TestCase):
                 ):
                     json_util.loads(f'{{"ts": {{"$timestamp": {value}}}}}')
 
+    def test_timestamp_with_extra_wrapper_fields(self):
+        with self.assertRaisesRegex(TypeError, r"Bad \$timestamp, extra field\(s\)"):
+            json_util.loads('{"ts": {"$timestamp": {"t": 4, "i": 13}, "extra": 1}}')
+
+    def test_timestamp_with_non_document_value(self):
+        for value in ('["t", "i"]', '"ti"', "5"):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    TypeError, r"\$timestamp value must be a document"
+                ):
+                    json_util.loads(f'{{"ts": {{"$timestamp": {value}}}}}')
+
     def test_uuid_default(self):
         # Cannot directly encode native UUIDs with the default
         # uuid_representation.


### PR DESCRIPTION
PYTHON-5968

## Changes in this PR

`bson.json_util.loads` now rejects `$timestamp` value documents that contain anything other than the required `t` and `i` components. Previously, unexpected fields could be silently discarded while constructing `bson.timestamp.Timestamp`.

This adds regressions for both additional fields and same-length invalid key sets, and updates the changelog and contributor list.

AI assistance disclosure: I used OpenAI Codex to help investigate the existing behavior, search for duplicates, implement the change, and run validation. I reviewed and understand every changed line and can explain and maintain the contribution.

## Test Plan

- `python3 -m unittest test.test_json_util.TestJsonUtil.test_timestamp test.test_json_util.TestJsonUtil.test_timestamp_with_invalid_fields`
- `python3 -m unittest test.test_json_util test.test_bson_corpus`
- `ruff check bson/json_util.py test/test_json_util.py`
- `ruff format --check bson/json_util.py test/test_json_util.py`
- `python3 -m compileall -q bson/json_util.py test/test_json_util.py`
- `git diff --check`

All listed checks passed.

## Checklist

### Checklist for Author
- [x] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add links.

No follow-up work is currently identified. As an external contributor without an existing JIRA ticket, I retained the template `PYTHON-XXXX` placeholder for a MongoDB employee to update.

### Checklist for Reviewer
- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation?
- [x] Is all relevant documentation updated?