### PR TITLE
PYTHON-5874 Fix test_fork.py failures on Python 3.15 due to fork() DeprecationWarning

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -952,8 +952,8 @@ class PyMongoTestCase(unittest.TestCase):
         proc = ctx.Process(target=_target)
         # Python 3.12+ warns when os.fork() runs in a multi-threaded process. The
         # warning is a general thread-count heuristic; benign here because the only
-        # extra threads are pymongo's, whose locks register_at_fork resets in the
-        # child. Suppressed only in this helper, not globally (PYTHON-5874).
+        # extra threads are pymongo's, whose locks are reset via register_at_fork
+        # in the child. Suppressed only in this helper, not globally (PYTHON-5874).
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -950,7 +950,17 @@ class PyMongoTestCase(unittest.TestCase):
 
         ctx = multiprocessing.get_context("fork")
         proc = ctx.Process(target=_target)
-        proc.start()
+        # Python 3.12+ warns when os.fork() runs in a multi-threaded process. The
+        # warning is a general thread-count heuristic; benign here because the only
+        # extra threads are pymongo's, whose locks register_at_fork resets in the
+        # child. Suppressed only in this helper, not globally (PYTHON-5874).
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*use of fork\(\) may lead to deadlocks.*",
+                category=DeprecationWarning,
+            )
+            proc.start()
         try:
             yield proc  # type: ignore
         finally:

--- a/test/asynchronous/__init__.py
+++ b/test/asynchronous/__init__.py
@@ -950,7 +950,17 @@ class AsyncPyMongoTestCase(unittest.TestCase):
 
         ctx = multiprocessing.get_context("fork")
         proc = ctx.Process(target=_target)
-        proc.start()
+        # Python 3.12+ warns when os.fork() runs in a multi-threaded process. The
+        # warning is a general thread-count heuristic; benign here because the only
+        # extra threads are pymongo's, whose locks register_at_fork resets in the
+        # child. Suppressed only in this helper, not globally (PYTHON-5874).
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*use of fork\(\) may lead to deadlocks.*",
+                category=DeprecationWarning,
+            )
+            proc.start()
         try:
             yield proc  # type: ignore
         finally:

--- a/test/asynchronous/__init__.py
+++ b/test/asynchronous/__init__.py
@@ -952,8 +952,8 @@ class AsyncPyMongoTestCase(unittest.TestCase):
         proc = ctx.Process(target=_target)
         # Python 3.12+ warns when os.fork() runs in a multi-threaded process. The
         # warning is a general thread-count heuristic; benign here because the only
-        # extra threads are pymongo's, whose locks register_at_fork resets in the
-        # child. Suppressed only in this helper, not globally (PYTHON-5874).
+        # extra threads are pymongo's, whose locks are reset via register_at_fork
+        # in the child. Suppressed only in this helper, not globally (PYTHON-5874).
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",

--- a/test/test_fork.py
+++ b/test/test_fork.py
@@ -29,16 +29,14 @@ from test import IntegrationTest
 from test.utils_shared import is_greenthread_patched
 
 
+# self.fork suppresses the Python 3.12+ fork() DeprecationWarning; it is
+# benign for these intentional forks (PYTHON-5874).
 @unittest.skipIf(
     not hasattr(os, "register_at_fork"), "register_at_fork not available in this version of Python"
 )
 @unittest.skipIf(
     is_greenthread_patched(),
     "gevent does not support POSIX-style forking.",
-)
-@unittest.skipIf(
-    sys.version_info >= (3, 15),
-    "fork() in multi-threaded processes is deprecated in Python 3.15+ (PYTHON-5874)",
 )
 class TestFork(IntegrationTest):
     def test_lock_client(self):


### PR DESCRIPTION
PYTHON-5874

Python 3.12+ emits a `DeprecationWarning` when `os.fork()` is called in a multi-threaded process, which the test suite's `filterwarnings = ["error"]` turns into a failure for the `test_fork.py` tests. These tests intentionally fork a running client whose `register_at_fork` handlers reset its locks in the child, so the warning is benign; suppress it in the `self.fork` helper and remove the 3.15 `skipIf` stopgap.

## Changes in this PR

- Suppress the Python 3.12+ `os.fork()` `DeprecationWarning` inside the `self.fork` test helper, scoped to that specific warning.
- Removed the `skipIf` that skipped `test_fork.py` on Python 3.15+ (stopgap from PYTHON-5837) so the tests run on 3.15+.

## Test Plan

- `test/test_fork.py` on Python 3.15.0rc1: 3/3 pass (previously 2 failed with the `DeprecationWarning`).
- `test/test_fork.py` on Python 3.13: 3/3 pass (no regression).
- ruff, ruff-format, and mypy clean on the changed files.

## Checklist

### Checklist for Author
- [x] Did you update the changelog (if necessary)? — not necessary; test-only change with no driver behavior change.
- [x] Is there test coverage? — the fix is to existing tests; no new coverage needed.
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s). — documentation note tracked on PYTHON-5874 (Documentation Changes = Needed); docs live externally on mongodb.com.

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
