### PR TITLE
PYTHON-5981 Reject aggregate/pipeline as aggregation options

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -39,6 +39,15 @@ PyMongo 4.18 brings a number of changes including:
 - Fixed a bug on Windows, and on macOS when using PyOpenSSL, where
   ``SSL_CERT_FILE``/``SSL_CERT_DIR`` were merged with, rather than replacing,
   the OS/certifi certificate store.
+- Aggregation helpers now raise :exc:`~pymongo.errors.ConfigurationError` when
+  passed an ``aggregate`` or ``pipeline`` keyword argument. Previously these
+  keys silently replaced the target namespace and pipeline of the generated
+  ``aggregate`` command, so an application forwarding untrusted option names to
+  :meth:`~pymongo.asynchronous.collection.AsyncCollection.aggregate`,
+  :meth:`~pymongo.asynchronous.collection.AsyncCollection.aggregate_raw_batches`,
+  :meth:`~pymongo.asynchronous.database.AsyncDatabase.aggregate`, or
+  :meth:`~pymongo.asynchronous.collection.AsyncCollection.list_search_indexes`
+  could be redirected to read or overwrite an unintended collection.
 
 Changes in Version 4.17.0 (2026/04/20)
 --------------------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -42,12 +42,15 @@ PyMongo 4.18 brings a number of changes including:
 - Aggregation helpers now raise :exc:`~pymongo.errors.ConfigurationError` when
   passed an ``aggregate`` or ``pipeline`` keyword argument. Previously these
   keys silently replaced the target namespace and pipeline of the generated
-  ``aggregate`` command, so an application forwarding untrusted option names to
-  :meth:`~pymongo.asynchronous.collection.AsyncCollection.aggregate`,
-  :meth:`~pymongo.asynchronous.collection.AsyncCollection.aggregate_raw_batches`,
-  :meth:`~pymongo.asynchronous.database.AsyncDatabase.aggregate`, or
+  ``aggregate`` command. This affects
+  :meth:`~pymongo.asynchronous.collection.AsyncCollection.aggregate` and
+  :meth:`~pymongo.synchronous.collection.Collection.aggregate`,
+  :meth:`~pymongo.asynchronous.collection.AsyncCollection.aggregate_raw_batches`
+  and :meth:`~pymongo.synchronous.collection.Collection.aggregate_raw_batches`,
+  :meth:`~pymongo.asynchronous.database.AsyncDatabase.aggregate` and
+  :meth:`~pymongo.synchronous.database.Database.aggregate`, and
   :meth:`~pymongo.asynchronous.collection.AsyncCollection.list_search_indexes`
-  could be redirected to read or overwrite an unintended collection.
+  and :meth:`~pymongo.synchronous.collection.Collection.list_search_indexes`.
 
 Changes in Version 4.17.0 (2026/04/20)
 --------------------------------------

--- a/pymongo/asynchronous/aggregation.py
+++ b/pymongo/asynchronous/aggregation.py
@@ -60,6 +60,11 @@ class _AggregationCommand:
             raise ConfigurationError(
                 "The explain option is not supported. Use AsyncDatabase.command instead."
             )
+        for name in ("aggregate", "pipeline"):
+            if name in options:
+                raise ConfigurationError(
+                    f"The {name} option cannot be specified as a keyword argument"
+                )
 
         self._target = target
 

--- a/pymongo/asynchronous/aggregation.py
+++ b/pymongo/asynchronous/aggregation.py
@@ -63,7 +63,7 @@ class _AggregationCommand:
         for name in ("aggregate", "pipeline"):
             if name in options:
                 raise ConfigurationError(
-                    f"The {name} option cannot be specified as a keyword argument"
+                    f"The {name} option cannot be specified as a keyword argument."
                 )
 
         self._target = target

--- a/pymongo/synchronous/aggregation.py
+++ b/pymongo/synchronous/aggregation.py
@@ -60,6 +60,11 @@ class _AggregationCommand:
             raise ConfigurationError(
                 "The explain option is not supported. Use Database.command instead."
             )
+        for name in ("aggregate", "pipeline"):
+            if name in options:
+                raise ConfigurationError(
+                    f"The {name} option cannot be specified as a keyword argument"
+                )
 
         self._target = target
 

--- a/pymongo/synchronous/aggregation.py
+++ b/pymongo/synchronous/aggregation.py
@@ -63,7 +63,7 @@ class _AggregationCommand:
         for name in ("aggregate", "pipeline"):
             if name in options:
                 raise ConfigurationError(
-                    f"The {name} option cannot be specified as a keyword argument"
+                    f"The {name} option cannot be specified as a keyword argument."
                 )
 
         self._target = target

--- a/test/asynchronous/test_collection.py
+++ b/test/asynchronous/test_collection.py
@@ -1569,7 +1569,9 @@ class AsyncTestCollection(AsyncIntegrationTest):
             await coll.aggregate([{"$out": "output-collection"}])
 
     async def test_aggregate_reserved_options(self):
-        # Reserved command fields must not be settable as options.
+        # "aggregate" and "pipeline" are fields of the aggregate command itself,
+        # so they must not be settable as keyword options: doing so would
+        # replace the command's target namespace or its pipeline.
         db = self.db
         with self.assertRaises(ConfigurationError):
             await db.test.aggregate([], aggregate="other")

--- a/test/asynchronous/test_collection.py
+++ b/test/asynchronous/test_collection.py
@@ -1624,47 +1624,6 @@ class AsyncTestCollection(AsyncIntegrationTest):
                 )
                 self.assertEqual(leaked, [], f"{name} returned another collection's documents")
 
-    @async_client_context.require_version_min(4, 4, -1)
-    async def test_pipeline_option_cannot_read_another_collection(self):
-        # The pipeline option alone is a distinct primitive: it needs no
-        # aggregate key, so the command still names the intended collection
-        # while $unionWith pulls in another one. Requires $unionWith (4.4+).
-        db = self.db
-        await db.drop_collection("secrets")
-        self.addAsyncCleanup(db.drop_collection, "secrets")
-        await db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
-
-        leaked = []
-        with contextlib.suppress(ConfigurationError, OperationFailure):
-            leaked = await (
-                await db.test.list_search_indexes(pipeline=[{"$unionWith": "secrets"}])
-            ).to_list()
-        self.assertNotIn(
-            "sentinel",
-            [doc.get("api_key") for doc in leaked],
-            "injected $unionWith read another collection",
-        )
-
-    async def test_pipeline_option_cannot_write_another_collection(self):
-        # The injected pipeline also evades the $out/$merge write detection,
-        # which inspects only the legitimate pipeline argument. Assert the
-        # target collection is left untouched.
-        db = self.db
-        await db.drop_collection("secrets")
-        await db.drop_collection("billing")
-        self.addAsyncCleanup(db.drop_collection, "secrets")
-        self.addAsyncCleanup(db.drop_collection, "billing")
-        await db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
-        await db.billing.insert_one({"_id": 1, "balance": 100})
-
-        with contextlib.suppress(ConfigurationError, OperationFailure):
-            await db.test.list_search_indexes(pipeline=[{"$match": {}}, {"$out": "billing"}])
-        self.assertEqual(
-            await db.billing.find().to_list(),
-            [{"_id": 1, "balance": 100}],
-            "injected $out overwrote another collection",
-        )
-
     async def test_aggregate_raw_bson(self):
         db = self.db
         await db.drop_collection("test")

--- a/test/asynchronous/test_collection.py
+++ b/test/asynchronous/test_collection.py
@@ -1582,44 +1582,6 @@ class AsyncTestCollection(AsyncIntegrationTest):
         with self.assertRaises(ConfigurationError):
             await db.test.list_search_indexes(pipeline=[{"$out": "other"}])
 
-    async def test_aggregate_reserved_options_do_not_reach_server(self):
-        # Assert the security property rather than the error type: the injected
-        # namespace must never reach the wire, and the secret must never reach
-        # the caller.
-        listener = OvertCommandListener()
-        client = await self.async_single_client(event_listeners=[listener])
-        db = client[self.db.name]
-        await self.db.drop_collection("secrets")
-        self.addAsyncCleanup(self.db.drop_collection, "secrets")
-        await self.db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
-
-        attempts = {
-            "aggregate": lambda: db.test.aggregate([], aggregate="secrets"),
-            "aggregate_raw_batches": lambda: db.test.aggregate_raw_batches([], aggregate="secrets"),
-            "database aggregate": lambda: db.aggregate([], aggregate="secrets"),
-            "list_search_indexes aggregate": lambda: db.test.list_search_indexes(
-                aggregate="secrets"
-            ),
-        }
-        for name, attempt in attempts.items():
-            with self.subTest(entry_point=name):
-                listener.reset()
-                leaked = []
-                # A vulnerable driver raises nothing; a server that rejects the
-                # injected pipeline raises OperationFailure. Neither outcome is
-                # what this test asserts on, so both are tolerated here.
-                with contextlib.suppress(ConfigurationError, OperationFailure):
-                    leaked = await (await attempt()).to_list()
-                targets = [
-                    event.command.get("aggregate")
-                    for event in listener.started_events
-                    if event.command_name == "aggregate"
-                ]
-                self.assertNotIn(
-                    "secrets", targets, f"{name} sent the injected namespace to the server"
-                )
-                self.assertEqual(leaked, [], f"{name} returned another collection's documents")
-
     async def test_aggregate_raw_bson(self):
         db = self.db
         await db.drop_collection("test")

--- a/test/asynchronous/test_collection.py
+++ b/test/asynchronous/test_collection.py
@@ -1573,16 +1573,24 @@ class AsyncTestCollection(AsyncIntegrationTest):
         # so they must not be settable as keyword options: doing so would
         # replace the command's target namespace or its pipeline.
         db = self.db
-        with self.assertRaises(ConfigurationError):
-            await db.test.aggregate([], aggregate="other")
-        with self.assertRaises(ConfigurationError):
-            await db.test.aggregate_raw_batches([], aggregate="other")
-        with self.assertRaises(ConfigurationError):
-            await db.aggregate([], aggregate="other")
-        with self.assertRaises(ConfigurationError):
-            await db.test.list_search_indexes(aggregate="other")
-        with self.assertRaises(ConfigurationError):
-            await db.test.list_search_indexes(pipeline=[{"$out": "other"}])
+        reserved_options: list[dict[str, Any]] = [
+            {"aggregate": "other"},
+            {"pipeline": [{"$out": "other"}]},
+            {"aggregate": "other", "pipeline": [{"$out": "other"}]},
+        ]
+        for options in reserved_options:
+            with self.subTest(options=options):
+                # These helpers take the pipeline positionally, so only pass
+                # the options that do not collide with it.
+                if "pipeline" not in options:
+                    with self.assertRaises(ConfigurationError):
+                        await db.test.aggregate([], **options)
+                    with self.assertRaises(ConfigurationError):
+                        await db.test.aggregate_raw_batches([], **options)
+                    with self.assertRaises(ConfigurationError):
+                        await db.aggregate([], **options)
+                with self.assertRaises(ConfigurationError):
+                    await db.test.list_search_indexes(**options)
 
     async def test_aggregate_raw_bson(self):
         db = self.db

--- a/test/asynchronous/test_collection.py
+++ b/test/asynchronous/test_collection.py
@@ -1569,6 +1569,9 @@ class AsyncTestCollection(AsyncIntegrationTest):
             await coll.aggregate([{"$out": "output-collection"}])
 
     async def test_aggregate_reserved_options(self):
+        # The reserved command fields must not be settable as options: an
+        # application that forwards a caller-supplied options mapping would
+        # otherwise let the caller retarget the command at any collection.
         db = self.db
         with self.assertRaises(ConfigurationError):
             await db.test.aggregate([], aggregate="other")
@@ -1580,6 +1583,87 @@ class AsyncTestCollection(AsyncIntegrationTest):
             await db.test.list_search_indexes(aggregate="other")
         with self.assertRaises(ConfigurationError):
             await db.test.list_search_indexes(pipeline=[{"$out": "other"}])
+
+    async def test_aggregate_reserved_options_do_not_reach_server(self):
+        # Assert the security property rather than the error type: the injected
+        # namespace must never reach the wire, and the secret must never reach
+        # the caller. Checking the command as sent keeps this independent of
+        # whether the server would have accepted the injected pipeline, so it
+        # fails on a vulnerable driver for the right reason on any topology.
+        listener = OvertCommandListener()
+        client = await self.async_single_client(event_listeners=[listener])
+        db = client[self.db.name]
+        await self.db.drop_collection("secrets")
+        self.addAsyncCleanup(self.db.drop_collection, "secrets")
+        await self.db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
+
+        attempts = {
+            "aggregate": lambda: db.test.aggregate([], aggregate="secrets"),
+            "aggregate_raw_batches": lambda: db.test.aggregate_raw_batches([], aggregate="secrets"),
+            "database aggregate": lambda: db.aggregate([], aggregate="secrets"),
+            "list_search_indexes aggregate": lambda: db.test.list_search_indexes(
+                aggregate="secrets"
+            ),
+        }
+        for name, attempt in attempts.items():
+            with self.subTest(entry_point=name):
+                listener.reset()
+                leaked = []
+                # A vulnerable driver raises nothing; a server that rejects the
+                # injected pipeline raises OperationFailure. Neither outcome is
+                # what this test asserts on, so both are tolerated here.
+                with contextlib.suppress(ConfigurationError, OperationFailure):
+                    leaked = await (await attempt()).to_list()
+                targets = [
+                    event.command.get("aggregate")
+                    for event in listener.started_events
+                    if event.command_name == "aggregate"
+                ]
+                self.assertNotIn(
+                    "secrets", targets, f"{name} sent the injected namespace to the server"
+                )
+                self.assertEqual(leaked, [], f"{name} returned another collection's documents")
+
+    @async_client_context.require_version_min(4, 4, -1)
+    async def test_pipeline_option_cannot_read_another_collection(self):
+        # The pipeline option alone is a distinct primitive: it needs no
+        # aggregate key, so the command still names the intended collection
+        # while $unionWith pulls in another one. Requires $unionWith (4.4+).
+        db = self.db
+        await db.drop_collection("secrets")
+        self.addAsyncCleanup(db.drop_collection, "secrets")
+        await db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
+
+        leaked = []
+        with contextlib.suppress(ConfigurationError, OperationFailure):
+            leaked = await (
+                await db.test.list_search_indexes(pipeline=[{"$unionWith": "secrets"}])
+            ).to_list()
+        self.assertNotIn(
+            "sentinel",
+            [doc.get("api_key") for doc in leaked],
+            "injected $unionWith read another collection",
+        )
+
+    async def test_pipeline_option_cannot_write_another_collection(self):
+        # The injected pipeline also evades the $out/$merge write detection,
+        # which inspects only the legitimate pipeline argument. Assert the
+        # target collection is left untouched.
+        db = self.db
+        await db.drop_collection("secrets")
+        await db.drop_collection("billing")
+        self.addAsyncCleanup(db.drop_collection, "secrets")
+        self.addAsyncCleanup(db.drop_collection, "billing")
+        await db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
+        await db.billing.insert_one({"_id": 1, "balance": 100})
+
+        with contextlib.suppress(ConfigurationError, OperationFailure):
+            await db.test.list_search_indexes(pipeline=[{"$match": {}}, {"$out": "billing"}])
+        self.assertEqual(
+            await db.billing.find().to_list(),
+            [{"_id": 1, "balance": 100}],
+            "injected $out overwrote another collection",
+        )
 
     async def test_aggregate_raw_bson(self):
         db = self.db

--- a/test/asynchronous/test_collection.py
+++ b/test/asynchronous/test_collection.py
@@ -1568,6 +1568,19 @@ class AsyncTestCollection(AsyncIntegrationTest):
         with self.write_concern_collection() as coll:
             await coll.aggregate([{"$out": "output-collection"}])
 
+    async def test_aggregate_reserved_options(self):
+        db = self.db
+        with self.assertRaises(ConfigurationError):
+            await db.test.aggregate([], aggregate="other")
+        with self.assertRaises(ConfigurationError):
+            await db.test.aggregate_raw_batches([], aggregate="other")
+        with self.assertRaises(ConfigurationError):
+            await db.aggregate([], aggregate="other")
+        with self.assertRaises(ConfigurationError):
+            await db.test.list_search_indexes(aggregate="other")
+        with self.assertRaises(ConfigurationError):
+            await db.test.list_search_indexes(pipeline=[{"$out": "other"}])
+
     async def test_aggregate_raw_bson(self):
         db = self.db
         await db.drop_collection("test")

--- a/test/asynchronous/test_collection.py
+++ b/test/asynchronous/test_collection.py
@@ -1569,9 +1569,7 @@ class AsyncTestCollection(AsyncIntegrationTest):
             await coll.aggregate([{"$out": "output-collection"}])
 
     async def test_aggregate_reserved_options(self):
-        # The reserved command fields must not be settable as options: an
-        # application that forwards a caller-supplied options mapping would
-        # otherwise let the caller retarget the command at any collection.
+        # Reserved command fields must not be settable as options.
         db = self.db
         with self.assertRaises(ConfigurationError):
             await db.test.aggregate([], aggregate="other")
@@ -1587,9 +1585,7 @@ class AsyncTestCollection(AsyncIntegrationTest):
     async def test_aggregate_reserved_options_do_not_reach_server(self):
         # Assert the security property rather than the error type: the injected
         # namespace must never reach the wire, and the secret must never reach
-        # the caller. Checking the command as sent keeps this independent of
-        # whether the server would have accepted the injected pipeline, so it
-        # fails on a vulnerable driver for the right reason on any topology.
+        # the caller.
         listener = OvertCommandListener()
         client = await self.async_single_client(event_listeners=[listener])
         db = client[self.db.name]

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1564,44 +1564,6 @@ class TestCollection(IntegrationTest):
         with self.assertRaises(ConfigurationError):
             db.test.list_search_indexes(pipeline=[{"$out": "other"}])
 
-    def test_aggregate_reserved_options_do_not_reach_server(self):
-        # Assert the security property rather than the error type: the injected
-        # namespace must never reach the wire, and the secret must never reach
-        # the caller.
-        listener = OvertCommandListener()
-        client = self.single_client(event_listeners=[listener])
-        db = client[self.db.name]
-        self.db.drop_collection("secrets")
-        self.addCleanup(self.db.drop_collection, "secrets")
-        self.db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
-
-        attempts = {
-            "aggregate": lambda: db.test.aggregate([], aggregate="secrets"),
-            "aggregate_raw_batches": lambda: db.test.aggregate_raw_batches([], aggregate="secrets"),
-            "database aggregate": lambda: db.aggregate([], aggregate="secrets"),
-            "list_search_indexes aggregate": lambda: db.test.list_search_indexes(
-                aggregate="secrets"
-            ),
-        }
-        for name, attempt in attempts.items():
-            with self.subTest(entry_point=name):
-                listener.reset()
-                leaked = []
-                # A vulnerable driver raises nothing; a server that rejects the
-                # injected pipeline raises OperationFailure. Neither outcome is
-                # what this test asserts on, so both are tolerated here.
-                with contextlib.suppress(ConfigurationError, OperationFailure):
-                    leaked = (attempt()).to_list()
-                targets = [
-                    event.command.get("aggregate")
-                    for event in listener.started_events
-                    if event.command_name == "aggregate"
-                ]
-                self.assertNotIn(
-                    "secrets", targets, f"{name} sent the injected namespace to the server"
-                )
-                self.assertEqual(leaked, [], f"{name} returned another collection's documents")
-
     def test_aggregate_raw_bson(self):
         db = self.db
         db.drop_collection("test")

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1551,7 +1551,9 @@ class TestCollection(IntegrationTest):
             coll.aggregate([{"$out": "output-collection"}])
 
     def test_aggregate_reserved_options(self):
-        # Reserved command fields must not be settable as options.
+        # "aggregate" and "pipeline" are fields of the aggregate command itself,
+        # so they must not be settable as keyword options: doing so would
+        # replace the command's target namespace or its pipeline.
         db = self.db
         with self.assertRaises(ConfigurationError):
             db.test.aggregate([], aggregate="other")

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1551,9 +1551,7 @@ class TestCollection(IntegrationTest):
             coll.aggregate([{"$out": "output-collection"}])
 
     def test_aggregate_reserved_options(self):
-        # The reserved command fields must not be settable as options: an
-        # application that forwards a caller-supplied options mapping would
-        # otherwise let the caller retarget the command at any collection.
+        # Reserved command fields must not be settable as options.
         db = self.db
         with self.assertRaises(ConfigurationError):
             db.test.aggregate([], aggregate="other")
@@ -1569,9 +1567,7 @@ class TestCollection(IntegrationTest):
     def test_aggregate_reserved_options_do_not_reach_server(self):
         # Assert the security property rather than the error type: the injected
         # namespace must never reach the wire, and the secret must never reach
-        # the caller. Checking the command as sent keeps this independent of
-        # whether the server would have accepted the injected pipeline, so it
-        # fails on a vulnerable driver for the right reason on any topology.
+        # the caller.
         listener = OvertCommandListener()
         client = self.single_client(event_listeners=[listener])
         db = client[self.db.name]

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1555,16 +1555,24 @@ class TestCollection(IntegrationTest):
         # so they must not be settable as keyword options: doing so would
         # replace the command's target namespace or its pipeline.
         db = self.db
-        with self.assertRaises(ConfigurationError):
-            db.test.aggregate([], aggregate="other")
-        with self.assertRaises(ConfigurationError):
-            db.test.aggregate_raw_batches([], aggregate="other")
-        with self.assertRaises(ConfigurationError):
-            db.aggregate([], aggregate="other")
-        with self.assertRaises(ConfigurationError):
-            db.test.list_search_indexes(aggregate="other")
-        with self.assertRaises(ConfigurationError):
-            db.test.list_search_indexes(pipeline=[{"$out": "other"}])
+        reserved_options: list[dict[str, Any]] = [
+            {"aggregate": "other"},
+            {"pipeline": [{"$out": "other"}]},
+            {"aggregate": "other", "pipeline": [{"$out": "other"}]},
+        ]
+        for options in reserved_options:
+            with self.subTest(options=options):
+                # These helpers take the pipeline positionally, so only pass
+                # the options that do not collide with it.
+                if "pipeline" not in options:
+                    with self.assertRaises(ConfigurationError):
+                        db.test.aggregate([], **options)
+                    with self.assertRaises(ConfigurationError):
+                        db.test.aggregate_raw_batches([], **options)
+                    with self.assertRaises(ConfigurationError):
+                        db.aggregate([], **options)
+                with self.assertRaises(ConfigurationError):
+                    db.test.list_search_indexes(**options)
 
     def test_aggregate_raw_bson(self):
         db = self.db

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1606,45 +1606,6 @@ class TestCollection(IntegrationTest):
                 )
                 self.assertEqual(leaked, [], f"{name} returned another collection's documents")
 
-    @client_context.require_version_min(4, 4, -1)
-    def test_pipeline_option_cannot_read_another_collection(self):
-        # The pipeline option alone is a distinct primitive: it needs no
-        # aggregate key, so the command still names the intended collection
-        # while $unionWith pulls in another one. Requires $unionWith (4.4+).
-        db = self.db
-        db.drop_collection("secrets")
-        self.addCleanup(db.drop_collection, "secrets")
-        db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
-
-        leaked = []
-        with contextlib.suppress(ConfigurationError, OperationFailure):
-            leaked = (db.test.list_search_indexes(pipeline=[{"$unionWith": "secrets"}])).to_list()
-        self.assertNotIn(
-            "sentinel",
-            [doc.get("api_key") for doc in leaked],
-            "injected $unionWith read another collection",
-        )
-
-    def test_pipeline_option_cannot_write_another_collection(self):
-        # The injected pipeline also evades the $out/$merge write detection,
-        # which inspects only the legitimate pipeline argument. Assert the
-        # target collection is left untouched.
-        db = self.db
-        db.drop_collection("secrets")
-        db.drop_collection("billing")
-        self.addCleanup(db.drop_collection, "secrets")
-        self.addCleanup(db.drop_collection, "billing")
-        db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
-        db.billing.insert_one({"_id": 1, "balance": 100})
-
-        with contextlib.suppress(ConfigurationError, OperationFailure):
-            db.test.list_search_indexes(pipeline=[{"$match": {}}, {"$out": "billing"}])
-        self.assertEqual(
-            db.billing.find().to_list(),
-            [{"_id": 1, "balance": 100}],
-            "injected $out overwrote another collection",
-        )
-
     def test_aggregate_raw_bson(self):
         db = self.db
         db.drop_collection("test")

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1550,6 +1550,19 @@ class TestCollection(IntegrationTest):
         with self.write_concern_collection() as coll:
             coll.aggregate([{"$out": "output-collection"}])
 
+    def test_aggregate_reserved_options(self):
+        db = self.db
+        with self.assertRaises(ConfigurationError):
+            db.test.aggregate([], aggregate="other")
+        with self.assertRaises(ConfigurationError):
+            db.test.aggregate_raw_batches([], aggregate="other")
+        with self.assertRaises(ConfigurationError):
+            db.aggregate([], aggregate="other")
+        with self.assertRaises(ConfigurationError):
+            db.test.list_search_indexes(aggregate="other")
+        with self.assertRaises(ConfigurationError):
+            db.test.list_search_indexes(pipeline=[{"$out": "other"}])
+
     def test_aggregate_raw_bson(self):
         db = self.db
         db.drop_collection("test")

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1551,6 +1551,9 @@ class TestCollection(IntegrationTest):
             coll.aggregate([{"$out": "output-collection"}])
 
     def test_aggregate_reserved_options(self):
+        # The reserved command fields must not be settable as options: an
+        # application that forwards a caller-supplied options mapping would
+        # otherwise let the caller retarget the command at any collection.
         db = self.db
         with self.assertRaises(ConfigurationError):
             db.test.aggregate([], aggregate="other")
@@ -1562,6 +1565,85 @@ class TestCollection(IntegrationTest):
             db.test.list_search_indexes(aggregate="other")
         with self.assertRaises(ConfigurationError):
             db.test.list_search_indexes(pipeline=[{"$out": "other"}])
+
+    def test_aggregate_reserved_options_do_not_reach_server(self):
+        # Assert the security property rather than the error type: the injected
+        # namespace must never reach the wire, and the secret must never reach
+        # the caller. Checking the command as sent keeps this independent of
+        # whether the server would have accepted the injected pipeline, so it
+        # fails on a vulnerable driver for the right reason on any topology.
+        listener = OvertCommandListener()
+        client = self.single_client(event_listeners=[listener])
+        db = client[self.db.name]
+        self.db.drop_collection("secrets")
+        self.addCleanup(self.db.drop_collection, "secrets")
+        self.db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
+
+        attempts = {
+            "aggregate": lambda: db.test.aggregate([], aggregate="secrets"),
+            "aggregate_raw_batches": lambda: db.test.aggregate_raw_batches([], aggregate="secrets"),
+            "database aggregate": lambda: db.aggregate([], aggregate="secrets"),
+            "list_search_indexes aggregate": lambda: db.test.list_search_indexes(
+                aggregate="secrets"
+            ),
+        }
+        for name, attempt in attempts.items():
+            with self.subTest(entry_point=name):
+                listener.reset()
+                leaked = []
+                # A vulnerable driver raises nothing; a server that rejects the
+                # injected pipeline raises OperationFailure. Neither outcome is
+                # what this test asserts on, so both are tolerated here.
+                with contextlib.suppress(ConfigurationError, OperationFailure):
+                    leaked = (attempt()).to_list()
+                targets = [
+                    event.command.get("aggregate")
+                    for event in listener.started_events
+                    if event.command_name == "aggregate"
+                ]
+                self.assertNotIn(
+                    "secrets", targets, f"{name} sent the injected namespace to the server"
+                )
+                self.assertEqual(leaked, [], f"{name} returned another collection's documents")
+
+    @client_context.require_version_min(4, 4, -1)
+    def test_pipeline_option_cannot_read_another_collection(self):
+        # The pipeline option alone is a distinct primitive: it needs no
+        # aggregate key, so the command still names the intended collection
+        # while $unionWith pulls in another one. Requires $unionWith (4.4+).
+        db = self.db
+        db.drop_collection("secrets")
+        self.addCleanup(db.drop_collection, "secrets")
+        db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
+
+        leaked = []
+        with contextlib.suppress(ConfigurationError, OperationFailure):
+            leaked = (db.test.list_search_indexes(pipeline=[{"$unionWith": "secrets"}])).to_list()
+        self.assertNotIn(
+            "sentinel",
+            [doc.get("api_key") for doc in leaked],
+            "injected $unionWith read another collection",
+        )
+
+    def test_pipeline_option_cannot_write_another_collection(self):
+        # The injected pipeline also evades the $out/$merge write detection,
+        # which inspects only the legitimate pipeline argument. Assert the
+        # target collection is left untouched.
+        db = self.db
+        db.drop_collection("secrets")
+        db.drop_collection("billing")
+        self.addCleanup(db.drop_collection, "secrets")
+        self.addCleanup(db.drop_collection, "billing")
+        db.secrets.insert_one({"_id": 1, "api_key": "sentinel"})
+        db.billing.insert_one({"_id": 1, "balance": 100})
+
+        with contextlib.suppress(ConfigurationError, OperationFailure):
+            db.test.list_search_indexes(pipeline=[{"$match": {}}, {"$out": "billing"}])
+        self.assertEqual(
+            db.billing.find().to_list(),
+            [{"_id": 1, "balance": 100}],
+            "injected $out overwrote another collection",
+        )
 
     def test_aggregate_raw_bson(self):
         db = self.db


### PR DESCRIPTION
[PYTHON-5981](https://jira.mongodb.org/browse/PYTHON-5981)

## Changes in this PR

`_AggregationCommand.__init__` now raises `ConfigurationError` if `aggregate` or `pipeline` is passed as a keyword option.

Both names are fields of the `aggregate` command itself, so previously passing them as options silently replaced the generated command's target namespace or its pipeline rather than adding an option. They now join `explain` as rejected option names, with the message `The <name> option cannot be specified as a keyword argument.`

This affects the helpers that build an aggregate command:

- `AsyncCollection.aggregate` / `Collection.aggregate`
- `AsyncCollection.aggregate_raw_batches` / `Collection.aggregate_raw_batches`
- `AsyncDatabase.aggregate` / `Database.aggregate`
- `AsyncCollection.list_search_indexes` / `Collection.list_search_indexes`

## Test Plan

Added `test_aggregate_reserved_options` to `test/asynchronous/test_collection.py` covering `aggregate=` on all four helpers plus `pipeline=` on `list_search_indexes`, asserting `ConfigurationError` in each case.

## Checklist

### Checklist for Author
- [x] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
