### PR TITLE
PYTHON-6003 Fix flaky test_pool_unpause

### DIFF
--- a/test/asynchronous/test_discovery_and_monitoring.py
+++ b/test/asynchronous/test_discovery_and_monitoring.py
@@ -361,8 +361,8 @@ class TestPoolManagement(AsyncIntegrationTest):
         # This test implements the prose test "AsyncConnection Pool Management"
         listener = CMAPHeartbeatListener()
         # Force polling: streaming's RTT monitor sends its own hello calls with the same
-        # appName, which can consume the failCommand's mode.times budget below the SDAM
-        # heartbeat monitor, so ServerHeartbeatFailedEvent never fires (PYTHON-6003).
+        # appName, which can consume the failCommand's mode.times budget before the SDAM
+        # heartbeat monitor's hello does, so ServerHeartbeatFailedEvent never fires (PYTHON-6003).
         _ = await self.async_single_client(
             appName="SDAMPoolManagementTest",
             heartbeatFrequencyMS=500,

--- a/test/asynchronous/test_discovery_and_monitoring.py
+++ b/test/asynchronous/test_discovery_and_monitoring.py
@@ -360,8 +360,14 @@ class TestPoolManagement(AsyncIntegrationTest):
     async def test_pool_unpause(self):
         # This test implements the prose test "AsyncConnection Pool Management"
         listener = CMAPHeartbeatListener()
+        # Force polling: streaming's RTT monitor sends its own hello calls with the same
+        # appName, which can consume the failCommand's mode.times budget below the SDAM
+        # heartbeat monitor, so ServerHeartbeatFailedEvent never fires (PYTHON-6003).
         _ = await self.async_single_client(
-            appName="SDAMPoolManagementTest", heartbeatFrequencyMS=500, event_listeners=[listener]
+            appName="SDAMPoolManagementTest",
+            heartbeatFrequencyMS=500,
+            event_listeners=[listener],
+            serverMonitoringMode="poll",
         )
         # Assert that AsyncConnectionPoolReadyEvent occurs after the first
         # ServerHeartbeatSucceededEvent.

--- a/test/test_discovery_and_monitoring.py
+++ b/test/test_discovery_and_monitoring.py
@@ -360,8 +360,14 @@ class TestPoolManagement(IntegrationTest):
     def test_pool_unpause(self):
         # This test implements the prose test "Connection Pool Management"
         listener = CMAPHeartbeatListener()
+        # Force polling: streaming's RTT monitor sends its own hello calls with the same
+        # appName, which can consume the failCommand's mode.times budget below the SDAM
+        # heartbeat monitor, so ServerHeartbeatFailedEvent never fires (PYTHON-6003).
         _ = self.single_client(
-            appName="SDAMPoolManagementTest", heartbeatFrequencyMS=500, event_listeners=[listener]
+            appName="SDAMPoolManagementTest",
+            heartbeatFrequencyMS=500,
+            event_listeners=[listener],
+            serverMonitoringMode="poll",
         )
         # Assert that ConnectionPoolReadyEvent occurs after the first
         # ServerHeartbeatSucceededEvent.

--- a/test/test_discovery_and_monitoring.py
+++ b/test/test_discovery_and_monitoring.py
@@ -361,8 +361,8 @@ class TestPoolManagement(IntegrationTest):
         # This test implements the prose test "Connection Pool Management"
         listener = CMAPHeartbeatListener()
         # Force polling: streaming's RTT monitor sends its own hello calls with the same
-        # appName, which can consume the failCommand's mode.times budget below the SDAM
-        # heartbeat monitor, so ServerHeartbeatFailedEvent never fires (PYTHON-6003).
+        # appName, which can consume the failCommand's mode.times budget before the SDAM
+        # heartbeat monitor's hello does, so ServerHeartbeatFailedEvent never fires (PYTHON-6003).
         _ = self.single_client(
             appName="SDAMPoolManagementTest",
             heartbeatFrequencyMS=500,


### PR DESCRIPTION
PYTHON-6003

## Changes in this PR
`test_pool_unpause` flaked because the default streaming SDAM protocol starts an RTT monitor that sends its own `hello` calls with the same `appName`, racing the test's `failCommand` (`mode.times: 2`) against the SDAM heartbeat monitor's `hello` calls. When the RTT monitor won the race, `ServerHeartbeatFailedEvent` never fired and the test timed out.

Fix: pass `serverMonitoringMode="poll"` to disable the RTT monitor and remove the race.

## Test Plan
- Reverted the fix and ran `test_pool_unpause` against a local MongoDB 8.0 server 15 times: reproduced the failure twice.
- With the fix, ran the async test 20 times and the sync mirror once, and all passed.
- `just lint` and `just typing` pass.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?

<!-- AI disclosure: This PR was drafted with assistance from Claude (Anthropic), including the root-cause investigation, code change, and local reproduction/verification. The change was reviewed and directed by a human author who ran the tests described above. -->