### PR TITLE
PYTHON-6007 Fix versionchanged marker for text_opts in ClientEncryption.encrypt

### DIFF
--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -1089,7 +1089,7 @@ class AsyncClientEncryption(Generic[_DocumentType]):
            Added the `string_opts` parameter, replacing the deprecated
            `text_opts`.
 
-        .. versionchanged:: 4.9
+        .. versionchanged:: 4.15
            Added the `text_opts` parameter.
 
         .. versionchanged:: 4.9

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -1082,7 +1082,7 @@ class ClientEncryption(Generic[_DocumentType]):
            Added the `string_opts` parameter, replacing the deprecated
            `text_opts`.
 
-        .. versionchanged:: 4.9
+        .. versionchanged:: 4.15
            Added the `text_opts` parameter.
 
         .. versionchanged:: 4.9


### PR DESCRIPTION
PYTHON-6007

## Summary
`ClientEncryption.encrypt`'s docstring said the `text_opts` parameter was added in 4.9, but it was actually added in 4.15.0.

## Motivation
The `versionchanged:: 4.9` entry for `text_opts` was copy-pasted from the adjacent `range_opts` entry when `text_opts` was introduced in PYTHON-5328 (GH-2521), which shipped in 4.15.0. The `range_opts` entry itself is correct as-is; it really was added in 4.9.

## Changes
- Corrected the `text_opts` `versionchanged` marker from 4.9 to 4.15 in `pymongo/asynchronous/encryption.py`.
- Regenerated the mirrored change in `pymongo/synchronous/encryption.py` via `just synchro`.

## Testing
- `just lint` and `just typing` (the two pre-existing `pymongo/ocsp_support.py` mypy errors reproduce identically on `main` and are unrelated to this change).
- Docstring-only change; no behavior to test.