### PR TITLE
PYTHON-6006 Add MongoDB 9.0 to the Evergreen test matrix

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -75,12 +75,12 @@ tasks:
           SUB_TEST_NAME: session-creds
           TOOLCHAIN_VERSION: 3.14t
     tags: [auth-aws, auth-aws-session-creds, free-threaded]
-  - name: test-auth-aws-rapid-web-identity-python3.14-cov
+  - name: test-auth-aws-9.0-web-identity-python3.14-cov
     commands:
       - func: run server
         vars:
           AUTH_AWS: "1"
-          VERSION: rapid
+          VERSION: "9.0"
       - func: assume ec2 role
       - func: run tests
         vars:
@@ -89,7 +89,21 @@ tasks:
           TOOLCHAIN_VERSION: "3.14"
           COVERAGE: "1"
     tags: [auth-aws, auth-aws-web-identity, pr]
-  - name: test-auth-aws-rapid-web-identity-session-name-python3.14
+  - name: test-auth-aws-9.0-web-identity-session-name-python3.14
+    commands:
+      - func: run server
+        vars:
+          AUTH_AWS: "1"
+          VERSION: "9.0"
+      - func: assume ec2 role
+      - func: run tests
+        vars:
+          TEST_NAME: auth_aws
+          SUB_TEST_NAME: web-identity
+          AWS_ROLE_SESSION_NAME: test
+          TOOLCHAIN_VERSION: "3.14"
+    tags: [auth-aws, auth-aws-web-identity]
+  - name: test-auth-aws-rapid-regular-python3.10-min-deps
     commands:
       - func: run server
         vars:
@@ -99,11 +113,11 @@ tasks:
       - func: run tests
         vars:
           TEST_NAME: auth_aws
-          SUB_TEST_NAME: web-identity
-          AWS_ROLE_SESSION_NAME: test
-          TOOLCHAIN_VERSION: "3.14"
-    tags: [auth-aws, auth-aws-web-identity]
-  - name: test-auth-aws-latest-regular-python3.10-min-deps
+          SUB_TEST_NAME: regular
+          TOOLCHAIN_VERSION: "3.10"
+          TEST_MIN_DEPS: "1"
+    tags: [auth-aws, auth-aws-regular]
+  - name: test-auth-aws-latest-assume-role-python3.11
     commands:
       - func: run server
         vars:
@@ -113,10 +127,9 @@ tasks:
       - func: run tests
         vars:
           TEST_NAME: auth_aws
-          SUB_TEST_NAME: regular
-          TOOLCHAIN_VERSION: "3.10"
-          TEST_MIN_DEPS: "1"
-    tags: [auth-aws, auth-aws-regular]
+          SUB_TEST_NAME: assume-role
+          TOOLCHAIN_VERSION: "3.11"
+    tags: [auth-aws, auth-aws-assume-role]
   - name: test-auth-aws-ecs
     commands:
       - func: assume ec2 role
@@ -490,6 +503,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
+  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: valid
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-ecdsa, "9.0"]
   - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -566,6 +590,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
+  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: revoked
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-ecdsa, "9.0"]
   - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -642,6 +677,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: valid-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-ecdsa, "9.0"]
   - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -718,6 +764,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: revoked-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-ecdsa, "9.0"]
   - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -794,6 +851,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
+  - name: test-ocsp-ecdsa-soft-fail-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: no-responder
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-ecdsa, "9.0"]
   - name: test-ocsp-ecdsa-soft-fail-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -889,6 +957,21 @@ tasks:
       - ocsp
       - ocsp-ecdsa
       - "8.0"
+      - ocsp-staple
+  - name: test-ocsp-ecdsa-valid-cert-server-staples-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
+          OCSP_SERVER_TYPE: valid
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags:
+      - ocsp
+      - ocsp-ecdsa
+      - "9.0"
       - ocsp-staple
   - name: test-ocsp-ecdsa-valid-cert-server-staples-rapid-python3.10-min-deps
     commands:
@@ -996,6 +1079,21 @@ tasks:
       - ocsp-ecdsa
       - "8.0"
       - ocsp-staple
+  - name: test-ocsp-ecdsa-invalid-cert-server-staples-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
+          OCSP_SERVER_TYPE: revoked
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags:
+      - ocsp
+      - ocsp-ecdsa
+      - "9.0"
+      - ocsp-staple
   - name: test-ocsp-ecdsa-invalid-cert-server-staples-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1099,6 +1197,21 @@ tasks:
       - ocsp
       - ocsp-ecdsa
       - "8.0"
+      - ocsp-staple
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
+          OCSP_SERVER_TYPE: valid-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags:
+      - ocsp
+      - ocsp-ecdsa
+      - "9.0"
       - ocsp-staple
   - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples-rapid-python3.10-min-deps
     commands:
@@ -1204,6 +1317,21 @@ tasks:
       - ocsp-ecdsa
       - "8.0"
       - ocsp-staple
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple.json
+          OCSP_SERVER_TYPE: revoked-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags:
+      - ocsp
+      - ocsp-ecdsa
+      - "9.0"
+      - ocsp-staple
   - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1288,6 +1416,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
+  - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
+          OCSP_SERVER_TYPE: revoked
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-ecdsa, "9.0"]
   - name: test-ocsp-ecdsa-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1364,6 +1503,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
+  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
+          OCSP_SERVER_TYPE: revoked-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-ecdsa, "9.0"]
   - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1440,6 +1590,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-ecdsa, "8.0"]
+  - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
+          OCSP_SERVER_TYPE: no-responder
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-ecdsa, "9.0"]
   - name: test-ocsp-ecdsa-malicious-no-responder-muststaple-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1516,6 +1677,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-rsa, "8.0"]
+  - name: test-ocsp-rsa-valid-cert-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: valid
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-rsa, "9.0"]
   - name: test-ocsp-rsa-valid-cert-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1592,6 +1764,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-rsa, "8.0"]
+  - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: revoked
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-rsa, "9.0"]
   - name: test-ocsp-rsa-invalid-cert-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1668,6 +1851,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-rsa, "8.0"]
+  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: valid-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-rsa, "9.0"]
   - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1744,6 +1938,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-rsa, "8.0"]
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: revoked-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-rsa, "9.0"]
   - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1820,6 +2025,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-rsa, "8.0"]
+  - name: test-ocsp-rsa-soft-fail-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-disableStapling.json
+          OCSP_SERVER_TYPE: no-responder
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-rsa, "9.0"]
   - name: test-ocsp-rsa-soft-fail-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -1915,6 +2131,21 @@ tasks:
       - ocsp
       - ocsp-rsa
       - "8.0"
+      - ocsp-staple
+  - name: test-ocsp-rsa-valid-cert-server-staples-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
+          OCSP_SERVER_TYPE: valid
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags:
+      - ocsp
+      - ocsp-rsa
+      - "9.0"
       - ocsp-staple
   - name: test-ocsp-rsa-valid-cert-server-staples-rapid-python3.10-min-deps
     commands:
@@ -2022,6 +2253,21 @@ tasks:
       - ocsp-rsa
       - "8.0"
       - ocsp-staple
+  - name: test-ocsp-rsa-invalid-cert-server-staples-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
+          OCSP_SERVER_TYPE: revoked
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags:
+      - ocsp
+      - ocsp-rsa
+      - "9.0"
+      - ocsp-staple
   - name: test-ocsp-rsa-invalid-cert-server-staples-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -2125,6 +2371,21 @@ tasks:
       - ocsp
       - ocsp-rsa
       - "8.0"
+      - ocsp-staple
+  - name: test-ocsp-rsa-delegate-valid-cert-server-staples-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
+          OCSP_SERVER_TYPE: valid-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags:
+      - ocsp
+      - ocsp-rsa
+      - "9.0"
       - ocsp-staple
   - name: test-ocsp-rsa-delegate-valid-cert-server-staples-rapid-python3.10-min-deps
     commands:
@@ -2230,6 +2491,21 @@ tasks:
       - ocsp-rsa
       - "8.0"
       - ocsp-staple
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple.json
+          OCSP_SERVER_TYPE: revoked-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags:
+      - ocsp
+      - ocsp-rsa
+      - "9.0"
+      - ocsp-staple
   - name: test-ocsp-rsa-delegate-invalid-cert-server-staples-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -2314,6 +2590,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-rsa, "8.0"]
+  - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
+          OCSP_SERVER_TYPE: revoked
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-rsa, "9.0"]
   - name: test-ocsp-rsa-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -2390,6 +2677,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-rsa, "8.0"]
+  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
+          OCSP_SERVER_TYPE: revoked-delegate
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-rsa, "9.0"]
   - name: test-ocsp-rsa-delegate-malicious-invalid-cert-muststaple-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -2466,6 +2764,17 @@ tasks:
           VERSION: "8.0"
           TEST_MIN_DEPS: "1"
     tags: [ocsp, ocsp-rsa, "8.0"]
+  - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-v9.0-python3.10-min-deps
+    commands:
+      - func: run tests
+        vars:
+          ORCHESTRATION_FILE: rsa-basic-tls-ocsp-mustStaple-disableStapling.json
+          OCSP_SERVER_TYPE: no-responder
+          TEST_NAME: ocsp
+          TOOLCHAIN_VERSION: "3.10"
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+    tags: [ocsp, ocsp-rsa, "9.0"]
   - name: test-ocsp-rsa-malicious-no-responder-muststaple-server-does-not-staple-rapid-python3.10-min-deps
     commands:
       - func: run tests
@@ -3321,7 +3630,7 @@ tasks:
       - free-threaded
 
   # Standard tests
-  - name: test-standard-v4.2-python3.11-sync-noauth-ssl-replica-set
+  - name: test-standard-v4.2-python3.11-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -3336,14 +3645,14 @@ tasks:
           TOPOLOGY: replica_set
           VERSION: "4.2"
           TOOLCHAIN_VERSION: "3.11"
-          TEST_NAME: default_sync
+          TEST_NAME: default_async
     tags:
       - test-standard
       - server-4.2
       - python-3.11
       - replica_set-noauth-ssl
-      - sync
-  - name: test-standard-v4.2-python3.14-sync-noauth-ssl-replica-set
+      - async
+  - name: test-standard-v4.2-python3.14t-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -3357,59 +3666,15 @@ tasks:
           SSL: ssl
           TOPOLOGY: replica_set
           VERSION: "4.2"
-          TOOLCHAIN_VERSION: "3.14"
-          TEST_NAME: default_sync
+          TOOLCHAIN_VERSION: 3.14t
+          TEST_NAME: default_async
     tags:
       - test-standard
       - server-4.2
-      - python-3.14
+      - python-3.14t
       - replica_set-noauth-ssl
-      - sync
-  - name: test-standard-v4.2-python3.12-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          TOOLCHAIN_VERSION: "3.12"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-4.2
-      - python-3.12
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v4.2-pypy3.11-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.2"
-          TOOLCHAIN_VERSION: pypy3.11
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-4.2
-      - python-pypy3.11
-      - sharded_cluster-auth-ssl
-      - sync
-      - pypy
+      - async
+      - free-threaded
   - name: test-standard-v4.2-python3.10-sync-noauth-nossl-standalone-min-deps
     commands:
       - func: run server
@@ -3434,7 +3699,7 @@ tasks:
       - python-3.10
       - standalone-noauth-nossl
       - sync
-  - name: test-standard-v4.2-python3.14t-sync-noauth-nossl-standalone
+  - name: test-standard-v4.2-python3.13-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -3448,82 +3713,60 @@ tasks:
           SSL: nossl
           TOPOLOGY: standalone
           VERSION: "4.2"
-          TOOLCHAIN_VERSION: 3.14t
+          TOOLCHAIN_VERSION: "3.13"
           TEST_NAME: default_sync
     tags:
       - test-standard
       - server-4.2
-      - python-3.14t
+      - python-3.13
       - standalone-noauth-nossl
       - sync
-      - free-threaded
-  - name: test-standard-v4.4-python3.11-async-noauth-ssl-replica-set
+  - name: test-standard-v4.2-pypy3.11-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
           AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
       - func: run tests
         vars:
           AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.2"
+          TOOLCHAIN_VERSION: pypy3.11
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-4.2
+      - python-pypy3.11
+      - standalone-noauth-nossl
+      - sync
+      - pypy
+  - name: test-standard-v4.4-python3.11-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
           SSL: ssl
-          TOPOLOGY: replica_set
+          TOPOLOGY: sharded_cluster
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
           VERSION: "4.4"
           TOOLCHAIN_VERSION: "3.11"
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
       - test-standard
       - server-4.4
       - python-3.11
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-v4.4-python3.14-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "4.4"
-          TOOLCHAIN_VERSION: "3.14"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-4.4
-      - python-3.14
-      - replica_set-noauth-ssl
-      - async
-  - name: test-standard-v4.4-python3.12-async-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: "4.4"
-          TOOLCHAIN_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-4.4
-      - python-3.12
       - sharded_cluster-auth-ssl
-      - async
-  - name: test-standard-v4.4-pypy3.11-async-auth-ssl-sharded-cluster
+      - sync
+  - name: test-standard-v4.4-python3.14t-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -3537,15 +3780,15 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: "4.4"
-          TOOLCHAIN_VERSION: pypy3.11
-          TEST_NAME: default_async
+          TOOLCHAIN_VERSION: 3.14t
+          TEST_NAME: default_sync
     tags:
       - test-standard
       - server-4.4
-      - python-pypy3.11
+      - python-3.14t
       - sharded_cluster-auth-ssl
-      - async
-      - pypy
+      - sync
+      - free-threaded
   - name: test-standard-v4.4-python3.10-async-noauth-nossl-standalone-min-deps
     commands:
       - func: run server
@@ -3570,7 +3813,7 @@ tasks:
       - python-3.10
       - standalone-noauth-nossl
       - async
-  - name: test-standard-v4.4-python3.14t-async-noauth-nossl-standalone
+  - name: test-standard-v4.4-python3.13-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -3584,15 +3827,37 @@ tasks:
           SSL: nossl
           TOPOLOGY: standalone
           VERSION: "4.4"
-          TOOLCHAIN_VERSION: 3.14t
+          TOOLCHAIN_VERSION: "3.13"
           TEST_NAME: default_async
     tags:
       - test-standard
       - server-4.4
-      - python-3.14t
+      - python-3.13
       - standalone-noauth-nossl
       - async
-      - free-threaded
+  - name: test-standard-v4.4-pypy3.11-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "4.4"
+          TOOLCHAIN_VERSION: pypy3.11
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-4.4
+      - python-pypy3.11
+      - standalone-noauth-nossl
+      - async
+      - pypy
   - name: test-standard-v5.0-python3.10-sync-noauth-ssl-replica-set-min-deps
     commands:
       - func: run server
@@ -3617,7 +3882,7 @@ tasks:
       - python-3.10
       - replica_set-noauth-ssl
       - sync
-  - name: test-standard-v5.0-python3.14t-sync-noauth-ssl-replica-set
+  - name: test-standard-v5.0-python3.13-sync-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -3631,16 +3896,38 @@ tasks:
           SSL: ssl
           TOPOLOGY: replica_set
           VERSION: "5.0"
-          TOOLCHAIN_VERSION: 3.14t
+          TOOLCHAIN_VERSION: "3.13"
           TEST_NAME: default_sync
     tags:
       - test-standard
       - server-5.0
-      - python-3.14t
+      - python-3.13
       - replica_set-noauth-ssl
       - sync
-      - free-threaded
-  - name: test-standard-v5.0-python3.11-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v5.0-pypy3.11-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "5.0"
+          TOOLCHAIN_VERSION: pypy3.11
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-5.0
+      - python-pypy3.11
+      - replica_set-noauth-ssl
+      - sync
+      - pypy
+  - name: test-standard-v5.0-python3.11-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -3655,14 +3942,14 @@ tasks:
           TOPOLOGY: sharded_cluster
           VERSION: "5.0"
           TOOLCHAIN_VERSION: "3.11"
-          TEST_NAME: default_sync
+          TEST_NAME: default_async
     tags:
       - test-standard
       - server-5.0
       - python-3.11
       - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v5.0-python3.14-sync-auth-ssl-sharded-cluster
+      - async
+  - name: test-standard-v5.0-python3.14t-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -3676,36 +3963,15 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: "5.0"
-          TOOLCHAIN_VERSION: "3.14"
-          TEST_NAME: default_sync
+          TOOLCHAIN_VERSION: 3.14t
+          TEST_NAME: default_async
     tags:
       - test-standard
       - server-5.0
-      - python-3.14
+      - python-3.14t
       - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-v5.0-python3.13-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "5.0"
-          TOOLCHAIN_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-5.0
-      - python-3.13
-      - standalone-noauth-nossl
-      - sync
+      - async
+      - free-threaded
   - name: test-standard-v6.0-python3.10-async-noauth-ssl-replica-set-min-deps
     commands:
       - func: run server
@@ -3730,7 +3996,7 @@ tasks:
       - python-3.10
       - replica_set-noauth-ssl
       - async
-  - name: test-standard-v6.0-python3.14t-async-noauth-ssl-replica-set
+  - name: test-standard-v6.0-python3.13-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
@@ -3744,102 +4010,80 @@ tasks:
           SSL: ssl
           TOPOLOGY: replica_set
           VERSION: "6.0"
-          TOOLCHAIN_VERSION: 3.14t
+          TOOLCHAIN_VERSION: "3.13"
           TEST_NAME: default_async
     tags:
       - test-standard
       - server-6.0
-      - python-3.14t
+      - python-3.13
       - replica_set-noauth-ssl
       - async
-      - free-threaded
-  - name: test-standard-v6.0-python3.11-async-auth-ssl-sharded-cluster
+  - name: test-standard-v6.0-pypy3.11-async-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
-          AUTH: auth
+          AUTH: noauth
           SSL: ssl
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: replica_set
           VERSION: "6.0"
       - func: run tests
         vars:
-          AUTH: auth
+          AUTH: noauth
           SSL: ssl
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: replica_set
           VERSION: "6.0"
-          TOOLCHAIN_VERSION: "3.11"
+          TOOLCHAIN_VERSION: pypy3.11
           TEST_NAME: default_async
     tags:
       - test-standard
       - server-6.0
-      - python-3.11
-      - sharded_cluster-auth-ssl
+      - python-pypy3.11
+      - replica_set-noauth-ssl
       - async
-  - name: test-standard-v6.0-python3.14-async-auth-ssl-sharded-cluster
+      - pypy
+  - name: test-standard-v6.0-python3.12-sync-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
           VERSION: "6.0"
       - func: run tests
         vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+          TOOLCHAIN_VERSION: "3.12"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-6.0
+      - python-3.12
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-v6.0-python3.14-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "6.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
           VERSION: "6.0"
           TOOLCHAIN_VERSION: "3.14"
-          TEST_NAME: default_async
+          TEST_NAME: default_sync
     tags:
       - test-standard
       - server-6.0
       - python-3.14
-      - sharded_cluster-auth-ssl
-      - async
-  - name: test-standard-v6.0-python3.13-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "6.0"
-          TOOLCHAIN_VERSION: "3.13"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-6.0
-      - python-3.13
       - standalone-noauth-nossl
-      - async
-  - name: test-standard-v7.0-python3.13-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "7.0"
-          TOOLCHAIN_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-7.0
-      - python-3.13
-      - replica_set-noauth-ssl
       - sync
   - name: test-standard-v7.0-python3.10-sync-auth-ssl-sharded-cluster-min-deps
     commands:
@@ -3865,7 +4109,7 @@ tasks:
       - python-3.10
       - sharded_cluster-auth-ssl
       - sync
-  - name: test-standard-v7.0-python3.14t-sync-auth-ssl-sharded-cluster
+  - name: test-standard-v7.0-python3.13-sync-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -3879,16 +4123,38 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: "7.0"
-          TOOLCHAIN_VERSION: 3.14t
+          TOOLCHAIN_VERSION: "3.13"
           TEST_NAME: default_sync
     tags:
       - test-standard
       - server-7.0
-      - python-3.14t
+      - python-3.13
       - sharded_cluster-auth-ssl
       - sync
-      - free-threaded
-  - name: test-standard-v7.0-python3.12-sync-noauth-nossl-standalone
+  - name: test-standard-v7.0-pypy3.11-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "7.0"
+          TOOLCHAIN_VERSION: pypy3.11
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-7.0
+      - python-pypy3.11
+      - sharded_cluster-auth-ssl
+      - sync
+      - pypy
+  - name: test-standard-v7.0-python3.12-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -3903,14 +4169,14 @@ tasks:
           TOPOLOGY: standalone
           VERSION: "7.0"
           TOOLCHAIN_VERSION: "3.12"
-          TEST_NAME: default_sync
+          TEST_NAME: default_async
     tags:
       - test-standard
       - server-7.0
       - python-3.12
       - standalone-noauth-nossl
-      - sync
-  - name: test-standard-v7.0-pypy3.11-sync-noauth-nossl-standalone
+      - async
+  - name: test-standard-v7.0-python3.14-async-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -3924,37 +4190,58 @@ tasks:
           SSL: nossl
           TOPOLOGY: standalone
           VERSION: "7.0"
-          TOOLCHAIN_VERSION: pypy3.11
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-7.0
-      - python-pypy3.11
-      - standalone-noauth-nossl
-      - sync
-      - pypy
-  - name: test-standard-v8.0-python3.13-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: "8.0"
-          TOOLCHAIN_VERSION: "3.13"
+          TOOLCHAIN_VERSION: "3.14"
           TEST_NAME: default_async
     tags:
       - test-standard
-      - server-8.0
-      - python-3.13
-      - replica_set-noauth-ssl
+      - server-7.0
+      - python-3.14
+      - standalone-noauth-nossl
       - async
+  - name: test-standard-v8.0-python3.12-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          TOOLCHAIN_VERSION: "3.12"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-8.0
+      - python-3.12
+      - replica_set-noauth-ssl
+      - sync
+  - name: test-standard-v8.0-python3.14-sync-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "8.0"
+          TOOLCHAIN_VERSION: "3.14"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-8.0
+      - python-3.14
+      - replica_set-noauth-ssl
+      - sync
   - name: test-standard-v8.0-python3.10-async-auth-ssl-sharded-cluster-min-deps
     commands:
       - func: run server
@@ -3979,7 +4266,7 @@ tasks:
       - python-3.10
       - sharded_cluster-auth-ssl
       - async
-  - name: test-standard-v8.0-python3.14t-async-auth-ssl-sharded-cluster
+  - name: test-standard-v8.0-python3.13-async-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -3993,294 +4280,316 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: "8.0"
+          TOOLCHAIN_VERSION: "3.13"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-8.0
+      - python-3.13
+      - sharded_cluster-auth-ssl
+      - async
+  - name: test-standard-v8.0-pypy3.11-async-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "8.0"
+          TOOLCHAIN_VERSION: pypy3.11
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-8.0
+      - python-pypy3.11
+      - sharded_cluster-auth-ssl
+      - async
+      - pypy
+  - name: test-standard-v9.0-python3.12-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "9.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "9.0"
+          TOOLCHAIN_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-9.0
+      - python-3.12
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-v9.0-python3.14-async-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "9.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: "9.0"
+          TOOLCHAIN_VERSION: "3.14"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-9.0
+      - python-3.14
+      - replica_set-noauth-ssl
+      - async
+  - name: test-standard-v9.0-python3.11-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "9.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "9.0"
+          TOOLCHAIN_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-9.0
+      - python-3.11
+      - standalone-noauth-nossl
+      - sync
+  - name: test-standard-v9.0-python3.14t-sync-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "9.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "9.0"
+          TOOLCHAIN_VERSION: 3.14t
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-9.0
+      - python-3.14t
+      - standalone-noauth-nossl
+      - sync
+      - free-threaded
+  - name: test-standard-latest-python3.11-sync-noauth-ssl-replica-set-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          COVERAGE: "1"
+          TOOLCHAIN_VERSION: "3.11"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-latest
+      - python-3.11
+      - replica_set-noauth-ssl
+      - sync
+      - pr
+  - name: test-standard-latest-python3.14t-sync-noauth-ssl-replica-set-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          COVERAGE: "1"
+          TOOLCHAIN_VERSION: 3.14t
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-latest
+      - python-3.14t
+      - replica_set-noauth-ssl
+      - sync
+      - free-threaded
+      - pr
+  - name: test-standard-latest-python3.12-async-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          COVERAGE: "1"
+          TOOLCHAIN_VERSION: "3.12"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-latest
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - async
+      - pr
+  - name: test-standard-latest-python3.14-async-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          COVERAGE: "1"
+          TOOLCHAIN_VERSION: "3.14"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-latest
+      - python-3.14
+      - sharded_cluster-auth-ssl
+      - async
+      - pr
+  - name: test-standard-rapid-python3.12-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          TOOLCHAIN_VERSION: "3.12"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-rapid
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-rapid-python3.14-sync-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          TOOLCHAIN_VERSION: "3.14"
+          TEST_NAME: default_sync
+    tags:
+      - test-standard
+      - server-rapid
+      - python-3.14
+      - sharded_cluster-auth-ssl
+      - sync
+  - name: test-standard-rapid-python3.11-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+          TOOLCHAIN_VERSION: "3.11"
+          TEST_NAME: default_async
+    tags:
+      - test-standard
+      - server-rapid
+      - python-3.11
+      - standalone-noauth-nossl
+      - async
+  - name: test-standard-rapid-python3.14t-async-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: rapid
           TOOLCHAIN_VERSION: 3.14t
           TEST_NAME: default_async
     tags:
       - test-standard
-      - server-8.0
+      - server-rapid
       - python-3.14t
-      - sharded_cluster-auth-ssl
+      - standalone-noauth-nossl
       - async
       - free-threaded
-  - name: test-standard-v8.0-python3.12-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          TOOLCHAIN_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-8.0
-      - python-3.12
-      - standalone-noauth-nossl
-      - async
-  - name: test-standard-v8.0-pypy3.11-async-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: "8.0"
-          TOOLCHAIN_VERSION: pypy3.11
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-8.0
-      - python-pypy3.11
-      - standalone-noauth-nossl
-      - async
-      - pypy
-  - name: test-standard-latest-python3.12-async-noauth-ssl-replica-set-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          COVERAGE: "1"
-          TOOLCHAIN_VERSION: "3.12"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-latest
-      - python-3.12
-      - replica_set-noauth-ssl
-      - async
-      - pr
-  - name: test-standard-latest-pypy3.11-async-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          TOOLCHAIN_VERSION: pypy3.11
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-latest
-      - python-pypy3.11
-      - replica_set-noauth-ssl
-      - async
-      - pypy
-  - name: test-standard-latest-python3.13-async-auth-ssl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          COVERAGE: "1"
-          TOOLCHAIN_VERSION: "3.13"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-latest
-      - python-3.13
-      - sharded_cluster-auth-ssl
-      - async
-      - pr
-  - name: test-standard-latest-python3.11-async-noauth-nossl-standalone-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          COVERAGE: "1"
-          TOOLCHAIN_VERSION: "3.11"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-latest
-      - python-3.11
-      - standalone-noauth-nossl
-      - async
-      - pr
-  - name: test-standard-latest-python3.14-async-noauth-nossl-standalone-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          COVERAGE: "1"
-          TOOLCHAIN_VERSION: "3.14"
-          TEST_NAME: default_async
-    tags:
-      - test-standard
-      - server-latest
-      - python-3.14
-      - standalone-noauth-nossl
-      - async
-      - pr
-  - name: test-standard-rapid-python3.12-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          TOOLCHAIN_VERSION: "3.12"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-rapid
-      - python-3.12
-      - replica_set-noauth-ssl
-      - sync
-  - name: test-standard-rapid-pypy3.11-sync-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-          TOOLCHAIN_VERSION: pypy3.11
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-rapid
-      - python-pypy3.11
-      - replica_set-noauth-ssl
-      - sync
-      - pypy
-  - name: test-standard-rapid-python3.13-sync-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: rapid
-          TOOLCHAIN_VERSION: "3.13"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-rapid
-      - python-3.13
-      - sharded_cluster-auth-ssl
-      - sync
-  - name: test-standard-rapid-python3.11-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          TOOLCHAIN_VERSION: "3.11"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-rapid
-      - python-3.11
-      - standalone-noauth-nossl
-      - sync
-  - name: test-standard-rapid-python3.14-sync-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: rapid
-          TOOLCHAIN_VERSION: "3.14"
-          TEST_NAME: default_sync
-    tags:
-      - test-standard
-      - server-rapid
-      - python-3.14
-      - standalone-noauth-nossl
-      - sync
 
   # Test non standard tests
   - name: test-non-standard-v4.2-python3.11-noauth-ssl-replica-set
@@ -4802,184 +5111,272 @@ tasks:
       - python-3.13
       - standalone-noauth-nossl
       - noauth
-  - name: test-non-standard-latest-python3.14t-noauth-ssl-replica-set
+  - name: test-non-standard-v9.0-python3.11-noauth-ssl-replica-set
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: latest
+          VERSION: "9.0"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: ssl
           TOPOLOGY: replica_set
-          VERSION: latest
-          TOOLCHAIN_VERSION: 3.14t
-    tags:
-      - test-non-standard
-      - server-latest
-      - python-3.14t
-      - replica_set-noauth-ssl
-      - noauth
-      - free-threaded
-  - name: test-non-standard-latest-pypy3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: latest
-          TOOLCHAIN_VERSION: pypy3.11
-    tags:
-      - test-non-standard
-      - server-latest
-      - python-pypy3.11
-      - replica_set-noauth-ssl
-      - noauth
-      - pypy
-  - name: test-non-standard-latest-python3.14-auth-ssl-sharded-cluster-cov
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          COVERAGE: "1"
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          COVERAGE: "1"
-          TOOLCHAIN_VERSION: "3.14"
-    tags:
-      - test-non-standard
-      - server-latest
-      - python-3.14
-      - sharded_cluster-auth-ssl
-      - auth
-      - pr
-      - cov
-  - name: test-non-standard-latest-python3.14-auth-ssl-sharded-cluster
-    commands:
-      - func: run server
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: auth
-          SSL: ssl
-          TOPOLOGY: sharded_cluster
-          VERSION: latest
-          TOOLCHAIN_VERSION: "3.14"
-    tags:
-      - test-non-standard-no-cov
-      - server-latest
-      - python-3.14
-      - sharded_cluster-auth-ssl
-      - auth
-      - pr
-  - name: test-non-standard-latest-python3.13-noauth-nossl-standalone
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: nossl
-          TOPOLOGY: standalone
-          VERSION: latest
-          TOOLCHAIN_VERSION: "3.13"
-    tags:
-      - test-non-standard
-      - server-latest
-      - python-3.13
-      - standalone-noauth-nossl
-      - noauth
-  - name: test-non-standard-rapid-python3.11-noauth-ssl-replica-set
-    commands:
-      - func: run server
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
-      - func: run tests
-        vars:
-          AUTH: noauth
-          SSL: ssl
-          TOPOLOGY: replica_set
-          VERSION: rapid
+          VERSION: "9.0"
           TOOLCHAIN_VERSION: "3.11"
     tags:
       - test-non-standard
-      - server-rapid
+      - server-9.0
       - python-3.11
       - replica_set-noauth-ssl
       - noauth
-  - name: test-non-standard-rapid-python3.12-auth-ssl-sharded-cluster
+  - name: test-non-standard-v9.0-python3.12-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: rapid
+          VERSION: "9.0"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
-          VERSION: rapid
+          VERSION: "9.0"
           TOOLCHAIN_VERSION: "3.12"
     tags:
       - test-non-standard
-      - server-rapid
+      - server-9.0
       - python-3.12
       - sharded_cluster-auth-ssl
       - auth
-  - name: test-non-standard-rapid-python3.10-noauth-nossl-standalone-min-deps
+  - name: test-non-standard-v9.0-python3.10-noauth-nossl-standalone-min-deps
     commands:
       - func: run server
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: rapid
+          VERSION: "9.0"
           TEST_MIN_DEPS: "1"
       - func: run tests
         vars:
           AUTH: noauth
           SSL: nossl
           TOPOLOGY: standalone
-          VERSION: rapid
+          VERSION: "9.0"
           TEST_MIN_DEPS: "1"
           TOOLCHAIN_VERSION: "3.10"
     tags:
       - test-non-standard
-      - server-rapid
+      - server-9.0
       - python-3.10
       - standalone-noauth-nossl
       - noauth
-  - name: test-non-standard-rapid-pypy3.11-noauth-nossl-standalone
+  - name: test-non-standard-v9.0-pypy3.11-noauth-nossl-standalone
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "9.0"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: "9.0"
+          TOOLCHAIN_VERSION: pypy3.11
+    tags:
+      - test-non-standard
+      - server-9.0
+      - python-pypy3.11
+      - standalone-noauth-nossl
+      - noauth
+      - pypy
+  - name: test-non-standard-latest-python3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: latest
+          TOOLCHAIN_VERSION: "3.11"
+    tags:
+      - test-non-standard
+      - server-latest
+      - python-3.11
+      - replica_set-noauth-ssl
+      - noauth
+  - name: test-non-standard-latest-python3.12-auth-ssl-sharded-cluster-cov
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          COVERAGE: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          COVERAGE: "1"
+          TOOLCHAIN_VERSION: "3.12"
+    tags:
+      - test-non-standard
+      - server-latest
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - auth
+      - pr
+      - cov
+  - name: test-non-standard-latest-python3.12-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          TOOLCHAIN_VERSION: "3.12"
+    tags:
+      - test-non-standard-no-cov
+      - server-latest
+      - python-3.12
+      - sharded_cluster-auth-ssl
+      - auth
+      - pr
+  - name: test-non-standard-latest-pypy3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: latest
+          TOOLCHAIN_VERSION: pypy3.11
+    tags:
+      - test-non-standard
+      - server-latest
+      - python-pypy3.11
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy
+  - name: test-non-standard-latest-python3.10-noauth-nossl-standalone-min-deps
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          TEST_MIN_DEPS: "1"
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: nossl
+          TOPOLOGY: standalone
+          VERSION: latest
+          TEST_MIN_DEPS: "1"
+          TOOLCHAIN_VERSION: "3.10"
+    tags:
+      - test-non-standard
+      - server-latest
+      - python-3.10
+      - standalone-noauth-nossl
+      - noauth
+  - name: test-non-standard-rapid-python3.14t-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          TOOLCHAIN_VERSION: 3.14t
+    tags:
+      - test-non-standard
+      - server-rapid
+      - python-3.14t
+      - replica_set-noauth-ssl
+      - noauth
+      - free-threaded
+  - name: test-non-standard-rapid-pypy3.11-noauth-ssl-replica-set
+    commands:
+      - func: run server
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: noauth
+          SSL: ssl
+          TOPOLOGY: replica_set
+          VERSION: rapid
+          TOOLCHAIN_VERSION: pypy3.11
+    tags:
+      - test-non-standard
+      - server-rapid
+      - python-pypy3.11
+      - replica_set-noauth-ssl
+      - noauth
+      - pypy
+  - name: test-non-standard-rapid-python3.14-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: rapid
+          TOOLCHAIN_VERSION: "3.14"
+    tags:
+      - test-non-standard
+      - server-rapid
+      - python-3.14
+      - sharded_cluster-auth-ssl
+      - auth
+  - name: test-non-standard-rapid-python3.13-noauth-nossl-standalone
     commands:
       - func: run server
         vars:
@@ -4993,14 +5390,13 @@ tasks:
           SSL: nossl
           TOPOLOGY: standalone
           VERSION: rapid
-          TOOLCHAIN_VERSION: pypy3.11
+          TOOLCHAIN_VERSION: "3.13"
     tags:
       - test-non-standard
       - server-rapid
-      - python-pypy3.11
+      - python-3.13
       - standalone-noauth-nossl
       - noauth
-      - pypy
 
   # Test numpy tests
   - name: test-numpy-python3.10-python3.10
@@ -5288,7 +5684,52 @@ tasks:
       - sharded_cluster-auth-ssl
       - auth
       - pypy
-  - name: test-standard-auth-latest-python3.11-auth-ssl-sharded-cluster-cov
+  - name: test-standard-auth-v9.0-python3.10-auth-ssl-sharded-cluster-min-deps
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "9.0"
+          TEST_MIN_DEPS: "1"
+          TOOLCHAIN_VERSION: "3.10"
+    tags:
+      - test-standard-auth
+      - server-9.0
+      - python-3.10
+      - sharded_cluster-auth-ssl
+      - auth
+  - name: test-standard-auth-v9.0-pypy3.11-auth-ssl-sharded-cluster
+    commands:
+      - func: run server
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "9.0"
+      - func: run tests
+        vars:
+          AUTH: auth
+          SSL: ssl
+          TOPOLOGY: sharded_cluster
+          VERSION: "9.0"
+          TOOLCHAIN_VERSION: pypy3.11
+    tags:
+      - test-standard-auth
+      - server-9.0
+      - python-pypy3.11
+      - sharded_cluster-auth-ssl
+      - auth
+      - pypy
+  - name: test-standard-auth-latest-python3.12-auth-ssl-sharded-cluster-cov
     commands:
       - func: run server
         vars:
@@ -5304,11 +5745,11 @@ tasks:
           TOPOLOGY: sharded_cluster
           VERSION: latest
           COVERAGE: "1"
-          TOOLCHAIN_VERSION: "3.11"
+          TOOLCHAIN_VERSION: "3.12"
     tags:
       - test-standard-auth
       - server-latest
-      - python-3.11
+      - python-3.12
       - sharded_cluster-auth-ssl
       - auth
       - pr
@@ -5334,7 +5775,7 @@ tasks:
       - sharded_cluster-auth-ssl
       - auth
       - pypy
-  - name: test-standard-auth-rapid-python3.10-auth-ssl-sharded-cluster-min-deps
+  - name: test-standard-auth-rapid-python3.11-auth-ssl-sharded-cluster
     commands:
       - func: run server
         vars:
@@ -5342,19 +5783,17 @@ tasks:
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: rapid
-          TEST_MIN_DEPS: "1"
       - func: run tests
         vars:
           AUTH: auth
           SSL: ssl
           TOPOLOGY: sharded_cluster
           VERSION: rapid
-          TEST_MIN_DEPS: "1"
-          TOOLCHAIN_VERSION: "3.10"
+          TOOLCHAIN_VERSION: "3.11"
     tags:
       - test-standard-auth
       - server-rapid
-      - python-3.10
+      - python-3.11
       - sharded_cluster-auth-ssl
       - auth
   - name: test-standard-auth-rapid-pypy3.11-auth-ssl-sharded-cluster

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -326,6 +326,7 @@ buildvariants:
       - name: .test-non-standard .server-6.0 .sharded_cluster-auth-ssl
       - name: .test-non-standard .server-7.0 .sharded_cluster-auth-ssl
       - name: .test-non-standard .server-8.0 .sharded_cluster-auth-ssl
+      - name: .test-non-standard .server-9.0 .sharded_cluster-auth-ssl
       - name: .test-non-standard .server-rapid .sharded_cluster-auth-ssl
       - name: .test-non-standard .server-latest .sharded_cluster-auth-ssl
     display_name: Load Balancer
@@ -545,6 +546,15 @@ buildvariants:
     expansions:
       VERSION: "8.0"
     tags: [coverage_tag]
+  - name: mongodb-v9.0
+    tasks:
+      - name: .server-version
+    display_name: "* MongoDB v9.0"
+    run_on:
+      - rhel87-small
+    expansions:
+      VERSION: "9.0"
+    tags: [coverage_tag]
   - name: mongodb-rapid
     tasks:
       - name: .server-version
@@ -582,6 +592,7 @@ buildvariants:
       - name: .test-standard !.replica_set-noauth-ssl .server-6.0
       - name: .test-standard !.replica_set-noauth-ssl .server-7.0
       - name: .test-standard !.replica_set-noauth-ssl .server-8.0
+      - name: .test-standard !.replica_set-noauth-ssl .server-9.0
       - name: .test-standard !.replica_set-noauth-ssl .server-rapid
       - name: .test-standard !.replica_set-noauth-ssl .server-latest
     display_name: Stable API require v1 RHEL8 Auth
@@ -598,6 +609,7 @@ buildvariants:
       - name: .test-standard .server-6.0 .standalone-noauth-nossl
       - name: .test-standard .server-7.0 .standalone-noauth-nossl
       - name: .test-standard .server-8.0 .standalone-noauth-nossl
+      - name: .test-standard .server-9.0 .standalone-noauth-nossl
       - name: .test-standard .server-rapid .standalone-noauth-nossl
       - name: .test-standard .server-latest .standalone-noauth-nossl
     display_name: Stable API accept v2 RHEL8 Auth
@@ -621,6 +633,7 @@ buildvariants:
       - name: .test-standard !.pypy .server-6.0
       - name: .test-standard !.pypy .server-7.0
       - name: .test-standard !.pypy .server-8.0
+      - name: .test-standard !.pypy .server-9.0
       - name: .test-standard !.pypy .server-rapid
       - name: .test-standard !.pypy .server-latest
     display_name: "* Test macOS Arm64"

--- a/.evergreen/scripts/generate_config_utils.py
+++ b/.evergreen/scripts/generate_config_utils.py
@@ -21,7 +21,7 @@ from shrub.v3.shrub_service import ShrubService
 # Globals
 ##############
 
-ALL_VERSIONS = ["4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest"]
+ALL_VERSIONS = ["4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "rapid", "latest"]
 CPYTHONS = ["3.10", "3.11", "3.12", "3.13", "3.14t", "3.14"]
 PYPYS = ["pypy3.11"]
 MIN_SUPPORT_VERSIONS = ["3.9", "pypy3.9", "pypy3.10"]

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,7 @@ Changes in Version 4.18.0 (2026/XX/XX)
 
 PyMongo 4.18 brings a number of changes including:
 
+- Added support for MongoDB 9.0.
 - Improved TLS connection performance by reusing TLS sessions across connections
   to the same server, avoiding a full handshake on each new connection.
   Session resumption is supported on all Python versions for synchronous clients


### PR DESCRIPTION
PYTHON-6006

## Changes in this PR
Added MongoDB 9.0 to the set of server versions tested in the Evergreen test matrix (`ALL_VERSIONS` in `.evergreen/scripts/generate_config_utils.py`), following the same pattern used for the 8.0 release. Regenerated the Evergreen config files (`tasks.yml`, `variants.yml`) to include the new `mongodb-v9.0` variant and corresponding matrix tasks.

## Test Plan
- Ran `just lint` and `just typing`, both pass.
- I dispatched all of the 9.0 tasks on this [patch](https://spruce.corp.mongodb.com/version/6a7e18885ff36100079c16e4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (all green)

## Checklist

### Checklist for Author
- [x] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?