### PR TITLE
Update changelog for CVE-2026-88029 reference [main]

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,16 @@ Bug fixes
 
 .. _PYTHON-6074: https://jira.mongodb.org/browse/PYTHON-6074
 
+Changes in Version 4.18.1 (2026/09/10)
+--------------------------------------
+
+Version 4.18.1 is a bug fix release.
+
+- Use an exact match for the file ID in GridFS delete methods
+  (`CVE-2026-88029`_).
+
+.. _CVE-2026-88029: https://www.cve.org/CVERecord?id=CVE-2026-88029
+
 Changes in Version 4.18.0 (2026/09/03)
 --------------------------------------
 


### PR DESCRIPTION
Forward port of https://github.com/mongodb/mongo-python-driver/pull/3049 to `main`.

## Changes in this PR

`main` had no 4.18.1 changelog section, so this adds it with the CVE reference.

## Test Plan

N/A — docs only.

## Checklist

### Checklist for Author
- [x] Did you update the changelog (if necessary)?
- [N/A] Is there test coverage?
- [N/A] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [N/A] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation?
- [ ] Is all relevant documentation (README or docstring) updated?