### PR TITLE
PYTHON-6002 Increase wait_until timeout for test_heartbeat_awaited_flag on PyPy

### DIFF
--- a/test/asynchronous/test_streaming_protocol.py
+++ b/test/asynchronous/test_streaming_protocol.py
@@ -199,9 +199,14 @@ class TestStreamingProtocol(AsyncIntegrationTest):
                 "appName": "heartbeatEventAwaitedFlag",
             },
         }
+        # PYTHON-6002: PyPy's JIT warm-up can delay the heartbeat monitor
+        # thread past the default timeout on slow/throttled CI runners.
+        timeout = 30 if "PyPy" in sys.version else 10
         async with self.fail_point(fail_heartbeat):
             await async_wait_until(
-                lambda: hb_listener.matching(hb_failed), "published failed event"
+                lambda: hb_listener.matching(hb_failed),
+                "published failed event",
+                timeout=timeout,
             )
         # Reconnect.
         await client.admin.command("ping")

--- a/test/test_streaming_protocol.py
+++ b/test/test_streaming_protocol.py
@@ -199,8 +199,15 @@ class TestStreamingProtocol(IntegrationTest):
                 "appName": "heartbeatEventAwaitedFlag",
             },
         }
+        # PYTHON-6002: PyPy's JIT warm-up can delay the heartbeat monitor
+        # thread past the default timeout on slow/throttled CI runners.
+        timeout = 30 if "PyPy" in sys.version else 10
         with self.fail_point(fail_heartbeat):
-            wait_until(lambda: hb_listener.matching(hb_failed), "published failed event")
+            wait_until(
+                lambda: hb_listener.matching(hb_failed),
+                "published failed event",
+                timeout=timeout,
+            )
         # Reconnect.
         client.admin.command("ping")
 


### PR DESCRIPTION
PYTHON-6002

## Changes in this PR
`test_heartbeat_awaited_flag` was failing near-consistently on the `pypy-3.11-ubuntu-latest` GitHub Actions job (`AssertionError: Didn't ever published failed event`), and occasionally on evergreen hosts running PyPy. PyPy's JIT warm-up can delay the heartbeat monitor thread past the test's 10s `wait_until` timeout on slow CI runners.

- Bump the timeout to 30s specifically on PyPy (`"PyPy" in sys.version`); other interpreters keep 10s.
- Regenerated the sync mirror using `just synchro`.

## Test Plan
- Ran 15x locally under PyPy 3.11 against a local `mongod` — always passed, confirming the race isn't reproducible on demand (it's CI-resource dependent), so this is a timeout fix rather than a logic fix.
- Ran `pytest test/asynchronous/test_streaming_protocol.py test/test_streaming_protocol.py` under both PyPy 3.11 and CPython — all pass.
- `just lint` and `just typing` pass.
- [x] Make sure the all the pypy EVG tasks pass 2 times
- [x] Make sure the GitHub pypy job passes 2 times

## Checklist

### Checklist for Author
- [x] Did you update the changelog (if necessary)? — not needed, test-only change.
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?