### PR TITLE
PYTHON-6056 Remove redundant cleanup in TestSearchIndexProse test_case_3

### DIFF
--- a/test/asynchronous/test_index_management.py
+++ b/test/asynchronous/test_index_management.py
@@ -213,7 +213,6 @@ class TestSearchIndexProse(SearchIndexIntegrationBase):
         # Create a new search index on ``self.coll0``.
         model = {"name": _NAME, "definition": {"mappings": {"dynamic": False}}}
         resp = await self.coll0.create_search_index(model)
-        self.addAsyncCleanup(self.drop_and_wait, self.coll0, _NAME)
 
         # Assert that the command returns the name of the index: ``"test-search-index"``.
         self.assertEqual(resp, "test-search-index")

--- a/test/test_index_management.py
+++ b/test/test_index_management.py
@@ -211,7 +211,6 @@ class TestSearchIndexProse(SearchIndexIntegrationBase):
         # Create a new search index on ``self.coll0``.
         model = {"name": _NAME, "definition": {"mappings": {"dynamic": False}}}
         resp = self.coll0.create_search_index(model)
-        self.addCleanup(self.drop_and_wait, self.coll0, _NAME)
 
         # Assert that the command returns the name of the index: ``"test-search-index"``.
         self.assertEqual(resp, "test-search-index")


### PR DESCRIPTION
PYTHON-6056

## Changes in this PR

PYTHON-6056 (#3012) added `addAsyncCleanup(self.drop_and_wait, self.coll0, _NAME)` to `test_case_3`, but that test already drops the index and waits for `list_search_indexes` to return empty in its own body. The test has failed on every run since #3012 merged (confirmed via Evergreen task history: last pass before the merge, failing on every run after).

- Removed the redundant `addAsyncCleanup`/`addCleanup` call from `test_case_3` in both the async source and its generated sync mirror.

## Test Plan

Run the search_index test: [patch](https://spruce.corp.mongodb.com/task/mongo_python_driver_search_index_helpers_rhel8_test_search_index_helpers_patch_09aa41b80c6d465d78d6507ddc8cedcd67e52876_6a9603ee700c920007ddcbd0_26_08_31_22_45_05/logs?execution=0)

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)? — not needed, test-only fix
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s). — not needed, single self-contained fix

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?