### PR TITLE
PYTHON-6071 Fix ML-KEM OCSP tests and run min-deps OCSP task on PRs

### DIFF
--- a/.evergreen/generated_configs/tasks.yml
+++ b/.evergreen/generated_configs/tasks.yml
@@ -898,6 +898,7 @@ tasks:
       - ocsp-ecdsa
       - "4.4"
       - ocsp-staple
+      - pr
   - name: test-ocsp-ecdsa-valid-cert-server-staples-v5.0-python3.10-min-deps
     commands:
       - func: run tests
@@ -2162,7 +2163,7 @@ tasks:
       - ocsp-rsa
       - rapid
       - ocsp-staple
-  - name: test-ocsp-rsa-valid-cert-server-staples-latest-python3.14-cov
+  - name: test-ocsp-rsa-valid-cert-server-staples-latest-python3.14
     commands:
       - func: run tests
         vars:
@@ -2171,13 +2172,11 @@ tasks:
           TEST_NAME: ocsp
           TOOLCHAIN_VERSION: "3.14"
           VERSION: latest
-          COVERAGE: "1"
     tags:
       - ocsp
       - ocsp-rsa
       - latest
       - ocsp-staple
-      - pr
   - name: test-ocsp-rsa-invalid-cert-server-staples-v4.4-python3.10-min-deps
     commands:
       - func: run tests

--- a/.evergreen/generated_configs/variants.yml
+++ b/.evergreen/generated_configs/variants.yml
@@ -398,6 +398,13 @@ buildvariants:
     run_on:
       - rhel87-small
     batchtime: 10080
+  - name: ocsp-staples-rhel8
+    tasks:
+      - name: .ocsp-staple .pr
+    display_name: OCSP Staples RHEL8
+    run_on:
+      - rhel87-small
+    tags: [pr]
   - name: ocsp-win64
     tasks:
       - name: .ocsp-rsa !.ocsp-staple .latest

--- a/.evergreen/scripts/generate_config.py
+++ b/.evergreen/scripts/generate_config.py
@@ -67,6 +67,18 @@ def create_ocsp_variants() -> list[BuildVariant]:
             batchtime=BATCHTIME_WEEK,
         )
         variants.append(variant)
+        # Run the stapled OCSP tasks (tagged "pr") on every PR so cryptography-backend
+        # regressions, like the min-deps ML-KEM breakage in PYTHON-6032, are caught before merge
+        # instead of on the next weekly batch run.
+        if host == DEFAULT_HOST:
+            variants.append(
+                create_variant(
+                    [".ocsp-staple .pr"],
+                    get_variant_name("OCSP Staples", host),
+                    tags=["pr"],
+                    host=host,
+                )
+            )
     return variants
 
 
@@ -992,7 +1004,20 @@ def _create_ocsp_tasks(algo, variant, server_type, base_task_name):
         tags = ["ocsp", f"ocsp-{algo}", version]
         if "disableStapling" not in variant:
             tags.append("ocsp-staple")
-        if base_task_name == "valid-cert-server-staples" and version == "latest":
+        # Run exactly one min-deps and one latest-CPython stapled OCSP task on
+        # every PR (ecdsa only, to avoid doubling coverage across algorithms)
+        # so a cryptography-backend regression at either dependency extreme,
+        # like the min-deps ML-KEM breakage in PYTHON-6032, is caught before
+        # merge instead of on the next weekly mainline batch run.
+        if (
+            base_task_name == "valid-cert-server-staples"
+            and algo == "ecdsa"
+            and version
+            in (
+                "latest",
+                "4.4",
+            )
+        ):
             tags.append("pr")
             if "TEST_MIN_DEPS" not in vars:
                 vars["COVERAGE"] = "1"

--- a/test/test_ocsp_support.py
+++ b/test/test_ocsp_support.py
@@ -80,8 +80,8 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.dsa import DSAPublicKey
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.hazmat.primitives.asymmetric.mlkem import (
-    MLKEM768PrivateKey,
-    MLKEM1024PrivateKey,
+    MLKEM768PublicKey,
+    MLKEM1024PublicKey,
 )
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
@@ -189,13 +189,14 @@ class TestVerifySignature(unittest.TestCase):
     def test_mlkem768_fails_closed(self):
         # ML-KEM is a key encapsulation mechanism, so an ML-KEM public key has
         # no verify(). Certificate.public_key() can return one, which used to
-        # reach the generic branch and raise AttributeError.
-        key = MLKEM768PrivateKey.generate().public_key()
-        self.assertEqual(_verify_signature(key, b"sig", Mock(), b"data"), 0)
+        # reach the generic branch and raise AttributeError. A spec'd mock has
+        # no verify() either, so reaching that branch again would raise here too.
+        key = MagicMock(spec=MLKEM768PublicKey)
+        self.assertEqual(_verify_signature(key, b"sig", Mock(), b"data"), 0)  # type: ignore[arg-type]
 
     def test_mlkem1024_fails_closed(self):
-        key = MLKEM1024PrivateKey.generate().public_key()
-        self.assertEqual(_verify_signature(key, b"sig", Mock(), b"data"), 0)
+        key = MagicMock(spec=MLKEM1024PublicKey)
+        self.assertEqual(_verify_signature(key, b"sig", Mock(), b"data"), 0)  # type: ignore[arg-type]
 
     def test_other_key_valid(self):
         key = Mock()


### PR DESCRIPTION
PYTHON-6071

## Changes in this PR

- Replaced real ML-KEM key generation in two OCSP tests with `MagicMock(spec=...)`, so they no longer depend on `cryptography`'s backend supporting ML-KEM.
- Added a min-deps stapled OCSP task to the PR-triggered Evergreen variant, alongside the existing latest-CPython one.
- Scoped both PR-gated OCSP tasks to one algorithm (`ecdsa`) to keep PR CI at two tasks instead of four.

## Test Plan

- `pytest test/test_ocsp_support.py::TestVerifySignature -m ocsp`: 9 passed, including under a min-deps (`cryptography==47.0.0`) environment where they previously failed with `UnsupportedAlgorithm`.
- `just lint` and `just typing`: clean.

## Checklist

### Checklist for Author
- [x] Did you update the changelog (if necessary)? Not needed (test/CI-only fix).
- [x] Is there test coverage? Yes, and it now runs on every PR.
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s). None; PYTHON-6071 is caused-by PYTHON-6032.

### Checklist for Reviewer
- [x] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?