### PR TITLE
PYTHON-6072 - Update changelog for 4.18 release

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Changes in Version 4.18.0 (2026/XX/XX)
+Changes in Version 4.18.0 (2026/09/03)
 --------------------------------------
 
 PyMongo 4.18 brings a number of changes including:

--- a/pymongo/_version.py
+++ b/pymongo/_version.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import re
 from typing import Union
 
-__version__ = "4.18.0.dev0"
+__version__ = "4.18.0"
 
 
 def get_version_tuple(version: str) -> tuple[Union[int, str], ...]:


### PR DESCRIPTION
PYTHON-6072

## Changes in this PR
Sets the PyMongo 4.18.0 release date and finalizes the version for release.
- Updated the 4.18.0 changelog header date from 2026/XX/XX to 2026/09/03.
- Bumped `pymongo/_version.py` from 4.18.0.dev0 to 4.18.0.

## Test Plan
No functional code changed. pre-commit hooks (ruff, ruff-format, synchro, rstcheck) passed on commit.

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- [x] Did you update the changelog (if necessary)?
- [x] Is there test coverage?  Docs/version-only change; no code to test.
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s).  Followup: cut the v4.18 release branch and publish 4.18.0, tracked in PYTHON-6072.

### Checklist for Reviewer
- [x] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
