### PR TITLE
PYTHON-6070 Improve help output for just run-server and just setup-tests

### DIFF
--- a/.evergreen/scripts/run_server.py
+++ b/.evergreen/scripts/run_server.py
@@ -13,13 +13,8 @@ def set_env(name: str, value: Any = "1") -> None:
 
 
 def start_server():
-    if not DRIVERS_TOOLS:
-        raise ValueError(
-            "DRIVERS_TOOLS is not set; run `just run-server` from an Evergreen task "
-            "or set DRIVERS_TOOLS to a drivers-evergreen-tools checkout."
-        )
-
-    if {"-h", "--help"} & set(sys.argv[1:]):
+    want_help = bool({"-h", "--help"} & set(sys.argv[1:]))
+    if want_help and DRIVERS_TOOLS:
         # Forward straight to run-mongodb.sh's own help, without run_command's
         # "Running command..." logging noise.
         subprocess.run(  # noqa: S603
@@ -28,6 +23,14 @@ def start_server():
             check=True,
         )
         return
+
+    # DRIVERS_TOOLS is only needed to actually start a server. When it's unset and
+    # -h/--help was requested, fall through to get_test_options' own argparse help below.
+    if not want_help and not DRIVERS_TOOLS:
+        raise ValueError(
+            "DRIVERS_TOOLS is not set; run `just run-server` from an Evergreen task "
+            "or set DRIVERS_TOOLS to a drivers-evergreen-tools checkout."
+        )
 
     opts, extra_opts = get_test_options(
         "Run a MongoDB server.  All given flags will be passed to run-mongodb.sh in DRIVERS_TOOLS.",

--- a/.evergreen/scripts/run_server.py
+++ b/.evergreen/scripts/run_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from typing import Any
 
@@ -19,9 +20,12 @@ def start_server():
         )
 
     if {"-h", "--help"} & set(sys.argv[1:]):
-        run_command(
-            ["bash", f"{DRIVERS_TOOLS}/.evergreen/run-mongodb.sh", "start", "-h"],
+        # Forward straight to run-mongodb.sh's own help, without run_command's
+        # "Running command..." logging noise.
+        subprocess.run(  # noqa: S603
+            ["bash", f"{DRIVERS_TOOLS}/.evergreen/run-mongodb.sh", "start", "-h"],  # noqa: S607
             cwd=DRIVERS_TOOLS,
+            check=True,
         )
         return
 

--- a/.evergreen/scripts/run_server.py
+++ b/.evergreen/scripts/run_server.py
@@ -13,7 +13,10 @@ def set_env(name: str, value: Any = "1") -> None:
 
 def start_server():
     if {"-h", "--help"} & set(sys.argv[1:]):
-        run_command(["bash", f"{DRIVERS_TOOLS}/.evergreen/run-mongodb.sh", "start", "-h"])
+        run_command(
+            ["bash", f"{DRIVERS_TOOLS}/.evergreen/run-mongodb.sh", "start", "-h"],
+            cwd=DRIVERS_TOOLS,
+        )
         return
 
     opts, extra_opts = get_test_options(

--- a/.evergreen/scripts/run_server.py
+++ b/.evergreen/scripts/run_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import Any
 
 from utils import DRIVERS_TOOLS, ROOT, get_test_options, run_command
@@ -11,6 +12,10 @@ def set_env(name: str, value: Any = "1") -> None:
 
 
 def start_server():
+    if {"-h", "--help"} & set(sys.argv[1:]):
+        run_command(["bash", f"{DRIVERS_TOOLS}/.evergreen/run-mongodb.sh", "start", "-h"])
+        return
+
     opts, extra_opts = get_test_options(
         "Run a MongoDB server.  All given flags will be passed to run-mongodb.sh in DRIVERS_TOOLS.",
         require_sub_test_name=False,

--- a/.evergreen/scripts/run_server.py
+++ b/.evergreen/scripts/run_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 from utils import DRIVERS_TOOLS, ROOT, get_test_options, run_command
@@ -13,12 +14,15 @@ def set_env(name: str, value: Any = "1") -> None:
 
 
 def start_server():
+    run_mongodb_script = (
+        Path(DRIVERS_TOOLS) / ".evergreen" / "run-mongodb.sh" if DRIVERS_TOOLS else None
+    )
     want_help = bool({"-h", "--help"} & set(sys.argv[1:]))
-    if want_help and DRIVERS_TOOLS:
+    if want_help and run_mongodb_script and run_mongodb_script.is_file():
         # Forward straight to run-mongodb.sh's own help, without run_command's
         # "Running command..." logging noise.
         subprocess.run(  # noqa: S603
-            ["bash", f"{DRIVERS_TOOLS}/.evergreen/run-mongodb.sh", "start", "-h"],  # noqa: S607
+            ["bash", str(run_mongodb_script), "start", "-h"],  # noqa: S607
             cwd=DRIVERS_TOOLS,
             check=True,
         )

--- a/.evergreen/scripts/run_server.py
+++ b/.evergreen/scripts/run_server.py
@@ -12,6 +12,12 @@ def set_env(name: str, value: Any = "1") -> None:
 
 
 def start_server():
+    if not DRIVERS_TOOLS:
+        raise ValueError(
+            "DRIVERS_TOOLS is not set; run `just run-server` from an Evergreen task "
+            "or set DRIVERS_TOOLS to a drivers-evergreen-tools checkout."
+        )
+
     if {"-h", "--help"} & set(sys.argv[1:]):
         run_command(
             ["bash", f"{DRIVERS_TOOLS}/.evergreen/run-mongodb.sh", "start", "-h"],

--- a/.evergreen/scripts/utils.py
+++ b/.evergreen/scripts/utils.py
@@ -95,6 +95,20 @@ NO_RUN_ORCHESTRATION = [
 # Mapping of env variables to options
 OPTION_TO_ENV_VAR = {"cov": "COVERAGE", "crypt_shared": "TEST_CRYPT_SHARED"}
 
+# Options that consume a following value, so it isn't mistaken for the test_name
+# positional when inferring known_test_name below.
+OPTIONS_WITH_VALUES = ["--green-framework", "--compressor", "--mongodb-api-version"]
+
+
+def _first_positional_arg(argv: list[str]) -> str | None:
+    args = iter(argv)
+    for arg in args:
+        if arg in OPTIONS_WITH_VALUES:
+            next(args, None)
+        elif not arg.startswith("-"):
+            return arg
+    return None
+
 
 def get_test_options(
     description, require_sub_test_name=True, allow_extra_opts=False
@@ -104,9 +118,9 @@ def get_test_options(
     known_test_name = None
     sub_test_choices = None
     if require_sub_test_name:
-        positional_args = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
-        if positional_args and positional_args[0] in SUB_TEST_NAME_MAP:
-            known_test_name = positional_args[0]
+        first_positional = _first_positional_arg(sys.argv[1:])
+        if first_positional in SUB_TEST_NAME_MAP:
+            known_test_name = first_positional
             sub_test_choices = SUB_TEST_NAME_MAP[known_test_name]
             description = f"{description.rstrip('.')} for '{known_test_name}'."
 

--- a/.evergreen/scripts/utils.py
+++ b/.evergreen/scripts/utils.py
@@ -134,15 +134,13 @@ def get_test_options(
             metavar=known_test_name or "test_name",
             help=test_name_help,
         )
-        if sub_test_choices:
-            example_sub_test_name = sub_test_choices[0]
-            help_text = (
-                f"The optional sub test name, for example {example_sub_test_name!r}. "
-                f"One of: {', '.join(sub_test_choices)}."
-            )
+        if known_test_name:
+            example_sub_test_name = sub_test_choices[0] if sub_test_choices else "azure"
+            help_text = f"The sub test name, for example {example_sub_test_name!r}. Required for {known_test_name!r}."
+            if sub_test_choices:
+                help_text += f" One of: {', '.join(sub_test_choices)}."
         else:
-            example_sub_test_name = "azure"
-            help_text = f"The optional sub test name, for example {example_sub_test_name!r}."
+            help_text = "The optional sub test name, for example 'azure'."
         parser.add_argument(
             "sub_test_name",
             nargs="?",

--- a/.evergreen/scripts/utils.py
+++ b/.evergreen/scripts/utils.py
@@ -104,12 +104,10 @@ def get_test_options(
     known_test_name = None
     sub_test_choices = None
     if require_sub_test_name:
-        for arg in sys.argv[1:]:
-            if arg in SUB_TEST_NAME_MAP:
-                known_test_name = arg
-                sub_test_choices = SUB_TEST_NAME_MAP[arg]
-                break
-        if known_test_name:
+        positional_args = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
+        if positional_args and positional_args[0] in SUB_TEST_NAME_MAP:
+            known_test_name = positional_args[0]
+            sub_test_choices = SUB_TEST_NAME_MAP[known_test_name]
             description = f"{description.rstrip('.')} for '{known_test_name}'."
 
     parser = argparse.ArgumentParser(

--- a/.evergreen/scripts/utils.py
+++ b/.evergreen/scripts/utils.py
@@ -48,8 +48,37 @@ TEST_SUITE_MAP = {
     "numpy": "",
 }
 
-# Tests that require a sub test suite.
-SUB_TEST_REQUIRED = ["auth_aws", "auth_oidc", "kms", "mod_wsgi", "perf"]
+# Tests that require a sub test suite, mapped to their valid sub_test_name
+# values, for test names where they're fully enumerable. A value of None
+# means the sub_test_name is required but not restricted to a fixed set.
+SUB_TEST_NAME_MAP: dict[str, list[str] | None] = {
+    "auth_aws": [
+        "regular",
+        "assume-role",
+        "ec2",
+        "env-creds",
+        "session-creds",
+        "web-identity",
+        "ecs",
+        "ecs-remote",
+    ],
+    "kms": ["azure", "azure-remote", "azure-fail", "gcp", "gcp-remote", "gcp-fail"],
+    "mod_wsgi": ["standalone", "embedded"],
+    "perf": ["sync", "async"],
+    "auth_oidc": [
+        "default",
+        "azure",
+        "azure-remote",
+        "gcp",
+        "gcp-remote",
+        "aks",
+        "aks-remote",
+        "gke",
+        "gke-remote",
+        "eks",
+        "eks-remote",
+    ],
+}
 
 EXTRA_TESTS = ["mod_wsgi", "aws_lambda", "doctest"]
 
@@ -70,27 +99,71 @@ OPTION_TO_ENV_VAR = {"cov": "COVERAGE", "crypt_shared": "TEST_CRYPT_SHARED"}
 def get_test_options(
     description, require_sub_test_name=True, allow_extra_opts=False
 ) -> tuple[argparse.Namespace, list[str]]:
+    # If a test name with known sub_test_name choices was given, pin the test_name
+    # argument to it so the usage/help output isn't cluttered with every choice.
+    known_test_name = None
+    sub_test_choices = None
+    if require_sub_test_name:
+        for arg in sys.argv[1:]:
+            if arg in SUB_TEST_NAME_MAP:
+                known_test_name = arg
+                sub_test_choices = SUB_TEST_NAME_MAP[arg]
+                break
+        if known_test_name:
+            description = f"{description.rstrip('.')} for '{known_test_name}'."
+
     parser = argparse.ArgumentParser(
         description=description, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     if require_sub_test_name:
+        if known_test_name:
+            parser.prog = f"{parser.prog} {known_test_name}"
+            test_name_choices = [known_test_name]
+            test_name_help = argparse.SUPPRESS
+        else:
+            test_name_choices = sorted(list(TEST_SUITE_MAP) + EXTRA_TESTS)
+            test_name_help = (
+                "The optional name of the test suite to set up, typically the same name "
+                f"as a pytest marker. One of: {', '.join(test_name_choices)}."
+            )
         parser.add_argument(
             "test_name",
-            choices=sorted(list(TEST_SUITE_MAP) + EXTRA_TESTS),
+            choices=test_name_choices,
             nargs="?",
             default="default",
-            help="The optional name of the test suite to set up, typically the same name as a pytest marker.",
+            metavar=known_test_name or "test_name",
+            help=test_name_help,
         )
+        if sub_test_choices:
+            example_sub_test_name = sub_test_choices[0]
+            help_text = (
+                f"The optional sub test name, for example {example_sub_test_name!r}. "
+                f"One of: {', '.join(sub_test_choices)}."
+            )
+        else:
+            example_sub_test_name = "azure"
+            help_text = f"The optional sub test name, for example {example_sub_test_name!r}."
         parser.add_argument(
-            "sub_test_name", nargs="?", help="The optional sub test name, for example 'azure'."
+            "sub_test_name",
+            nargs="?",
+            choices=sub_test_choices,
+            metavar="sub_test_name",
+            help=help_text,
         )
     else:
+        run_server_choices = sorted(
+            set(list(TEST_SUITE_MAP) + EXTRA_TESTS) - set(NO_RUN_ORCHESTRATION)
+        )
         parser.add_argument(
             "test_name",
-            choices=set(list(TEST_SUITE_MAP) + EXTRA_TESTS) - set(NO_RUN_ORCHESTRATION),
+            choices=run_server_choices,
             nargs="?",
             default="default",
-            help="The optional name of the test suite to be run, which informs the server configuration.",
+            metavar="test_name",
+            help=(
+                "The optional name of the test suite to be run, which informs the server "
+                f"configuration. One of: {', '.join(run_server_choices)}."
+            ),
         )
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Whether to log at the DEBUG level."
@@ -100,7 +173,9 @@ def get_test_options(
     )
     parser.add_argument("--auth", action="store_true", help="Whether to add authentication.")
     parser.add_argument("--ssl", action="store_true", help="Whether to add TLS configuration.")
-    parser.add_argument(
+
+    other_group = parser.add_argument_group("other options")
+    other_group.add_argument(
         "--test-min-deps", action="store_true", help="Test against minimum dependency versions"
     )
 
@@ -110,24 +185,26 @@ def get_test_options(
             "--debug-log", action="store_true", help="Enable pymongo standard logging."
         )
         parser.add_argument("--cov", action="store_true", help="Add test coverage.")
-        parser.add_argument(
+        other_group.add_argument(
             "--green-framework",
             nargs=1,
             choices=["gevent"],
             help="Optional green framework to test against.",
         )
-        parser.add_argument(
+        other_group.add_argument(
             "--compressor",
             nargs=1,
             choices=["zlib", "zstd", "snappy"],
             help="Optional compression algorithm.",
         )
-        parser.add_argument("--crypt-shared", action="store_true", help="Test with crypt_shared.")
-        parser.add_argument("--no-ext", action="store_true", help="Run without c extensions.")
-        parser.add_argument(
+        other_group.add_argument(
+            "--crypt-shared", action="store_true", help="Test with crypt_shared."
+        )
+        other_group.add_argument("--no-ext", action="store_true", help="Run without c extensions.")
+        other_group.add_argument(
             "--mongodb-api-version", choices=["1"], help="MongoDB stable API version to use."
         )
-        parser.add_argument(
+        other_group.add_argument(
             "--disable-test-commands", action="store_true", help="Disable test commands."
         )
 
@@ -146,7 +223,7 @@ def get_test_options(
     # Handle validation and environment variable overrides.
     test_name = opts.test_name
     sub_test_name = opts.sub_test_name if require_sub_test_name else ""
-    if require_sub_test_name and test_name in SUB_TEST_REQUIRED and not sub_test_name:
+    if require_sub_test_name and test_name in SUB_TEST_NAME_MAP and not sub_test_name:
         raise ValueError(f"Test '{test_name}' requires a sub_test_name")
     handle_env_overrides(parser, opts)
     if "auth" in test_name:


### PR DESCRIPTION
PYTHON-6070

## Changes in this PR
<!-- What changes did you make to the code? What new APIs (public or private) were added, removed, or edited to generate
the desired outcome explained in the above summary? -->
- `just run-server -h` now forwards to `run-mongodb.sh start -h` instead of printing generic argparse help for `run_server.py`.
- `just setup-tests <test_name> -h` shows the valid `sub_test_name` choices for test names where they're enumerable (`kms`, `auth_aws`, `auth_oidc`, `mod_wsgi`, `perf`).
- Merged `SUB_TEST_REQUIRED` into `SUB_TEST_NAME_MAP` so the sub-test-required check and the choice list share one source of truth.
- Grouped the less common `setup-tests` flags (`--test-min-deps`, `--green-framework`, `--compressor`, `--crypt-shared`, `--no-ext`, `--mongodb-api-version`, `--disable-test-commands`) under an "other options" help section.
- Trimmed the `test_name`/`sub_test_name` usage/help output so the full choice list appears once instead of being repeated in both the usage line and the arguments section.

<details>
<summary>Example: <code>just setup-tests kms -h</code></summary>

```
usage: setup_tests.py kms [-h] [--verbose] [--quiet] [--auth] [--ssl]
                          [--test-min-deps] [--debug-log] [--cov]
                          [--green-framework {gevent}]
                          [--compressor {zlib,zstd,snappy}] [--crypt-shared]
                          [--no-ext] [--mongodb-api-version {1}]
                          [--disable-test-commands]
                          [sub_test_name]

Set up the test environment and services for 'kms'.

positional arguments:
  sub_test_name         The optional sub test name, for example 'azure'. One
                        of: azure, azure-remote, azure-fail, gcp, gcp-remote,
                        gcp-fail.

options:
  -h, --help            show this help message and exit
  --verbose, -v         Whether to log at the DEBUG level.
  --quiet, -q           Whether to log at the WARNING level.
  --auth                Whether to add authentication.
  --ssl                 Whether to add TLS configuration.
  --debug-log           Enable pymongo standard logging.
  --cov                 Add test coverage.

other options:
  --test-min-deps       Test against minimum dependency versions
  --green-framework {gevent}
                        Optional green framework to test against.
  --compressor {zlib,zstd,snappy}
                        Optional compression algorithm.
  --crypt-shared        Test with crypt_shared.
  --no-ext              Run without c extensions.
  --mongodb-api-version {1}
                        MongoDB stable API version to use.
  --disable-test-commands
                        Disable test commands.
```

</details>

<details>
<summary>Example: <code>just run-server -h</code></summary>

`run_server.py` now forwards straight to the drivers-tools script instead of printing its own help:

```
$ just run-server -h
usage: drivers-orchestration [-h] [--verbose] [--quiet] [--version VERSION]
                             [--topology {standalone,replica_set,sharded_cluster}]
                             [--auth] [--ssl] [--local-atlas]
                             [--mongodb-runner]
                             [--orchestration-file ORCHESTRATION_FILE]
                             [--load-balancer] [--auth-aws]
                             [--skip-crypt-shared] [--install-legacy-shell]
                             [--disable-test-commands]
                             [--storage-engine {,mmapv1,wiredtiger,inmemory}]
                             [--require-api-version]
                             [--existing-binaries-dir EXISTING_BINARIES_DIR]
                             [--tls-pem-key-file TLS_PEM_KEY_FILE]
                             [--tls-ca-file TLS_CA_FILE]
                             [--tls-allow-invalid-certificates] [--arch ARCH]
                             [--mongo-orchestration-home MONGO_ORCHESTRATION_HOME]
                             [--mongodb-binaries MONGODB_BINARIES]
                             [--tls-cert-key-file TLS_CERT_KEY_FILE]

Run mongo-orchestration and launch a deployment.

Use '--help' for more information.

options:
  -h, --help            show this help message and exit
  --verbose, -v         Whether to log at the DEBUG level
  --quiet, -q           Whether to log at the WARNING level
  --version VERSION     The version to download. Use "latest" to download the
                        newest available version (including release
                        candidates).
  --topology {standalone,replica_set,sharded_cluster}
                        The topology of the server deployment (defaults to
                        standalone unless another flag like load_balancer is
                        set)
  --auth                Whether to add authentication
  --ssl                 Whether to add TLS configuration
  --local-atlas         Whether to use mongodb-atlas-local to start the server
  --mongodb-runner      Whether to use mongodb-runner to start the server
  --orchestration-file ORCHESTRATION_FILE
                        The name of the orchestration config file

Other options:
  --load-balancer       Whether to use a load balancer
  --auth-aws            Whether to use MONGODB-AWS auth
  --skip-crypt-shared   Whether to skip installing crypt_shared lib
  --install-legacy-shell
                        Whether to install the legacy shell
  --disable-test-commands
                        Whether to disable test commands
  --storage-engine {,mmapv1,wiredtiger,inmemory}
                        The storage engine to use
  --require-api-version
                        Whether to set requireApiVersion
  --existing-binaries-dir EXISTING_BINARIES_DIR
                        A directory containing existing mongodb binaries to
                        use instead of downloading new ones
  --tls-pem-key-file TLS_PEM_KEY_FILE
                        A .pem file that contains the TLS certificate and key
                        for the server
  --tls-ca-file TLS_CA_FILE
                        A .pem file that contains the root certificate chain
                        for the server
  --tls-allow-invalid-certificates
                        Whether to pass --tlsAllowInvalidCertificates to
                        mongod
  --arch ARCH           the architecture. if unspecified, the arch will be
                        inferred.
  --mongo-orchestration-home MONGO_ORCHESTRATION_HOME
                        The path to mongo-orchestration home
  --mongodb-binaries MONGODB_BINARIES
                        The path to store the MongoDB binaries
  --tls-cert-key-file TLS_CERT_KEY_FILE
                        A .pem to be used as the tlsCertificateKeyFile option
                        in mongo-orchestration
```

(This help text comes from `run-mongodb.sh` in drivers-evergreen-tools, not from this repo.)

</details>

## Test Plan
<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why.
All code should be tested in some way – so please list what your validation strategy was. -->
- Manually invoked `get_test_options` with `kms`, `auth_aws`, `auth_oidc`, `mod_wsgi`, `perf`, and no test name, confirming help output and validation for each.
- Manually invoked `just run-server -h` against a local checkout of drivers-evergreen-tools to confirm it forwards to and prints `run-mongodb.sh start -h`'s own output.
- Ran `just lint-manual` — all hooks pass.
- Ran `just typing` — pre-existing unrelated failures in `pymongo/ocsp_support.py`, no new errors.
- Submitted an Evergreen patch tagged `pr` (all 47 `pr`-tagged variants) — completed with no task failures.

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- [ ] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?