### PR TITLE
PYTHON-5975 Fix missing await calls in async test suite

### DIFF
--- a/test/asynchronous/test_client.py
+++ b/test/asynchronous/test_client.py
@@ -31,7 +31,6 @@ import socket
 import struct
 import subprocess
 import sys
-import threading
 import time
 import uuid
 from collections.abc import Iterable
@@ -113,6 +112,7 @@ from test.asynchronous import (
     remove_all_users,
     unittest,
 )
+from test.asynchronous.helpers import ExceptionCatchingTask
 from test.asynchronous.pymongo_mocks import AsyncMockClient
 from test.asynchronous.utils import (
     async_get_pool,
@@ -1972,7 +1972,6 @@ class TestClient(AsyncIntegrationTest):
         if not negotiated:
             self.skipTest("server did not negotiate compression for any compressor")
 
-    @async_client_context.require_sync
     async def test_reset_during_update_pool(self):
         client = await self.async_rs_or_single_client(minPoolSize=10)
         await client.admin.command("ping")
@@ -1980,39 +1979,30 @@ class TestClient(AsyncIntegrationTest):
         generation = pool.gen.get_overall()
 
         # Continuously reset the pool.
-        class ResetPoolThread(threading.Thread):
-            def __init__(self, pool):
-                super().__init__()
-                self.running = True
-                self.pool = pool
+        running = True
 
-            def stop(self):
-                self.running = False
+        async def reset_pool():
+            while running:
+                exc = AutoReconnect("mock pool error")
+                ctx = _ErrorContext(exc, 0, pool.gen.get_overall(), False, None)
+                await client._topology.handle_error(pool.address, ctx)
+                await asyncio.sleep(0.001)
 
-            async def _run(self):
-                while self.running:
-                    exc = AutoReconnect("mock pool error")
-                    ctx = _ErrorContext(exc, 0, pool.gen.get_overall(), False, None)
-                    await client._topology.handle_error(pool.address, ctx)
-                    await asyncio.sleep(0.001)
-
-            def run(self):
-                self._run()
-
-        t = ResetPoolThread(pool)
-        t.start()
+        t = ExceptionCatchingTask(target=reset_pool)
+        await t.start()
 
         # Ensure that update_pool completes without error even when the pool
         # is reset concurrently.
         try:
-            while True:
+            while t.is_alive():
                 for _ in range(10):
                     await client._topology.update_pool()
                 if generation != pool.gen.get_overall():
                     break
         finally:
-            t.stop()
-            t.join()
+            running = False
+            await t.join()
+        self.assertIsNone(t.exc)
         await client.admin.command("ping")
 
     async def test_background_connections_do_not_hold_locks(self):

--- a/test/asynchronous/test_retryable_writes.py
+++ b/test/asynchronous/test_retryable_writes.py
@@ -78,6 +78,12 @@ _IS_SYNC = False
 
 
 class InsertEventListener(EventListener):
+    fail_point_exc: BaseException | None = None
+
+    def _store_fail_point_exc(self, task: asyncio.Task) -> None:
+        if not task.cancelled():
+            self.fail_point_exc = task.exception()
+
     def succeeded(self, event: CommandSucceededEvent) -> None:
         super().succeeded(event)
         if (
@@ -99,6 +105,7 @@ class InsertEventListener(EventListener):
                 # succeeded() cannot await, so the fail point may be configured after
                 # the driver dispatches the retry it is meant to fail.
                 self._task = create_task(async_client_context.client.admin.command(cmd))  # type: ignore[arg-type]
+                self._task.add_done_callback(self._store_fail_point_exc)
 
 
 def retryable_single_statement_ops(coll):
@@ -564,6 +571,7 @@ class TestPoolPausedError(AsyncIntegrationTest):
         with self.assertRaises(WriteConcernError) as exc:
             await client.test.test.insert_one({"_id": 1})
         self.assertEqual(exc.exception.code, 91)
+        self.assertIsNone(cmd_listener.fail_point_exc)
         await client.admin.command(
             {
                 "configureFailPoint": "failCommand",

--- a/test/asynchronous/test_retryable_writes.py
+++ b/test/asynchronous/test_retryable_writes.py
@@ -23,6 +23,7 @@ import sys
 import threading
 from unittest import mock
 
+from pymongo._asyncio_task import create_task
 from pymongo.common import MAX_ADAPTIVE_RETRIES
 from test.asynchronous.utils import async_set_fail_point, flaky
 
@@ -83,17 +84,21 @@ class InsertEventListener(EventListener):
             event.command_name == "insert"
             and event.reply.get("writeConcernError", {}).get("code", None) == 91
         ):
-            async_client_context.client.admin.command(
-                {
-                    "configureFailPoint": "failCommand",
-                    "mode": {"times": 1},
-                    "data": {
-                        "errorCode": 10107,
-                        "errorLabels": ["RetryableWriteError", "NoWritesPerformed"],
-                        "failCommands": ["insert"],
-                    },
-                }
-            )
+            cmd = {
+                "configureFailPoint": "failCommand",
+                "mode": {"times": 1},
+                "data": {
+                    "errorCode": 10107,
+                    "errorLabels": ["RetryableWriteError", "NoWritesPerformed"],
+                    "failCommands": ["insert"],
+                },
+            }
+            if _IS_SYNC:
+                async_client_context.client.admin.command(cmd)
+            else:
+                # succeeded() cannot await, so the fail point may be configured after
+                # the driver dispatches the retry it is meant to fail.
+                self._task = create_task(async_client_context.client.admin.command(cmd))  # type: ignore[arg-type]
 
 
 def retryable_single_statement_ops(coll):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -31,7 +31,6 @@ import socket
 import struct
 import subprocess
 import sys
-import threading
 import time
 import uuid
 from collections.abc import Iterable
@@ -112,6 +111,7 @@ from test import (
     remove_all_users,
     unittest,
 )
+from test.helpers import ExceptionCatchingTask
 from test.pymongo_mocks import MockClient
 from test.test_binary import BinaryData
 from test.utils import (
@@ -1925,7 +1925,6 @@ class TestClient(IntegrationTest):
         if not negotiated:
             self.skipTest("server did not negotiate compression for any compressor")
 
-    @client_context.require_sync
     def test_reset_during_update_pool(self):
         client = self.rs_or_single_client(minPoolSize=10)
         client.admin.command("ping")
@@ -1933,39 +1932,30 @@ class TestClient(IntegrationTest):
         generation = pool.gen.get_overall()
 
         # Continuously reset the pool.
-        class ResetPoolThread(threading.Thread):
-            def __init__(self, pool):
-                super().__init__()
-                self.running = True
-                self.pool = pool
+        running = True
 
-            def stop(self):
-                self.running = False
+        def reset_pool():
+            while running:
+                exc = AutoReconnect("mock pool error")
+                ctx = _ErrorContext(exc, 0, pool.gen.get_overall(), False, None)
+                client._topology.handle_error(pool.address, ctx)
+                time.sleep(0.001)
 
-            def _run(self):
-                while self.running:
-                    exc = AutoReconnect("mock pool error")
-                    ctx = _ErrorContext(exc, 0, pool.gen.get_overall(), False, None)
-                    client._topology.handle_error(pool.address, ctx)
-                    time.sleep(0.001)
-
-            def run(self):
-                self._run()
-
-        t = ResetPoolThread(pool)
+        t = ExceptionCatchingTask(target=reset_pool)
         t.start()
 
         # Ensure that update_pool completes without error even when the pool
         # is reset concurrently.
         try:
-            while True:
+            while t.is_alive():
                 for _ in range(10):
                     client._topology.update_pool()
                 if generation != pool.gen.get_overall():
                     break
         finally:
-            t.stop()
+            running = False
             t.join()
+        self.assertIsNone(t.exc)
         client.admin.command("ping")
 
     def test_background_connections_do_not_hold_locks(self):

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -23,6 +23,7 @@ import sys
 import threading
 from unittest import mock
 
+from pymongo._asyncio_task import create_task
 from pymongo.common import MAX_ADAPTIVE_RETRIES
 from test.utils import flaky, set_fail_point
 
@@ -83,17 +84,21 @@ class InsertEventListener(EventListener):
             event.command_name == "insert"
             and event.reply.get("writeConcernError", {}).get("code", None) == 91
         ):
-            client_context.client.admin.command(
-                {
-                    "configureFailPoint": "failCommand",
-                    "mode": {"times": 1},
-                    "data": {
-                        "errorCode": 10107,
-                        "errorLabels": ["RetryableWriteError", "NoWritesPerformed"],
-                        "failCommands": ["insert"],
-                    },
-                }
-            )
+            cmd = {
+                "configureFailPoint": "failCommand",
+                "mode": {"times": 1},
+                "data": {
+                    "errorCode": 10107,
+                    "errorLabels": ["RetryableWriteError", "NoWritesPerformed"],
+                    "failCommands": ["insert"],
+                },
+            }
+            if _IS_SYNC:
+                client_context.client.admin.command(cmd)
+            else:
+                # succeeded() cannot await, so the fail point may be configured after
+                # the driver dispatches the retry it is meant to fail.
+                self._task = create_task(client_context.client.admin.command(cmd))  # type: ignore[arg-type]
 
 
 def retryable_single_statement_ops(coll):

--- a/test/test_retryable_writes.py
+++ b/test/test_retryable_writes.py
@@ -78,6 +78,12 @@ _IS_SYNC = True
 
 
 class InsertEventListener(EventListener):
+    fail_point_exc: BaseException | None = None
+
+    def _store_fail_point_exc(self, task: asyncio.Task) -> None:
+        if not task.cancelled():
+            self.fail_point_exc = task.exception()
+
     def succeeded(self, event: CommandSucceededEvent) -> None:
         super().succeeded(event)
         if (
@@ -99,6 +105,7 @@ class InsertEventListener(EventListener):
                 # succeeded() cannot await, so the fail point may be configured after
                 # the driver dispatches the retry it is meant to fail.
                 self._task = create_task(client_context.client.admin.command(cmd))  # type: ignore[arg-type]
+                self._task.add_done_callback(self._store_fail_point_exc)
 
 
 def retryable_single_statement_ops(coll):
@@ -560,6 +567,7 @@ class TestPoolPausedError(IntegrationTest):
         with self.assertRaises(WriteConcernError) as exc:
             client.test.test.insert_one({"_id": 1})
         self.assertEqual(exc.exception.code, 91)
+        self.assertIsNone(cmd_listener.fail_point_exc)
         client.admin.command(
             {
                 "configureFailPoint": "failCommand",


### PR DESCRIPTION
PYTHON-5975

## Changes in this PR
- Replaced the raw `threading.Thread` in `test_reset_during_update_pool` with `ExceptionCatchingTask`, so the pool-reset loop actually runs.
- Dropped that test's `require_sync`, which existed only because of the raw thread.
- Asserted the background task's exception, so a broken pool-reset loop fails the test instead of hanging it.
- Fixed `InsertEventListener.succeeded()` to run its `configureFailPoint` command instead of dropping an unawaited coroutine.
- Consumed that command's exception through a done callback.

## Test Plan
- `test_reset_during_update_pool` went from `SKIPPED` to passing in the async suite.
- `test_returns_original_error_code` passes, and I confirmed the listener's fail point branch executes rather than passing vacuously.
- Both suites pass against a local replica set (9.1.0): sync 140 passed / 11 skipped, async 132 passed / 19 skipped.
- `just lint`, `just synchro`, and `mypy --config-file mypy_test.ini` are clean on all four files.
- Unverified: the listener's `create_task` branch, which its own `require_sync` still gates. A synchronous monitoring callback cannot await, so nothing orders the fail point ahead of the retry it targets.

## Checklist

### Checklist for Author
- [ ] Did you update the changelog (if necessary)? Test-only fix, no user-facing change.
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s). Static-check follow-up noted on PYTHON-5976.

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?