### PR TITLE
PYTHON-5980 Reinstate exclude-newer uv config

### DIFF
--- a/.evergreen/scripts/install-dependencies.sh
+++ b/.evergreen/scripts/install-dependencies.sh
@@ -15,8 +15,17 @@ if [ -z "${PYMONGO_BIN_DIR:-}" ]; then
   PYMONGO_BIN_DIR="$HOME/.local/bin"
 fi
 
-# Ensure uv is installed.
-if ! command -v uv &>/dev/null; then
+# Ensure uv >= 0.10 is installed (older versions don't support pyproject.toml
+# settings we rely on, e.g. relative `exclude-newer` values).
+MIN_UV_VERSION="0.10.0"
+
+uv_version_ok() {
+  command -v uv &>/dev/null || return 1
+  _current="$(uv --version | cut -d' ' -f2)"
+  [ "$(printf '%s\n%s\n' "$MIN_UV_VERSION" "$_current" | sort -V | head -n1)" = "$MIN_UV_VERSION" ]
+}
+
+if ! uv_version_ok; then
   _BIN_DIR=$PYMONGO_BIN_DIR
   mkdir -p ${_BIN_DIR}
   echo "Installing uv..."
@@ -26,6 +35,10 @@ if ! command -v uv &>/dev/null; then
   fi
   export PATH="$PYMONGO_BIN_DIR:$PATH"
   echo "Installing uv... done."
+  if ! uv_version_ok; then
+    echo "Installed uv $(uv --version) but >= $MIN_UV_VERSION is required." >&2
+    exit 1
+  fi
 fi
 
 # Ensure just is installed.

--- a/.evergreen/scripts/install-dependencies.sh
+++ b/.evergreen/scripts/install-dependencies.sh
@@ -22,7 +22,13 @@ MIN_UV_VERSION="0.10.0"
 uv_version_ok() {
   command -v uv &>/dev/null || return 1
   _current="$(uv --version | cut -d' ' -f2)"
-  [ "$(printf '%s\n%s\n' "$MIN_UV_VERSION" "$_current" | sort -V | head -n1)" = "$MIN_UV_VERSION" ]
+  IFS='.' read -r _min_major _min_minor _min_patch <<< "$MIN_UV_VERSION"
+  IFS='.' read -r _cur_major _cur_minor _cur_patch <<< "$_current"
+  [ "${_cur_major:-0}" -gt "${_min_major:-0}" ] && return 0
+  [ "${_cur_major:-0}" -lt "${_min_major:-0}" ] && return 1
+  [ "${_cur_minor:-0}" -gt "${_min_minor:-0}" ] && return 0
+  [ "${_cur_minor:-0}" -lt "${_min_minor:-0}" ] && return 1
+  [ "${_cur_patch:-0}" -ge "${_min_patch:-0}" ]
 }
 
 if ! uv_version_ok; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ Source = "https://github.com/mongodb/mongo-python-driver"
 Tracker = "https://jira.mongodb.org/projects/PYTHON/issues"
 
 [tool.uv]
+# Wait 7 days before resolving newly published package versions.
+exclude-newer = "7 days"
 # boto3 dropped Python 3.9 support in 1.43, so the universal lock forks at
 # 3.10. Without a floor the pre-3.10 fork back-solves to boto3 1.7.84 (2018),
 # whose vendored six and invalid escape sequences break test collection. No

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version <= '3.9'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 constraints = [{ name = "boto3", specifier = ">=1.34" }]
 


### PR DESCRIPTION
## Summary
- PYTHON-5980 (#2977) removed the per-run `set-uv-exclude-newer` action, which was correct once `uv.lock` is committed, but it also dropped `exclude-newer = "7 days"` from `[tool.uv]` in `pyproject.toml`.
- That setting still matters whenever `uv lock` is regenerated (locally, or by the weekly `uv-lock-update.yml` job) to avoid resolving packages published in the last 7 days. Restore it and regenerate `uv.lock`.
- The config was previously removed because Evergreen hosts can have an older `uv` (< 0.10) already on `PATH`, which can't parse the relative `"7 days"` value and silently falls back to no `exclude-newer`. `install-dependencies.sh` now checks the `uv` version and installs a newer one when needed.

## Test plan
- [ ] CI passes (`uv lock --check` job in test-python.yml)